### PR TITLE
[workflow] Fix build errors on arm64 and refine the yaml files

### DIFF
--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -43,12 +43,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
-      - name: Install CMake 3.22
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake=3.22.*
-          cmake --version
 
       - name: Install package dependencies
         run: |

--- a/packaging/rpm/rhel-8/Dockerfile
+++ b/packaging/rpm/rhel-8/Dockerfile
@@ -45,7 +45,7 @@ RUN echo "Detected architecture: ${TARGETARCH}"
 # PostgreSQL yum repo setup for RHEL 8
 RUN if [ -n "${TARGETARCH}" ] && ( [ "${TARGETARCH}" = "arm64" ] || [ "${TARGETARCH}" = "arm64v8" ] ); then ARCH=aarch64; else ARCH=x86_64; fi; \
     echo "Setting up PGDG repo for RHEL 8 (arch=${ARCH})" && \
-    dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${ARCH}/pgdg-redhat-repo-latest.noarch.rpm && \
+    dnf -y --disablerepo=* install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${ARCH}/pgdg-redhat-repo-latest.noarch.rpm && \
     dnf -qy module disable postgresql && \
     dnf -y install postgresql${POSTGRES_VERSION} \
     postgresql${POSTGRES_VERSION}-devel \

--- a/packaging/rpm/rhel-9/Dockerfile
+++ b/packaging/rpm/rhel-9/Dockerfile
@@ -38,14 +38,16 @@ RUN dnf -y swap curl-minimal curl && \
         krb5-devel \
         python3 \
         tar && \
+    dnf update -y --refresh && \
     dnf clean all
 
 RUN echo "Detected architecture: ${TARGETARCH}"
 
-# PostgreSQL yum repo setup for RHEL 9
+# PostgreSQL repo setup for RHEL 9
+# Note: transient PGDG repodata signature outages were observed (repomd.xml GPG signature verification error). If happends again, consider temporarily using --nogpgcheck flag or check https://github.com/pgdg-packaging/pgdg-rpms/issues for fixing.
 RUN if [ -n "${TARGETARCH}" ] && ( [ "${TARGETARCH}" = "arm64" ] || [ "${TARGETARCH}" = "arm64v8" ] ); then ARCH=aarch64; else ARCH=x86_64; fi; \
     echo "Setting up PGDG repo for RHEL 9 (arch=${ARCH})" && \
-    dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-${ARCH}/pgdg-redhat-repo-latest.noarch.rpm && \
+    dnf -y --disablerepo=* install https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-${ARCH}/pgdg-redhat-repo-latest.noarch.rpm && \
     dnf -qy module disable postgresql && \
     dnf -y install postgresql${POSTGRES_VERSION} \
     postgresql${POSTGRES_VERSION}-devel \


### PR DESCRIPTION
Workflow configuration update:

- Removed the installation of CMake 3.22 from the regress_tests.yml workflow, as we install latest version in later step.
- Add --disablerepo=* to disable all existing repos and make sure the URL provided is being used.