### PR TITLE
build: skip trigger when PR is draft

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -13,7 +13,7 @@ on:
       - '.devcontainer/**'
       - '*.md'
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - 'docs/**'
       - '.devcontainer/**'
@@ -28,6 +28,7 @@ jobs:
   build-deb-packages:
     runs-on: ${{ matrix.runner }}
     name: Deb packages for ${{ matrix.os }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_rpm_packages.yml
+++ b/.github/workflows/build_rpm_packages.yml
@@ -13,7 +13,7 @@ on:
       - '.devcontainer/**'
       - '*.md'
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - 'docs/**'
       - '.devcontainer/**'
@@ -24,6 +24,7 @@ jobs:
   build-rpm-packages:
     runs-on: ${{ matrix.runner }}
     name: RPM packages for ${{ matrix.os }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -14,7 +14,7 @@ on:
       - '.devcontainer/**'
       - '*.md'
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - 'docs/**'
       - '.devcontainer/**'
@@ -24,6 +24,7 @@ jobs:
   test-run-in-Ubuntu:
     runs-on: ${{ matrix.runner }}
     name: Run sql tests on ${{ matrix.runner }} with pg ${{ matrix.pg_version }}
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR skips the CI trigger from checks when the PR is still a draft, but keeps the trigger for opened, reopened, synchronize, and ready_for_review. 