### PR TITLE
Deb package: support deb:trixie and update the workflow

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -8,16 +8,16 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/**'
     paths-ignore:
       - 'docs/**'
       - '.devcontainer/**'
       - '*.md'
   pull_request:
     types: [opened, reopened, synchronize]
-    paths-ignore:
-      - 'docs/**'
-      - '.devcontainer/**'
-      - '*.md'
+    paths:
+      - 'packaging/**'
+      - '.github/workflows/**'
 
 permissions:
   packages: write
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu22.04]
+        os: [deb11, deb12, deb13, ubuntu22.04, ubuntu24.04]
         arch: [amd64, arm64]
         include:
           - arch: amd64

--- a/packaging/Dockerfile_build_deb_packages
+++ b/packaging/Dockerfile_build_deb_packages
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=debian:bookworm
+ARG BASE_IMAGE=debian:trixie
 FROM ${BASE_IMAGE}
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -26,8 +26,8 @@ ENV LC_COLLATE=en_US.UTF-8
 ENV LC_CTYPE=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" > /etc/apt/sources.list.d/pgdg.list && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN echo "deb [signed-by=/usr/share/keyrings/pgdg-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" > /etc/apt/sources.list.d/pgdg.list && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /usr/share/keyrings/pgdg-archive-keyring.gpg
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -9,6 +9,15 @@ E.g. to build for Debian 12 and PostgreSQL 16, run:
 ./packaging/build_packages.sh --os deb12 --pg 16
 ```
 
+Supported DEB/Ubuntu distributions:
+- deb11 — Debian 11 (bullseye)
+- deb12 — Debian 12 (bookworm)
+- deb13 — Debian 13 (trixie)
+- ubuntu22.04 — Ubuntu 22.04 (jammy)
+- ubuntu24.04 — Ubuntu 24.04 (noble)
+
+Supported PG versions: 15, 16, 17
+
 ## Building RPM Packages
 
 For Red Hat-based distributions, you can build RPM packages:
@@ -21,7 +30,7 @@ Supported RPM distributions:
 - rhel8 (Red Hat Enterprise Linux 8 compatible)
 - rhel9 (Red Hat Enterprise Linux 9 compatible)
 
-Supported PG versions: 16, 17
+Supported PG versions: 15, 16, 17
 
 ### RPM Build Prerequisites
 

--- a/packaging/build_packages.sh
+++ b/packaging/build_packages.sh
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
         --os)
             shift
             case $1 in
-                deb11|deb12|ubuntu22.04|ubuntu24.04)
+                deb11|deb12|deb13|ubuntu22.04|ubuntu24.04)
                     OS=$1
                     PACKAGE_TYPE="deb"
                     ;;
@@ -121,6 +121,9 @@ if [[ "$PACKAGE_TYPE" == "deb" ]]; then
             ;;
         deb12)
             DOCKER_IMAGE="debian:bookworm"
+            ;;
+        deb13)
+            DOCKER_IMAGE="debian:trixie"
             ;;
         ubuntu22.04)
             DOCKER_IMAGE="ubuntu:22.04"


### PR DESCRIPTION
1. support deb13 and set it as default base image in dockerfile
2. update workflow to not run for every PR check, instead, only run it when changing related paths, and run for main/release branches

resolves #270 