### PR TITLE
Add RFC-0007: Guidance for Onboarding Statistics

### DIFF
--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -1,0 +1,182 @@
+---
+rfc: 0007
+title: "RFC Title"
+status: Draft
+owner: "@github-username"
+issue: "https://github.com/documentdb/documentdb/issues/XXX"
+discussion: "https://github.com/documentdb/documentdb/discussions/XXX"
+version-target: 1.0
+implementations:
+  - "https://github.com/documentdb/documentdb/pull/XXX"
+---
+
+# RFC-XXXX: [Title]
+
+*Delete these italicized instructions before submitting your RFC. For details of the RFC process, see https://github.com/documentdb/documentdb/blob/main/rfcs/0003-rfc-process.md*
+
+*RFC statuses follow this flow:*
+
+```
+[Draft] → [Proposed] → [Accepted/Rejected] → [Implementing] → [Complete]
+                                           ↘ [Archived]
+```
+
+## Problem
+
+*This section is REQUIRED before moving from Draft to Proposed status.*
+
+**Section purpose:** Clearly articulate the problem or opportunity this RFC addresses. 
+
+**Complete this section when:** You're ready to start a discussion and get initial feedback on whether this problem is worth solving.
+
+**Guidance:**
+- What problem are you trying to solve?
+- Who is impacted by this problem?
+- What are the consequences of not solving it?
+- What are the current workarounds, if any?
+- What are the success criteria?
+- What are the non-goals?
+- What behavior are you intending to emulate? What are the quircks there?
+- Is there an API spec being targeted?
+
+**Example prompts to guide your thinking:**
+- "Users currently struggle with..."
+- "The system lacks..."
+- "This creates friction when..."
+- "Without this, contributors must..."
+
+---
+
+## Approach
+
+*This section is REQUIRED before moving from Proposed to Accepted status.*
+
+**Purpose:** Describe your proposed solution at a high level.
+
+**Complete this section when:** You've received feedback that the problem is worth solving and you're ready to propose a specific approach.
+
+**Progressive disclosure:** Start lean! You don't need all the details yet. Focus on the core idea and high-level approach. Detailed design comes later.
+
+**Guidance:**
+- What is your proposed solution?
+- Why is this approach better than alternatives?
+- What are the key benefits and tradeoffs?
+- How does this fit with existing DocumentDB architecture?
+
+**Example prompts for solution thinking:**
+- "The proposed solution is to..."
+- "This approach is preferable because..."
+- "Key tradeoffs include..."
+- "This aligns with existing patterns by..."
+
+---
+
+## Detailed Design
+
+*This section MAY BE REQUIRED before moving from Proposed to Accepted status. This section MUST be completed and approved to move to Implementing status.*
+
+**Purpose:** Provide comprehensive technical details needed for implementation.
+
+**Complete this section when:** Your solution approach has been validated and you're ready to commit to specific implementation details.
+
+**Guidance:** This is where you get specific. Include enough detail that someone could implement this RFC without having to make major design decisions.
+
+### Technical Details
+
+*Describe the technical implementation specifics*
+- Data structures
+- Algorithms
+- Architecture patterns
+- Performance considerations
+
+### API Changes
+
+*Document any public API additions or modifications*
+- New functions, including UDFs
+- Modified signatures
+- Breaking changes
+- Deprecation plans
+
+### Database Schema Changes
+
+*If applicable, describe schema modifications*
+- New tables/collections
+- Schema migrations
+- Index changes
+- Data migration strategies
+
+### Configuration Changes
+
+*Document new or modified configuration options*
+- New settings
+- Modified defaults
+- Environment variables
+- Configuration validation
+
+### Testing Strategy
+
+*Describe how this will be tested*
+- Unit test approach
+- Integration test requirements
+- Compatibility test requirements
+- Performance test plans
+- Migration test strategy
+
+### Migration Path
+
+*How do existing users/deployments upgrade?*
+- Backwards/forwards compatibility
+- Migration steps
+- Rollback strategy
+- Deprecation timeline
+
+### Documentation Updates
+
+*What documentation needs to change?*
+- User-facing docs
+- Developer guides
+- API references
+- Examples/tutorials
+
+---
+
+## Implementation Tracking
+
+*This section SHALL be populated during the Implementation phase.*
+
+**Purpose:** Track the implementation progress of this RFC.
+
+**Complete this section when:** Your RFC has been accepted and implementation work begins.
+
+**Guidance:**
+- Link to the PRs that implement this RFC. Update as implementation progresses.
+- Provide success metrics.
+
+### Implementation PRs
+
+- [ ] PR #XXX: [Brief description of what this PR implements]
+- [ ] PR #XXX: [Brief description of what this PR implements]
+- [ ] PR #XXX: [Brief description of what this PR implements]
+
+### Status Updates
+
+*Add dated status updates as implementation progresses*
+
+**YYYY-MM-DD:** Initial implementation started in PR #XXX
+
+**YYYY-MM-DD:** [Update on progress, blockers, or changes]
+
+### Open Questions
+
+*Track unresolved questions that arise during implementation*
+
+- [ ] Question: [Description]
+  - Discussion: [Link to discussion or resolution]
+
+### Implementation Notes
+
+*Capture important decisions or learnings during implementation*
+
+- **Decision [YYYY-MM-DD]:** [What was decided]
+  - **Context:** [Why this decision was made]
+  - **Alternatives:** [What else was considered]

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -97,6 +97,8 @@ Where `<scope>` describes the category of statistics being exposed. Examples inc
 
 - Columns representing **dimensions** (e.g., name, database, collection, user) should **not** use a suffix.
 
+- `stats_reset` column is required if the view contains cumulative counters. This column indicates the timestamp of the last reset.
+
 **Example** (for illustration purposes only, not an actual view):
 ```sql
 CREATE VIEW documentdb_stat_queries AS
@@ -107,7 +109,8 @@ SELECT
     query_count,        -- value (with _count suffix)
     total_seconds,      -- value (with _seconds suffix)
     avg_milliseconds,   -- value (with _milliseconds suffix)
-    cache_hit_percent   -- value (with _percent suffix)
+    cache_hit_percent,  -- value (with _percent suffix)
+    stats_reset         -- timestamp of last reset
 FROM ...
 ```
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -295,7 +295,7 @@ Contributors adding new statistics must consider the impact on frequently execut
 
 3. **Memory budget**: Shared-memory-backed stats should declare their memory footprint in the PR description. Prefer fixed-size allocations (bounded by `MaxBackends` or a compile-time constant).
 
-4. **Validation**: PRs adding a new statistic should include a before/after benchmark demonstrating negligible throughput regression with the stat enabled.
+4. **Validation**: PRs adding a new statistic should include a before/after benchmark demonstrating negligible throughput regression with the stat enabled. The [micro-benchmarks](https://github.com/documentdb/micro-benchmarks) framework is recommended for this purpose.
 
 ### Contributor Checklist: How to add a new statistic
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -8,7 +8,7 @@ issue: "https://github.com/documentdb/documentdb/issues/TBD"
 
 # RFC-0007: Guidance for Onboarding Statistics
 
-## Background & Motivation
+## Problem
 
 ### What exists today
 
@@ -69,6 +69,9 @@ The **permission model** is straightforward:
 
 - **Read**: any connected role can query statistics — views are granted `SELECT … TO PUBLIC`.
 - **Reset**: only the extension admin role (`__API_ADMIN_ROLE__`) can clear cumulative counters via reset functions. `EXECUTE` is revoked from `PUBLIC`.
+- **Helpers**: not granted to `PUBLIC` — the view is the API boundary.
+
+This model matches how `pg_stat_statements` exposes statistics. Any deviation (for example, a stat that genuinely needs PUBLIC EXECUTE on its helper) must be explicitly justified in the contributing PR.
 
 This RFC defines:
 - Naming conventions for views and functions
@@ -81,6 +84,10 @@ The goal is to provide a predictable and maintainable pattern that aligns with f
 ---
 
 ## Detailed Design
+
+### Technical Details
+
+This RFC defines conventions only; no new code paths or data structures are introduced. Each statistic implemented under these conventions will have its own technical design.
 
 ### API Changes
 
@@ -171,7 +178,7 @@ LANGUAGE c
 AS '$libdir/pg_documentdb', 'documentdb_stat_get_<scope>';
 ```
 
-##### Reset functions (for cumulative counters)
+#### Reset Functions
 
 If a view contains cumulative counters that may need to be reset, a reset function must be provided.
 
@@ -201,14 +208,9 @@ GRANT  EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>(
 
 Non-superuser operators who need reset capability must be granted membership in `__API_ADMIN_ROLE__` (or be granted EXECUTE explicitly on a per-function basis if more granular control is desired).
 
-#### Permission Model Summary
+### Configuration Changes
 
-This model — public SELECT on the view, no PUBLIC EXECUTE on helpers, named-role EXECUTE on reset — matches how `pg_stat_statements` exposes statistics. Any deviation (for example, a stat that genuinely needs PUBLIC EXECUTE on its helper) must be explicitly justified in the contributing PR.
-
-
-#### Configuration Flags (GUC)
-
-Since collecting statistics introduces overhead, each category of statistical data should be gated behind a configuration flag.
+Each category of statistical data should be gated behind a GUC (Grand Unified Configuration) flag to control collection overhead.
 
 **Naming pattern**
 ```
@@ -230,7 +232,7 @@ When the flag is set to `false`:
 - The corresponding view should return an **empty result set** (not fail, and not return zeroed rows). An empty set is unambiguous in dashboards and alerting; zeroed rows can be misread as "the system is healthy."
 
 
-#### Documentation Updates
+### Documentation Updates
 
 The following documentation must be updated when new statistics are added:
 
@@ -278,48 +280,15 @@ This RFC is purely additive and applies only to **new** statistics. Pre-existing
 
 ### Contributor Checklist: How to add a new statistic
 
-When adding a new statistic under this RFC, a contributor should:
+This section walks through every step a contributor must complete when adding a new statistic. Code examples use a hypothetical `io` scope for illustration.
 
-1. **Pick a scope name.** Lowercase, singular-or-plural noun matching the category (e.g., `queries`, `connections`). Confirm it does not collide with an existing `documentdb_stat_*` view or with PostgreSQL's `pg_stat_*` namespace.
-2. **Register the GUC.** Add `documentdb.track_<scope>` (default chosen per the rule of thumb in "Configuration Flags (GUC)") in the C code that registers extension GUCs, and reference it from the collection path so disabling the flag halts collection.
-3. **Add the SQL definitions** under `pg_documentdb/sql/udfs/stats/`:
-   - Update `stats--latest.sql` with the view, optional helper(s), and optional reset function.
-   - Add a `stats--<from>-<to>.sql` upgrade script for the version bump.
-4. **Apply the canonical grants** (see "Permissions for helpers" and "Permissions for reset functions"):
-   - `GRANT SELECT ON ... TO PUBLIC;` for the view.
-   - No grant to `PUBLIC` on helper functions.
-   - `REVOKE EXECUTE ... FROM PUBLIC;` and `GRANT EXECUTE ... TO __API_ADMIN_ROLE__;` for any reset function.
-5. **Add tests** as listed in the Testing Strategy section above (column shape, flag-off behavior, reset behavior, permissions).
-6. **Update documentation.** Open a companion PR against `https://github.com/documentdb/documentdb.github.io` adding an entry to `/articles/postgresql/stats.md` with description, column definitions and units, an example query and output, related configuration parameters, and reset functions (if applicable).
-7. **Justify any deviation from the canonical permission/path conventions** in the PR description so reviewers can evaluate it explicitly.
+#### 1. Pick a scope name
 
----
+Choose a lowercase, singular-or-plural noun matching the category (e.g., `queries`, `connections`, `io`). Confirm it does not collide with an existing `documentdb_stat_*` view or with PostgreSQL's `pg_stat_*` namespace.
 
-## Implementation Tracking
+#### 2. Register the GUC
 
-NA
-
-### Status Updates
-
-NA
-
-### Open Questions
-
-NA
-
-### Implementation Notes
-
-NA
-
----
-
-## Appendix A: Worked Example — `documentdb_stat_io`
-
-This appendix shows the complete set of artifacts a contributor would produce when adding a hypothetical I/O statistics scope. The example is **illustrative only** — it does not propose a real statistic. Its purpose is to demonstrate the full pattern end-to-end so that contributors can follow it as a template.
-
-### A.1 — Register the GUC
-
-In `pg_documentdb/src/configs/system_configs.c`, add a boolean GUC to gate collection:
+In `pg_documentdb/src/configs/system_configs.c`, add a boolean GUC to gate collection. Choose the default per the rule of thumb in "Configuration Changes."
 
 ```c
 /* Whether to collect I/O statistics. */
@@ -336,9 +305,11 @@ DefineCustomBoolVariable(
     NULL, NULL, NULL);
 ```
 
-### A.2 — Helper function
+#### 3. Add the SQL definitions
 
-In `pg_documentdb/sql/udfs/stats/stats--latest.sql`, define the internal helper:
+Add the view, optional helper(s), and optional reset function under `pg_documentdb/sql/udfs/stats/`:
+
+**Helper function** (in `stats--latest.sql`):
 
 ```sql
 CREATE OR REPLACE FUNCTION __API_SCHEMA_INTERNAL__.documentdb_stat_get_io()
@@ -357,7 +328,7 @@ AS 'MODULE_PATHNAME', 'documentdb_stat_get_io';
 -- The view owner has the privileges needed to call it.
 ```
 
-### A.3 — View
+**View:**
 
 ```sql
 CREATE OR REPLACE VIEW __API_CATALOG_SCHEMA__.documentdb_stat_io AS
@@ -370,29 +341,37 @@ SELECT database,
 FROM   __API_SCHEMA_INTERNAL__.documentdb_stat_get_io()
 WHERE  current_setting('documentdb.track_io')::bool;
 -- Returns empty result set when tracking is off.
-
-GRANT SELECT ON __API_CATALOG_SCHEMA__.documentdb_stat_io TO PUBLIC;
 ```
 
-### A.4 — Reset function
+**Reset function** (if the view has cumulative counters):
 
 ```sql
 CREATE OR REPLACE FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_io()
 RETURNS void
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'documentdb_stat_reset_io';
+```
 
+#### 4. Apply the canonical grants
+
+Place these alongside the definitions in the same stats SQL file:
+
+```sql
+-- View: readable by all
+GRANT SELECT ON __API_CATALOG_SCHEMA__.documentdb_stat_io TO PUBLIC;
+
+-- Reset: restricted to admin role
 REVOKE EXECUTE ON FUNCTION
     __API_CATALOG_SCHEMA__.documentdb_stat_reset_io() FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION
     __API_CATALOG_SCHEMA__.documentdb_stat_reset_io() TO __API_ADMIN_ROLE__;
 ```
 
-### A.5 — Upgrade script
+#### 5. Add the upgrade script
 
-Add `pg_documentdb/sql/udfs/stats/stats--0.111-0--0.112-0.sql` containing the same definitions as above (view, helper, reset, grants) for the version bump.
+Add `pg_documentdb/sql/udfs/stats/stats--<from>-<to>.sql` (e.g., `stats--0.111-0--0.112-0.sql`) containing the same definitions for the version bump.
 
-### A.6 — Tests (sketch)
+#### 6. Add tests
 
 ```sql
 -- 1. Column shape
@@ -420,6 +399,28 @@ SELECT * FROM __API_CATALOG_SCHEMA__.documentdb_stat_io;   -- OK
 SELECT __API_CATALOG_SCHEMA__.documentdb_stat_reset_io();  -- ERROR: permission denied
 ```
 
-### A.7 — Documentation
+#### 7. Update documentation
 
 Open a companion PR against `https://github.com/documentdb/documentdb.github.io` adding an entry to `/articles/postgresql/stats.md` covering: description, column definitions with units, example query and output, related GUC (`documentdb.track_io`), and the reset function.
+
+#### 8. Justify any deviations
+
+If your statistic deviates from the canonical permission or path conventions, explain why in the PR description so reviewers can evaluate it explicitly.
+
+---
+
+## Implementation Tracking
+
+NA
+
+### Status Updates
+
+NA
+
+### Open Questions
+
+NA
+
+### Implementation Notes
+
+NA

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -46,6 +46,7 @@ This RFC proposes a set of conventions and rules that define **how** statistics 
 
 - This RFC does **not** design or implement any specific statistics.
 - This RFC does **not** replace or modify existing PostgreSQL statistics.
+- This RFC does **not** address using statistics for query planning or optimization. The focus is solely on exposability and monitoring.
 
 ---
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -116,9 +116,16 @@ By default, all statistical views are readable by all users:
 GRANT SELECT ON __API_CATALOG_SCHEMA__.documentdb_stat_<scope> TO PUBLIC;
 ```
 
-All statistical views must be defined in the following location:
+All statistical views must be defined under `pg_documentdb/sql/`, following the extension's existing versioned-SQL convention used elsewhere in the tree (see `pg_documentdb/sql/udfs/...` for examples):
+
+- A `stats--latest.sql` file containing the current definition.
+- One `stats--<from>-<to>.sql` upgrade script per version bump that adds or modifies a stat (for example `stats--0.110-0--0.111-0.sql`).
+
+Recommended location:
+
 ```
-pg_documentdb/sql/stats/stats--<version>.sql
+pg_documentdb/sql/udfs/stats/stats--latest.sql
+pg_documentdb/sql/udfs/stats/stats--<from>-<to>.sql
 ```
 
 #### Helper Functions
@@ -126,18 +133,35 @@ If a view is backed by helper functions, those functions must follow this naming
 
 - Single helper per scope:
   ```
-  __API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>
+  __API_SCHEMA_INTERNAL__.documentdb_stat_get_<scope>
   ```
 - Multiple helpers per scope (when the view is composed from several functions): add an `<aspect>` suffix:
   ```
-  __API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>_<aspect>
+  __API_SCHEMA_INTERNAL__.documentdb_stat_get_<scope>_<aspect>
   ```
   Examples: `documentdb_stat_get_queries_summary`, `documentdb_stat_get_queries_per_collection`.
 
-By default, helper functions must be executable by all users:
+Helper functions live in `__API_SCHEMA_INTERNAL__` because they are implementation details of the view, not part of the public stats API. The view (in `__API_CATALOG_SCHEMA__`) is the documented surface; clients should always go through it.
+
+**Permissions for helpers**
+
+By default, helper functions are **not** granted to `PUBLIC`. The view is the policy boundary, and the view's owner has the privileges needed to call the helper. Two reasons to keep helpers private:
+
+1. The helper signature is not part of the public stats API; granting EXECUTE to PUBLIC would freeze it as ABI.
+2. Any row filtering or redaction performed by the view (for example, hiding query text from non-privileged roles, mirroring `pg_stat_activity`) is bypassable if callers can reach the helper directly.
+
+Where a helper must read state the caller cannot reach (for example, a shared-memory hash table holding per-query timings), declare it as `SECURITY DEFINER` so it executes with the function owner's privileges, and **always pin the search path** to defeat search-path attacks:
+
+```sql
+CREATE FUNCTION __API_SCHEMA_INTERNAL__.documentdb_stat_get_<scope>(...)
+RETURNS SETOF ...
+LANGUAGE c
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS '$libdir/pg_documentdb', 'documentdb_stat_get_<scope>';
 ```
-GRANT EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>() TO PUBLIC;
-```
+
+`SECURITY DEFINER` functions must not interpolate user-controlled strings into SQL.
 
 ##### Reset functions (for cumulative counters)
 
@@ -158,11 +182,18 @@ __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>
   __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>(database text, collection text)
   ```
 
-By default, EXECUTE on reset functions is revoked from `PUBLIC`:
-```
+**Permissions for reset functions**
+
+EXECUTE is revoked from `PUBLIC` and granted to the existing extension admin role, mirroring the pattern in `pg_documentdb/sql/rbac/extension_admin_setup--0.10-0.sql`:
+
+```sql
 REVOKE EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>() FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>() TO __API_ADMIN_ROLE__;
 ```
-Superusers can always execute these functions (they bypass ACLs); any non-superuser role that needs reset capability must be explicitly granted EXECUTE.
+
+Superusers always bypass ACLs and can call any reset function. Non-superuser operators who need reset capability must be granted membership in `__API_ADMIN_ROLE__` (or be granted EXECUTE explicitly on a per-function basis if more granular control is desired).
+
+This model — public SELECT on the view, no PUBLIC EXECUTE on helpers, named-role EXECUTE on reset — matches how `pg_stat_statements` and Citus's `citus_stat_*` family expose statistics. Any deviation (for example, a stat that genuinely needs PUBLIC EXECUTE on its helper) must be explicitly justified in the contributing PR.
 
 
 #### Configuration Changes
@@ -214,13 +245,13 @@ Each new statistic must include:
 
 ### Database Schema Changes
 
-This RFC does not introduce data tables. It does add objects to the extension's catalog schema (`__API_CATALOG_SCHEMA__`):
+This RFC does not introduce data tables. It does add objects across two extension schemas:
 
-- One view per scope (`documentdb_stat_<scope>`).
-- Optional helper functions (`documentdb_stat_get_<scope>[_<aspect>]`).
-- Optional reset functions (`documentdb_stat_reset_<scope>`).
+- One view per scope in `__API_CATALOG_SCHEMA__` (`documentdb_stat_<scope>`).
+- Optional helper functions in `__API_SCHEMA_INTERNAL__` (`documentdb_stat_get_<scope>[_<aspect>]`).
+- Optional reset functions in `__API_CATALOG_SCHEMA__` (`documentdb_stat_reset_<scope>`).
 
-Each new statistic is delivered as part of a versioned extension upgrade script under `pg_documentdb/sql/stats/stats--<version>.sql`.
+Each new statistic is delivered following the extension's existing versioned-SQL convention: a `stats--latest.sql` plus one `stats--<from>-<to>.sql` upgrade script per version bump, located under `pg_documentdb/sql/udfs/stats/`.
 
 ### Testing Strategy
 
@@ -234,6 +265,23 @@ Each new statistic added under this RFC should include:
 ### Migration Path
 
 This RFC is purely additive and applies only to **new** statistics. Pre-existing statistics in DocumentDB are not retroactively required to follow these conventions; they may be migrated opportunistically when touched. No user-visible upgrade or rollback steps are required by this RFC itself.
+
+### Contributor Checklist: How to add a new statistic
+
+When adding a new statistic under this RFC, a contributor should:
+
+1. **Pick a scope name.** Lowercase, singular-or-plural noun matching the category (e.g., `queries`, `connections`). Confirm it does not collide with an existing `documentdb_stat_*` view or with PostgreSQL's `pg_stat_*` namespace.
+2. **Register the GUC.** Add `documentdb.track_<scope>` (default per the Open Questions decision) in the C code that registers extension GUCs, and reference it from the collection path so disabling the flag halts collection.
+3. **Add the SQL definitions** under `pg_documentdb/sql/udfs/stats/`:
+   - Update `stats--latest.sql` with the view, optional helper(s), and optional reset function.
+   - Add a `stats--<from>-<to>.sql` upgrade script for the version bump.
+4. **Apply the canonical grants** (see "Permissions for helpers" and "Permissions for reset functions"):
+   - `GRANT SELECT ON ... TO PUBLIC;` for the view.
+   - No grant to `PUBLIC` on helper functions; use `SECURITY DEFINER` with `SET search_path = pg_catalog, pg_temp` if the helper needs privileged state.
+   - `REVOKE EXECUTE ... FROM PUBLIC;` and `GRANT EXECUTE ... TO __API_ADMIN_ROLE__;` for any reset function.
+5. **Add tests** as listed in the Testing Strategy section above (column shape, flag-off behavior, reset behavior, permissions).
+6. **Update documentation.** Open a companion PR against `https://github.com/documentdb/documentdb.github.io` adding an entry to `/articles/postgresql/stats.md` with description, column definitions and units, an example query and output, related configuration parameters, and reset functions (if applicable).
+7. **Justify any deviation from the canonical permission/path conventions** in the PR description so reviewers can evaluate it explicitly.
 
 ---
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -53,6 +53,7 @@ This RFC establishes that baseline for DocumentDB. It defines **how** statistics
 - This RFC does **not** design or implement any specific statistics.
 - This RFC does **not** replace or modify existing PostgreSQL statistics.
 - This RFC does **not** address using statistics for query planning or optimization. The focus is solely on exposability and monitoring.
+- This RFC does **not** cover statistics exposed through the MongoDB wire protocol (e.g., `collStats`, `dbStats`). Those follow MongoDB API compatibility conventions. This RFC covers only **extension-defined statistics** consumed via SQL by operators and monitoring tools.
 
 ---
 
@@ -283,6 +284,18 @@ Each new statistic added under this RFC should include:
 ### Migration Path
 
 This RFC is purely additive and applies only to **new** statistics. Pre-existing statistics in DocumentDB are not retroactively required to follow these conventions; they may be migrated opportunistically when touched. No user-visible upgrade or rollback steps are required by this RFC itself.
+
+### Performance Considerations
+
+Contributors adding new statistics must consider the impact on frequently executed code paths (e.g., per-query, per-operation):
+
+1. **Collection overhead**: Use lock-free mechanisms (atomic increments, per-backend buffers) for counters updated in the query execution path. Never hold a lock to update a statistic.
+
+2. **GUC as a kill switch**: When `documentdb.track_<scope>` is `false`, collection must stop entirely — not just hide output. Zero overhead when disabled.
+
+3. **Memory budget**: Shared-memory-backed stats should declare their memory footprint in the PR description. Prefer fixed-size allocations (bounded by `MaxBackends` or a compile-time constant).
+
+4. **Validation**: PRs adding a new statistic should include a before/after benchmark demonstrating negligible throughput regression with the stat enabled.
 
 ### Contributor Checklist: How to add a new statistic
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -211,7 +211,7 @@ Examples:
 - `documentdb_track_connections`
 - `documentdb_track_collections`
 
-Default value: `true` (see Open Questions — whether to default to `true` or `false` is unresolved).
+Default value: chosen by the contributor based on the cost/value of the statistic. As a rule of thumb, default to `true` for low-overhead, broadly useful statistics (so they are discoverable out of the box) and to `false` for statistics whose collection is expensive or whose results are only meaningful in targeted investigations (matching the precedent set by `pg_stat_statements`).
 
 These parameters should be configurable via `postgresql.conf` and/or runtime configuration where supported.
 
@@ -271,7 +271,7 @@ This RFC is purely additive and applies only to **new** statistics. Pre-existing
 When adding a new statistic under this RFC, a contributor should:
 
 1. **Pick a scope name.** Lowercase, singular-or-plural noun matching the category (e.g., `queries`, `connections`). Confirm it does not collide with an existing `documentdb_stat_*` view or with PostgreSQL's `pg_stat_*` namespace.
-2. **Register the GUC.** Add `documentdb.track_<scope>` (default per the Open Questions decision) in the C code that registers extension GUCs, and reference it from the collection path so disabling the flag halts collection.
+2. **Register the GUC.** Add `documentdb.track_<scope>` (default chosen per the rule of thumb in "Configuration Changes") in the C code that registers extension GUCs, and reference it from the collection path so disabling the flag halts collection.
 3. **Add the SQL definitions** under `pg_documentdb/sql/udfs/stats/`:
    - Update `stats--latest.sql` with the view, optional helper(s), and optional reset function.
    - Add a `stats--<from>-<to>.sql` upgrade script for the version bump.
@@ -295,8 +295,7 @@ NA
 
 ### Open Questions
 
-- **Default value of `documentdb_track_<scope>`.** This RFC currently proposes `true` for discoverability, but that conflicts with the "minimal overhead" framing in the Problem section and diverges from `pg_stat_statements`-style extensions that default to off. Decide before moving Draft → Proposed.
-- **Tracking issue and discussion links.** `issue` is currently a `TBD` placeholder; file a tracking issue and update the frontmatter before moving Draft → Proposed.
+NA
 
 ### Implementation Notes
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -8,22 +8,32 @@ issue: "https://github.com/documentdb/documentdb/issues/TBD"
 
 # RFC-0007: Guidance for Onboarding Statistics
 
-## Problem
+## Background & Motivation
 
-DocumentDB currently lacks a standardized, well-defined process for contributors to onboard new statistics. While contributors may want to expose various runtime, performance, or usage insights, there is no consistent guidance for:
+### What exists today
 
-- How statistics should be exposed
-- How statistics collection should be enabled or disabled safely
+DocumentDB exposes diagnostic commands such as `coll_stats`, `db_stats`, `index_stats`, and `current_op`. These exist to provide **MongoDB API compatibility** — they return BSON documents and mirror the behavior of their MongoDB counterparts. They are not designed as a general-purpose statistics framework for the PostgreSQL layer.
 
-This creates friction for both contributors and reviewers:
+Outside of these MongoDB-compatible commands, DocumentDB has **no mechanism** for exposing internal runtime, performance, or usage statistics as PostgreSQL-native objects. There are currently:
 
-- Contributors must guess conventions or invent their own patterns.
-- Reviewers lack a consistent set of rules to evaluate submissions.
-- Inconsistencies across statistics make them harder to discover, document, and maintain.
+- **No `SELECT`-able views** — no tabular interface comparable to PostgreSQL's `pg_stat_*` views.
+- **No configuration flags** to gate statistics collection — no way to control overhead.
+- **No reset functions** for cumulative counters.
+- **No consistent permission policy** for who can read statistics versus who can reset them.
 
-Without this guidance, statistics may become fragmented, inconsistent, or unsafe (for example: unexpected overhead, unclear reset behavior, or overly broad permissions).
+### Why conventions matter now
 
-This RFC proposes a set of conventions and rules that define **how** statistics should be added, not **which** specific statistics must exist.
+As DocumentDB grows, contributors will need to add new statistics — query performance counters, connection usage, cache hit rates, and similar observability data. Without a shared convention:
+
+- Contributors must guess patterns or invent their own, leading to inconsistent APIs.
+- Reviewers lack a baseline to evaluate whether a new statistic follows a safe and discoverable pattern.
+- Downstream consumers (dashboards, alerting, documentation) must handle each statistic as a special case.
+
+PostgreSQL's own `pg_stat_*` family and extensions like `pg_stat_statements` demonstrate that a small, consistent set of conventions — standard naming, a GUC to gate collection, public `SELECT` on views, restricted `EXECUTE` on reset functions — makes statistics predictable and maintainable at scale.
+
+### What this RFC does
+
+This RFC establishes that baseline for DocumentDB. It defines **how** statistics should be added — not **which** specific statistics must exist. The goal is a set of rules that make new statistics **predictable, discoverable, and safe by default**, so that a contributor (or even an AI code-generation tool) can follow the pattern end-to-end without tribal knowledge.
 
 ### Who is impacted
 
@@ -50,15 +60,19 @@ This RFC proposes a set of conventions and rules that define **how** statistics 
 
 The approach is inspired by established conventions in PostgreSQL (e.g., `pg_stat_*` views) and widely-used extensions (e.g., Citus).
 
-In DocumentDB, statistics should be exposed through **views**.
+In DocumentDB, statistics should be exposed through **views** — literal PostgreSQL `CREATE VIEW` objects that users can `SELECT` from, not an abstract concept. Each view provides a stable, tabular interface to a category of statistics.
 
 - Views may be backed directly by SQL statements.
-- Views may also be backed by one or more underlying helper functions when the logic is complex or requires internal state.
+- Views may also be backed by one or more underlying helper functions when the logic is complex or requires internal state (e.g., reading from shared memory).
 
+The **permission model** is straightforward:
+
+- **Read**: any connected role can query statistics — views are granted `SELECT … TO PUBLIC`.
+- **Reset**: only the extension admin role (`__API_ADMIN_ROLE__`) can clear cumulative counters via reset functions. `EXECUTE` is revoked from `PUBLIC`.
 
 This RFC defines:
 - Naming conventions for views and functions
-- Standard patterns for permissions
+- Standard patterns for permissions (as summarized above)
 - Configuration switches to enable/disable collection
 - Documentation requirements for each statistic
 
@@ -300,3 +314,118 @@ NA
 ### Implementation Notes
 
 NA
+
+---
+
+## Appendix A: Worked Example — `documentdb_stat_io`
+
+This appendix shows the complete set of artifacts a contributor would produce when adding a hypothetical I/O statistics scope. The example is **illustrative only** — it does not propose a real statistic. Its purpose is to demonstrate the full pattern end-to-end so that contributors can follow it as a template.
+
+### A.1 — Register the GUC
+
+In `pg_documentdb/src/configs/system_configs.c`, add a boolean GUC to gate collection:
+
+```c
+/* Whether to collect I/O statistics. */
+bool DocumentDBTrackIO = true;
+
+DefineCustomBoolVariable(
+    psprintf("%s.track_io", prefix),
+    gettext_noop("Enables collection of I/O statistics."),
+    NULL,
+    &DocumentDBTrackIO,
+    true,                       /* default on — low overhead */
+    PGC_SUSET,
+    0,
+    NULL, NULL, NULL);
+```
+
+### A.2 — Helper function
+
+In `pg_documentdb/sql/udfs/stats/stats--latest.sql`, define the internal helper:
+
+```sql
+CREATE OR REPLACE FUNCTION __API_SCHEMA_INTERNAL__.documentdb_stat_get_io()
+RETURNS TABLE (
+    database       text,
+    read_count     bigint,
+    write_count    bigint,
+    read_bytes     bigint,
+    write_bytes    bigint,
+    stats_reset    timestamptz
+)
+LANGUAGE c
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS 'MODULE_PATHNAME', 'documentdb_stat_get_io';
+
+-- Helper is NOT granted to PUBLIC.
+-- The view owner has the privileges needed to call it.
+```
+
+### A.3 — View
+
+```sql
+CREATE OR REPLACE VIEW __API_CATALOG_SCHEMA__.documentdb_stat_io AS
+SELECT database,
+       read_count,        -- value (with _count suffix)
+       write_count,       -- value (with _count suffix)
+       read_bytes,        -- value (with _bytes suffix)
+       write_bytes,       -- value (with _bytes suffix)
+       stats_reset        -- timestamp of last reset (exempt from suffix rule)
+FROM   __API_SCHEMA_INTERNAL__.documentdb_stat_get_io()
+WHERE  current_setting('documentdb.track_io')::bool;
+-- Returns empty result set when tracking is off.
+
+GRANT SELECT ON __API_CATALOG_SCHEMA__.documentdb_stat_io TO PUBLIC;
+```
+
+### A.4 — Reset function
+
+```sql
+CREATE OR REPLACE FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_io()
+RETURNS void
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'documentdb_stat_reset_io';
+
+REVOKE EXECUTE ON FUNCTION
+    __API_CATALOG_SCHEMA__.documentdb_stat_reset_io() FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION
+    __API_CATALOG_SCHEMA__.documentdb_stat_reset_io() TO __API_ADMIN_ROLE__;
+```
+
+### A.5 — Upgrade script
+
+Add `pg_documentdb/sql/udfs/stats/stats--0.111-0--0.112-0.sql` containing the same definitions as above (view, helper, reset, grants) for the version bump.
+
+### A.6 — Tests (sketch)
+
+```sql
+-- 1. Column shape
+SELECT column_name, data_type
+FROM   information_schema.columns
+WHERE  table_name = 'documentdb_stat_io'
+ORDER  BY ordinal_position;
+-- Expect: database (text), read_count (bigint), write_count (bigint),
+--         read_bytes (bigint), write_bytes (bigint), stats_reset (timestamptz)
+
+-- 2. Flag off → empty result set
+SET documentdb.track_io = false;
+SELECT count(*) FROM __API_CATALOG_SCHEMA__.documentdb_stat_io;
+-- Expect: 0
+
+-- 3. Reset advances stats_reset
+SELECT stats_reset AS before FROM __API_CATALOG_SCHEMA__.documentdb_stat_io LIMIT 1;
+SELECT __API_CATALOG_SCHEMA__.documentdb_stat_reset_io();
+SELECT stats_reset AS after FROM __API_CATALOG_SCHEMA__.documentdb_stat_io LIMIT 1;
+-- Expect: after > before
+
+-- 4. Permission: unprivileged role can SELECT but cannot reset
+SET ROLE unprivileged_user;
+SELECT * FROM __API_CATALOG_SCHEMA__.documentdb_stat_io;   -- OK
+SELECT __API_CATALOG_SCHEMA__.documentdb_stat_reset_io();  -- ERROR: permission denied
+```
+
+### A.7 — Documentation
+
+Open a companion PR against `https://github.com/documentdb/documentdb.github.io` adding an entry to `/articles/postgresql/stats.md` covering: description, column definitions with units, example query and output, related GUC (`documentdb.track_io`), and the reset function.

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -178,10 +178,10 @@ By default, helper functions are **not** granted to `PUBLIC`. The view is the po
 2. Any row filtering or redaction performed by the view (for example, hiding query text from non-privileged roles, mirroring `pg_stat_activity`) is bypassable if callers can reach the helper directly.
 
 ```sql
-CREATE FUNCTION __API_SCHEMA_INTERNAL__.documentdb_stat_get_<scope>(...)
+CREATE OR REPLACE FUNCTION __API_SCHEMA_INTERNAL__.documentdb_stat_get_<scope>(...)
 RETURNS SETOF ...
-LANGUAGE c
-AS '$libdir/pg_documentdb', 'documentdb_stat_get_<scope>';
+LANGUAGE c VOLATILE PARALLEL UNSAFE
+AS 'MODULE_PATHNAME', $$documentdb_stat_get_<scope>$$;
 ```
 
 #### Reset Functions
@@ -327,8 +327,8 @@ RETURNS TABLE (
     write_bytes    bigint,
     stats_reset    timestamptz
 )
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'documentdb_stat_get_io';
+LANGUAGE c VOLATILE PARALLEL UNSAFE
+AS 'MODULE_PATHNAME', $$documentdb_stat_get_io$$;
 
 -- Helper is NOT granted to PUBLIC.
 -- The view owner has the privileges needed to call it.
@@ -345,7 +345,7 @@ SELECT database,
        write_bytes,       -- value (with _bytes suffix)
        stats_reset        -- timestamp of last reset (exempt from suffix rule)
 FROM   __API_SCHEMA_INTERNAL__.documentdb_stat_get_io()
-WHERE  current_setting('documentdb.track_io')::bool;
+WHERE  current_setting(__SINGLE_QUOTED_STRING__(__API_GUC_PREFIX__) || '.track_io')::bool;
 -- Returns empty result set when tracking is off.
 ```
 
@@ -354,8 +354,8 @@ WHERE  current_setting('documentdb.track_io')::bool;
 ```sql
 CREATE OR REPLACE FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_io()
 RETURNS void
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'documentdb_stat_reset_io';
+LANGUAGE c VOLATILE PARALLEL UNSAFE
+AS 'MODULE_PATHNAME', $$documentdb_stat_reset_io$$;
 ```
 
 #### 4. Apply the canonical grants

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -422,7 +422,11 @@ SELECT __API_CATALOG_SCHEMA__.documentdb_stat_reset_io();  -- ERROR: permission 
 
 Open a companion PR against `https://github.com/documentdb/documentdb.github.io` adding an entry to `/articles/postgresql/stats.md` covering: description, column definitions with units, example query and output, related GUC (`documentdb.track_io`), and the reset function.
 
-#### 8. Justify any deviations
+#### 8. Validate performance
+
+Run a before/after benchmark demonstrating negligible throughput regression with the stat enabled. Ensure collection uses lock-free mechanisms and the GUC fully disables collection (zero overhead when off). See "Performance Considerations" for details.
+
+#### 9. Justify any deviations
 
 If your statistic deviates from the canonical permission or path conventions, explain why in the PR description so reviewers can evaluate it explicitly.
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -78,7 +78,7 @@ Statistcs will be exposed through views.
 
 **View naming pattern**
 ```
-documentdb_stat_<scope>
+__API_CATALOG_SCHEMA__.documentdb_stat_<scope>
 ```
 
 **Column naming in views**
@@ -93,7 +93,7 @@ documentdb_stat_<scope>
 
 By default, all statistical views are readable by all users:
 ```
-GRANT SELECT ON documentdb_stat_<scope> TO PUBLIC;
+GRANT SELECT ON __API_CATALOG_SCHEMA__.documentdb_stat_<scope> TO PUBLIC;
 ```
 
 All statistical views must be defined in the following location:
@@ -104,12 +104,12 @@ pg_documentdb/sql/stats/stats--<version>.sql
 ### Helper Functions
 If a view is backed by one or more helper functions, those functions must follow this naming pattern:
 ```
-documentdb_stat_get_<scope>
+__API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>
 ```
 
 By default, helper functions must be executable by all users:
 ```
-GRANT EXECUTE ON FUNCTION documentdb_stat_get_<xxxx>() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>() TO PUBLIC;
 ```
 
 #### Reset functions (for cumulative counters)
@@ -118,11 +118,11 @@ If a view contains cumulative counters that may need to be reset, a reset functi
 
 **Naming pattern**
 ```
-documentdb_stat_reset_<xxxx>
+__API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>
 ```
 By default, this function is restricted to superusers:
 ```
-REVOKE EXECUTE ON FUNCTION documentdb_stat_reset_<xxxx>() FROM public;
+REVOKE EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>() FROM public;
 ```
 Other roles may be explicitly granted permission as needed.
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -97,6 +97,20 @@ Where `<scope>` describes the category of statistics being exposed. Examples inc
 
 - Columns representing **dimensions** (e.g., name, database, collection, user) should **not** use a suffix.
 
+**Example** (for illustration purposes only, not an actual view):
+```sql
+CREATE VIEW documentdb_stat_queries AS
+SELECT
+    database,           -- dimension (no suffix)
+    collection,         -- dimension (no suffix)
+    user_name,          -- dimension (no suffix)
+    query_count,        -- value (with _count suffix)
+    total_seconds,      -- value (with _seconds suffix)
+    avg_milliseconds,   -- value (with _milliseconds suffix)
+    cache_hit_percent   -- value (with _percent suffix)
+FROM ...
+```
+
 By default, all statistical views are readable by all users:
 ```
 GRANT SELECT ON __API_CATALOG_SCHEMA__.documentdb_stat_<scope> TO PUBLIC;

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -29,7 +29,7 @@ As DocumentDB grows, contributors will need to add new statistics — query perf
 - Reviewers lack a baseline to evaluate whether a new statistic follows a safe and discoverable pattern.
 - Over time, inconsistencies accumulate and make the statistics surface harder to discover, document, and maintain.
 
-PostgreSQL's own `pg_stat_*` family and extensions like `pg_stat_statements` demonstrate that a small, consistent set of conventions — standard naming, a GUC to gate collection, public `SELECT` on views, restricted `EXECUTE` on reset functions — makes statistics predictable and maintainable at scale.
+PostgreSQL's own `pg_stat_*` family and extensions like `pg_stat_statements` demonstrate that a small, consistent set of conventions — standard naming, a GUC (Grand Unified Configuration) parameter to gate collection, public `SELECT` on views, restricted `EXECUTE` on reset functions — makes statistics predictable and maintainable at scale.
 
 ### What this RFC does
 
@@ -90,6 +90,12 @@ The goal is to provide a predictable and maintainable pattern that aligns with f
 This RFC defines conventions only; no new code paths or data structures are introduced. Each statistic implemented under these conventions will have its own technical design.
 
 ### API Changes
+
+The naming patterns below use build-system macros that expand to real PostgreSQL schema and role names at install time:
+
+- `__API_CATALOG_SCHEMA__` — the public-facing schema where views and reset functions are created.
+- `__API_SCHEMA_INTERNAL__` — the internal schema for implementation-detail functions (not part of the public API).
+- `__API_ADMIN_ROLE__` — the extension's admin role, used to restrict destructive operations like counter resets.
 
 #### Views
 Statistics will be exposed through views.
@@ -210,7 +216,7 @@ Non-superuser operators who need reset capability must be granted membership in 
 
 ### Configuration Changes
 
-Each category of statistical data should be gated behind a GUC (Grand Unified Configuration) flag to control collection overhead.
+Each category of statistical data should be gated behind a GUC flag to control collection overhead.
 
 **Naming pattern**
 ```

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -3,11 +3,7 @@ rfc: 0007
 title: "Guidance for Onboarding Statistics"
 status: Draft
 owner: "@WentingWu666666"
-issue: NA
-discussion: NA
-version-target: NA
-implementations: NA
-
+issue: "https://github.com/documentdb/documentdb/issues/TBD"
 ---
 
 # RFC-0007: Guidance for Onboarding Statistics
@@ -74,8 +70,8 @@ The goal is to provide a predictable and maintainable pattern that aligns with f
 
 ### API Changes
 
-### Views
-Statistcs will be exposed through views.
+#### Views
+Statistics will be exposed through views.
 
 **View naming pattern**
 ```
@@ -98,7 +94,7 @@ Where `<scope>` describes the category of statistics being exposed. Examples inc
 
 - Columns representing **dimensions** (e.g., name, database, collection, user) should **not** use a suffix.
 
-- `stats_reset` column is required if the view contains cumulative counters. This column indicates the timestamp of the last reset.
+- Metadata columns that carry a timestamp are exempt from the unit-suffix rule. Specifically, `stats_reset` is required if the view contains cumulative counters and indicates the timestamp of the last reset. Other timestamp-typed metadata columns (e.g., `last_updated`, `first_seen`) are likewise exempt.
 
 **Example** (for illustration purposes only, not an actual view):
 ```sql
@@ -125,18 +121,25 @@ All statistical views must be defined in the following location:
 pg_documentdb/sql/stats/stats--<version>.sql
 ```
 
-### Helper Functions
-If a view is backed by one or more helper functions, those functions must follow this naming pattern:
-```
-__API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>
-```
+#### Helper Functions
+If a view is backed by helper functions, those functions must follow this naming pattern:
+
+- Single helper per scope:
+  ```
+  __API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>
+  ```
+- Multiple helpers per scope (when the view is composed from several functions): add an `<aspect>` suffix:
+  ```
+  __API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>_<aspect>
+  ```
+  Examples: `documentdb_stat_get_queries_summary`, `documentdb_stat_get_queries_per_collection`.
 
 By default, helper functions must be executable by all users:
 ```
 GRANT EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_get_<scope>() TO PUBLIC;
 ```
 
-#### Reset functions (for cumulative counters)
+##### Reset functions (for cumulative counters)
 
 If a view contains cumulative counters that may need to be reset, a reset function must be provided.
 
@@ -144,14 +147,25 @@ If a view contains cumulative counters that may need to be reset, a reset functi
 ```
 __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>
 ```
-By default, this function is restricted to superusers:
+
+**Signatures**
+- The canonical signature is the no-argument form, which resets all counters for the scope:
+  ```
+  __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>()
+  ```
+- Targeted variants may be added with parameters that match the dimension columns of the view, for example:
+  ```
+  __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>(database text, collection text)
+  ```
+
+By default, EXECUTE on reset functions is revoked from `PUBLIC`:
 ```
-REVOKE EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>() FROM public;
+REVOKE EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>() FROM PUBLIC;
 ```
-Other roles may be explicitly granted permission as needed.
+Superusers can always execute these functions (they bypass ACLs); any non-superuser role that needs reset capability must be explicitly granted EXECUTE.
 
 
-### Configuration Changes
+#### Configuration Changes
 
 Since collecting statistics introduces overhead, each category of statistical data should be gated behind a configuration flag.
 
@@ -166,16 +180,16 @@ Examples:
 - `documentdb_track_connections`
 - `documentdb_track_collections`
 
-Default value: `true`
+Default value: `true` (see Open Questions — whether to default to `true` or `false` is unresolved).
 
 These parameters should be configurable via `postgresql.conf` and/or runtime configuration where supported.
 
 When the flag is set to `false`:
-- Statistics collection should stop
-- The corresponding view should return empty or zeroed data (not fail)
+- Statistics collection should stop.
+- The corresponding view should return an **empty result set** (not fail, and not return zeroed rows). An empty set is unambiguous in dashboards and alerting; zeroed rows can be misread as "the system is healthy."
 
 
-### Documentation Updates
+#### Documentation Updates
 
 The following documentation must be updated when new statistics are added:
 
@@ -198,6 +212,29 @@ Each new statistic must include:
 - Related configuration parameters
 - Reset functions (if applicable)
 
+### Database Schema Changes
+
+This RFC does not introduce data tables. It does add objects to the extension's catalog schema (`__API_CATALOG_SCHEMA__`):
+
+- One view per scope (`documentdb_stat_<scope>`).
+- Optional helper functions (`documentdb_stat_get_<scope>[_<aspect>]`).
+- Optional reset functions (`documentdb_stat_reset_<scope>`).
+
+Each new statistic is delivered as part of a versioned extension upgrade script under `pg_documentdb/sql/stats/stats--<version>.sql`.
+
+### Testing Strategy
+
+Each new statistic added under this RFC should include:
+
+- Unit/regression tests that verify the view's columns, types, and naming conventions.
+- A test that exercises the `documentdb_track_<scope>` flag in both states and asserts the view returns an empty set when the flag is `false`.
+- For views with cumulative counters: a test that exercises the reset function and asserts `stats_reset` advances.
+- A permissions test that asserts `SELECT` on the view succeeds for an unprivileged role and `EXECUTE` on the reset function fails for an unprivileged role.
+
+### Migration Path
+
+This RFC is purely additive and applies only to **new** statistics. Pre-existing statistics in DocumentDB are not retroactively required to follow these conventions; they may be migrated opportunistically when touched. No user-visible upgrade or rollback steps are required by this RFC itself.
+
 ---
 
 ## Implementation Tracking
@@ -210,7 +247,8 @@ NA
 
 ### Open Questions
 
-NA
+- **Default value of `documentdb_track_<scope>`.** This RFC currently proposes `true` for discoverability, but that conflicts with the "minimal overhead" framing in the Problem section and diverges from `pg_stat_statements`-style extensions that default to off. Decide before moving Draft → Proposed.
+- **Tracking issue and discussion links.** `issue` is currently a `TBD` placeholder; file a tracking issue and update the frontmatter before moving Draft → Proposed.
 
 ### Implementation Notes
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -81,6 +81,12 @@ Statistcs will be exposed through views.
 __API_CATALOG_SCHEMA__.documentdb_stat_<scope>
 ```
 
+Where `<scope>` describes the category of statistics being exposed. Examples include:
+- `queries`
+- `connections`
+- `collections`
+- `indexes`
+
 **Column naming in views**
 - Columns representing a **value** must end with a unit suffix:
   - `_count`

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -58,7 +58,7 @@ This RFC establishes that baseline for DocumentDB. It defines **how** statistics
 
 ## Approach
 
-The approach is inspired by established conventions in PostgreSQL (e.g., `pg_stat_*` views) and widely-used extensions (e.g., Citus).
+The approach is inspired by established conventions in PostgreSQL (e.g., `pg_stat_*` views) and widely-used extensions (e.g., `pg_stat_statements`).
 
 In DocumentDB, statistics should be exposed through **views** — literal PostgreSQL `CREATE VIEW` objects that users can `SELECT` from, not an abstract concept. Each view provides a stable, tabular interface to a category of statistics.
 
@@ -212,14 +212,14 @@ Since collecting statistics introduces overhead, each category of statistical da
 
 **Naming pattern**
 ```
-documentdb_track_<scope>
+documentdb.track_<scope>
 ```
 
 Examples:
 
-- `documentdb_track_queries`
-- `documentdb_track_connections`
-- `documentdb_track_collections`
+- `documentdb.track_queries`
+- `documentdb.track_connections`
+- `documentdb.track_collections`
 
 Default value: chosen by the contributor based on the cost/value of the statistic. As a rule of thumb, default to `true` for low-overhead, broadly useful statistics (so they are discoverable out of the box) and to `false` for statistics whose collection is expensive or whose results are only meaningful in targeted investigations (matching the precedent set by `pg_stat_statements`).
 
@@ -268,7 +268,7 @@ Each new statistic is delivered following the extension's existing versioned-SQL
 Each new statistic added under this RFC should include:
 
 - Unit/regression tests that verify the view's columns, types, and naming conventions.
-- A test that exercises the `documentdb_track_<scope>` flag in both states and asserts the view returns an empty set when the flag is `false`.
+- A test that exercises the `documentdb.track_<scope>` flag in both states and asserts the view returns an empty set when the flag is `false`.
 - For views with cumulative counters: a test that exercises the reset function and asserts `stats_reset` advances.
 - A permissions test that asserts `SELECT` on the view succeeds for an unprivileged role and `EXECUTE` on the reset function fails for an unprivileged role.
 
@@ -281,13 +281,13 @@ This RFC is purely additive and applies only to **new** statistics. Pre-existing
 When adding a new statistic under this RFC, a contributor should:
 
 1. **Pick a scope name.** Lowercase, singular-or-plural noun matching the category (e.g., `queries`, `connections`). Confirm it does not collide with an existing `documentdb_stat_*` view or with PostgreSQL's `pg_stat_*` namespace.
-2. **Register the GUC.** Add `documentdb.track_<scope>` (default chosen per the rule of thumb in "Configuration Changes") in the C code that registers extension GUCs, and reference it from the collection path so disabling the flag halts collection.
+2. **Register the GUC.** Add `documentdb.track_<scope>` (default chosen per the rule of thumb in "Configuration Flags (GUC)") in the C code that registers extension GUCs, and reference it from the collection path so disabling the flag halts collection.
 3. **Add the SQL definitions** under `pg_documentdb/sql/udfs/stats/`:
    - Update `stats--latest.sql` with the view, optional helper(s), and optional reset function.
    - Add a `stats--<from>-<to>.sql` upgrade script for the version bump.
 4. **Apply the canonical grants** (see "Permissions for helpers" and "Permissions for reset functions"):
    - `GRANT SELECT ON ... TO PUBLIC;` for the view.
-   - No grant to `PUBLIC` on helper functions; use `SECURITY DEFINER` with `SET search_path = pg_catalog, pg_temp` if the helper needs privileged state.
+   - No grant to `PUBLIC` on helper functions.
    - `REVOKE EXECUTE ... FROM PUBLIC;` and `GRANT EXECUTE ... TO __API_ADMIN_ROLE__;` for any reset function.
 5. **Add tests** as listed in the Testing Strategy section above (column shape, flag-off behavior, reset behavior, permissions).
 6. **Update documentation.** Open a companion PR against `https://github.com/documentdb/documentdb.github.io` adding an entry to `/articles/postgresql/stats.md` with description, column definitions and units, an example query and output, related configuration parameters, and reset functions (if applicable).

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -1,182 +1,139 @@
 ---
 rfc: 0007
-title: "RFC Title"
+title: "Guidance for Onboarding Statistical Views"
 status: Draft
-owner: "@github-username"
-issue: "https://github.com/documentdb/documentdb/issues/XXX"
-discussion: "https://github.com/documentdb/documentdb/discussions/XXX"
-version-target: 1.0
-implementations:
-  - "https://github.com/documentdb/documentdb/pull/XXX"
+owner: "@WentingWu666666"
+issue: NA
+discussion: NA
+version-target: NA
+implementations: NA
+
 ---
 
-# RFC-XXXX: [Title]
-
-*Delete these italicized instructions before submitting your RFC. For details of the RFC process, see https://github.com/documentdb/documentdb/blob/main/rfcs/0003-rfc-process.md*
-
-*RFC statuses follow this flow:*
-
-```
-[Draft] → [Proposed] → [Accepted/Rejected] → [Implementing] → [Complete]
-                                           ↘ [Archived]
-```
+# RFC-0007: Guidance for Onboarding Statistical Views
 
 ## Problem
 
-*This section is REQUIRED before moving from Draft to Proposed status.*
+DocumentDB currently lacks a standardized, well-defined process for contributors to onboard new statistical views. 
+While contributors may want to expose various runtime, performance, or usage insights through SQL views, there is no consistent guidance for:
+- How views should be named and organized  
+- Where SQL definitions should live in the repository  
+- How columns and units should be defined  
+- How permissions should be handled  
+- How statistics collection should be enabled/disabled safely  
 
-**Section purpose:** Clearly articulate the problem or opportunity this RFC addresses. 
+This creates friction for both contributors and reviewers:
+- Contributors must guess conventions or invent their own patterns.
+- Reviewers lack a consistent set of rules to evaluate submissions.
+- Inconsistencies across views make them harder to discover, document, and maintain.
 
-**Complete this section when:** You're ready to start a discussion and get initial feedback on whether this problem is worth solving.
+Without this guidance, statistical views may become fragmented, inconsistent, or unsafe (e.g., unexpected overhead, unclear reset behavior, or overly broad permissions).
 
-**Guidance:**
-- What problem are you trying to solve?
-- Who is impacted by this problem?
-- What are the consequences of not solving it?
-- What are the current workarounds, if any?
-- What are the success criteria?
-- What are the non-goals?
-- What behavior are you intending to emulate? What are the quircks there?
-- Is there an API spec being targeted?
+This RFC proposes a set of conventions and rules that define *how* statistical views should be added, not *which* specific views must exist.
 
-**Example prompts to guide your thinking:**
-- "Users currently struggle with..."
-- "The system lacks..."
-- "This creates friction when..."
-- "Without this, contributors must..."
+### Who is impacted
+
+- Contributors adding new statistical or observability-related functionality  
+- Maintainers reviewing and approving contributions  
+- Users who rely on DocumentDB system statistics for monitoring and troubleshooting  
+
+### Success criteria
+
+- A clear, documented set of rules for adding new statistical views  
+- Consistent naming, schema placement, and column conventions  
+- Controlled permissions and predictable reset behavior  
+- Minimal friction for contributors to follow the pattern  
+
+### Non-goals
+
+- This RFC does **not** design or implement any specific statistical view.
+- This RFC does **not** replace existing PostgreSQL statistical views.
 
 ---
 
 ## Approach
 
-*This section is REQUIRED before moving from Proposed to Accepted status.*
-
-**Purpose:** Describe your proposed solution at a high level.
-
-**Complete this section when:** You've received feedback that the problem is worth solving and you're ready to propose a specific approach.
-
-**Progressive disclosure:** Start lean! You don't need all the details yet. Focus on the core idea and high-level approach. Detailed design comes later.
-
-**Guidance:**
-- What is your proposed solution?
-- Why is this approach better than alternatives?
-- What are the key benefits and tradeoffs?
-- How does this fit with existing DocumentDB architecture?
-
-**Example prompts for solution thinking:**
-- "The proposed solution is to..."
-- "This approach is preferable because..."
-- "Key tradeoffs include..."
-- "This aligns with existing patterns by..."
+The proposed solution is to define and document a standard onboarding pattern for statistical views in DocumentDB, 
+inspired by established conventions in PostgreSQL (e.g., `pg_stat_*` views) and widely-used extensions (e.g., Citus).
 
 ---
 
 ## Detailed Design
 
-*This section MAY BE REQUIRED before moving from Proposed to Accepted status. This section MUST be completed and approved to move to Implementing status.*
-
-**Purpose:** Provide comprehensive technical details needed for implementation.
-
-**Complete this section when:** Your solution approach has been validated and you're ready to commit to specific implementation details.
-
-**Guidance:** This is where you get specific. Include enough detail that someone could implement this RFC without having to make major design decisions.
-
-### Technical Details
-
-*Describe the technical implementation specifics*
-- Data structures
-- Algorithms
-- Architecture patterns
-- Performance considerations
-
 ### API Changes
 
-*Document any public API additions or modifications*
-- New functions, including UDFs
-- Modified signatures
-- Breaking changes
-- Deprecation plans
+#### 1. Naming Convention
+**View name**: documentdb_stat_<scope>
+Examples:
+- `documentdb_stat_collections`
+- `documentdb_stat_queries`
+- `documentdb_stat_connections`
 
-### Database Schema Changes
+**Column naming**
+- Columns representing a value must end with a unit suffix:
+  - `_count`
+  - `_seconds`
+  - `_milliseconds`
+  - `_bytes`
+  - `_percent`
 
-*If applicable, describe schema modifications*
-- New tables/collections
-- Schema migrations
-- Index changes
-- Data migration strategies
+- Columns representing dimensions (e.g., name, database, collection, user) should **not** use a suffix.
+
+TBD
 
 ### Configuration Changes
 
-*Document new or modified configuration options*
-- New settings
-- Modified defaults
-- Environment variables
-- Configuration validation
+Since collecting statistics introduces overhead, each category of statistical data should be gated behind a configuration flag.
 
-### Testing Strategy
+Pattern: documentdb_track_<scope>
 
-*Describe how this will be tested*
-- Unit test approach
-- Integration test requirements
-- Compatibility test requirements
-- Performance test plans
-- Migration test strategy
+Examples:
 
-### Migration Path
+- `documentdb_track_queries`
+- `documentdb_track_connections`
+- `documentdb_track_collections`
 
-*How do existing users/deployments upgrade?*
-- Backwards/forwards compatibility
-- Migration steps
-- Rollback strategy
-- Deprecation timeline
+Default value: true
+
+These parameters should be configurable via `postgresql.conf` and/or runtime configuration where supported.
+
+When the flag is set to `false`:
+- Statistics collection should stop
+- The corresponding view should return empty or zeroed data (not fail)
+
 
 ### Documentation Updates
 
-*What documentation needs to change?*
-- User-facing docs
-- Developer guides
-- API references
-- Examples/tutorials
+Update the following documentation to include:
+
+- List of statistical views
+- Column descriptions and units
+- Reset functions (if any)
+- Related configuration parameters
+
+Target location:
+https://github.com/documentdb/documentdb.github.io
+/articles/postgresql/stats.md
+
+Each new statistical view must include:
+- Description of purpose
+- Example query
+- Sample output
 
 ---
 
 ## Implementation Tracking
 
-*This section SHALL be populated during the Implementation phase.*
-
-**Purpose:** Track the implementation progress of this RFC.
-
-**Complete this section when:** Your RFC has been accepted and implementation work begins.
-
-**Guidance:**
-- Link to the PRs that implement this RFC. Update as implementation progresses.
-- Provide success metrics.
-
-### Implementation PRs
-
-- [ ] PR #XXX: [Brief description of what this PR implements]
-- [ ] PR #XXX: [Brief description of what this PR implements]
-- [ ] PR #XXX: [Brief description of what this PR implements]
+NA
 
 ### Status Updates
 
-*Add dated status updates as implementation progresses*
-
-**YYYY-MM-DD:** Initial implementation started in PR #XXX
-
-**YYYY-MM-DD:** [Update on progress, blockers, or changes]
+NA
 
 ### Open Questions
 
-*Track unresolved questions that arise during implementation*
-
-- [ ] Question: [Description]
-  - Discussion: [Link to discussion or resolution]
+NA
 
 ### Implementation Notes
 
-*Capture important decisions or learnings during implementation*
-
-- **Decision [YYYY-MM-DD]:** [What was decided]
-  - **Context:** [Why this decision was made]
-  - **Alternatives:** [What else was considered]
+NA

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -12,7 +12,7 @@ issue: "https://github.com/documentdb/documentdb/issues/TBD"
 
 ### What exists today
 
-DocumentDB exposes diagnostic commands such as `coll_stats`, `db_stats`, `index_stats`, and `current_op`. These exist to provide **MongoDB API compatibility** — they return BSON documents and mirror the behavior of their MongoDB counterparts. They are not designed as a general-purpose statistics framework for the PostgreSQL layer.
+DocumentDB exposes diagnostic commands such as `coll_stats`, `db_stats`, `index_stats`, and `current_op`. These exist to provide **MongoDB API compatibility** — they return BSON documents and mirror the behavior of their MongoDB counterparts. They are not designed as a reusable pattern for exposing new PostgreSQL-native statistics.
 
 Outside of these MongoDB-compatible commands, DocumentDB has **no mechanism** for exposing internal runtime, performance, or usage statistics as PostgreSQL-native objects. There are currently:
 
@@ -27,7 +27,7 @@ As DocumentDB grows, contributors will need to add new statistics — query perf
 
 - Contributors must guess patterns or invent their own, leading to inconsistent APIs.
 - Reviewers lack a baseline to evaluate whether a new statistic follows a safe and discoverable pattern.
-- Downstream consumers (dashboards, alerting, documentation) must handle each statistic as a special case.
+- Over time, inconsistencies accumulate and make the statistics surface harder to discover, document, and maintain.
 
 PostgreSQL's own `pg_stat_*` family and extensions like `pg_stat_statements` demonstrate that a small, consistent set of conventions — standard naming, a GUC to gate collection, public `SELECT` on views, restricted `EXECUTE` on reset functions — makes statistics predictable and maintainable at scale.
 
@@ -161,21 +161,15 @@ Helper functions live in `__API_SCHEMA_INTERNAL__` because they are implementati
 
 By default, helper functions are **not** granted to `PUBLIC`. The view is the policy boundary, and the view's owner has the privileges needed to call the helper. Two reasons to keep helpers private:
 
-1. The helper signature is not part of the public stats API; granting EXECUTE to PUBLIC would freeze it as ABI.
+1. The helper signature is not part of the public stats API; granting EXECUTE to PUBLIC would freeze it as a public API contract.
 2. Any row filtering or redaction performed by the view (for example, hiding query text from non-privileged roles, mirroring `pg_stat_activity`) is bypassable if callers can reach the helper directly.
-
-Where a helper must read state the caller cannot reach (for example, a shared-memory hash table holding per-query timings), declare it as `SECURITY DEFINER` so it executes with the function owner's privileges, and **always pin the search path** to defeat search-path attacks:
 
 ```sql
 CREATE FUNCTION __API_SCHEMA_INTERNAL__.documentdb_stat_get_<scope>(...)
 RETURNS SETOF ...
 LANGUAGE c
-SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp
 AS '$libdir/pg_documentdb', 'documentdb_stat_get_<scope>';
 ```
-
-`SECURITY DEFINER` functions must not interpolate user-controlled strings into SQL.
 
 ##### Reset functions (for cumulative counters)
 
@@ -198,19 +192,21 @@ __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>
 
 **Permissions for reset functions**
 
-EXECUTE is revoked from `PUBLIC` and granted to the existing extension admin role, mirroring the pattern in `pg_documentdb/sql/rbac/extension_admin_setup--0.10-0.sql`:
+EXECUTE is revoked from `PUBLIC` and granted to the existing extension admin role (`__API_ADMIN_ROLE__`). These grants should be placed in the stats SQL file alongside the function definition:
 
 ```sql
 REVOKE EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>() FROM PUBLIC;
 GRANT  EXECUTE ON FUNCTION __API_CATALOG_SCHEMA__.documentdb_stat_reset_<scope>() TO __API_ADMIN_ROLE__;
 ```
 
-Superusers always bypass ACLs and can call any reset function. Non-superuser operators who need reset capability must be granted membership in `__API_ADMIN_ROLE__` (or be granted EXECUTE explicitly on a per-function basis if more granular control is desired).
+Non-superuser operators who need reset capability must be granted membership in `__API_ADMIN_ROLE__` (or be granted EXECUTE explicitly on a per-function basis if more granular control is desired).
 
-This model — public SELECT on the view, no PUBLIC EXECUTE on helpers, named-role EXECUTE on reset — matches how `pg_stat_statements` and Citus's `citus_stat_*` family expose statistics. Any deviation (for example, a stat that genuinely needs PUBLIC EXECUTE on its helper) must be explicitly justified in the contributing PR.
+#### Permission Model Summary
+
+This model — public SELECT on the view, no PUBLIC EXECUTE on helpers, named-role EXECUTE on reset — matches how `pg_stat_statements` exposes statistics. Any deviation (for example, a stat that genuinely needs PUBLIC EXECUTE on its helper) must be explicitly justified in the contributing PR.
 
 
-#### Configuration Changes
+#### Configuration Flags (GUC)
 
 Since collecting statistics introduces overhead, each category of statistical data should be gated behind a configuration flag.
 
@@ -355,8 +351,6 @@ RETURNS TABLE (
     stats_reset    timestamptz
 )
 LANGUAGE c
-SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp
 AS 'MODULE_PATHNAME', 'documentdb_stat_get_io';
 
 -- Helper is NOT granted to PUBLIC.

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -1,6 +1,6 @@
 ---
 rfc: 0007
-title: "Guidance for Onboarding Statistical Views"
+title: "Guidance for Onboarding Statistics"
 status: Draft
 owner: "@WentingWu666666"
 issue: NA
@@ -10,51 +10,62 @@ implementations: NA
 
 ---
 
-# RFC-0007: Guidance for Onboarding Statistical Views
+# RFC-0007: Guidance for Onboarding Statistics
 
 ## Problem
 
-DocumentDB currently lacks a standardized, well-defined process for contributors to onboard new statistical views. 
-While contributors may want to expose various runtime, performance, or usage insights through SQL views, there is no consistent guidance for:
-- How views should be named and organized  
-- Where SQL definitions should live in the repository  
-- How columns and units should be defined  
-- How permissions should be handled  
-- How statistics collection should be enabled/disabled safely  
+DocumentDB currently lacks a standardized, well-defined process for contributors to onboard new statistics. While contributors may want to expose various runtime, performance, or usage insights, there is no consistent guidance for:
+
+- How statistics should be exposed
+- How statistics collection should be enabled or disabled safely
 
 This creates friction for both contributors and reviewers:
+
 - Contributors must guess conventions or invent their own patterns.
 - Reviewers lack a consistent set of rules to evaluate submissions.
-- Inconsistencies across views make them harder to discover, document, and maintain.
+- Inconsistencies across statistics make them harder to discover, document, and maintain.
 
-Without this guidance, statistical views may become fragmented, inconsistent, or unsafe (e.g., unexpected overhead, unclear reset behavior, or overly broad permissions).
+Without this guidance, statistics may become fragmented, inconsistent, or unsafe (for example: unexpected overhead, unclear reset behavior, or overly broad permissions).
 
-This RFC proposes a set of conventions and rules that define *how* statistical views should be added, not *which* specific views must exist.
+This RFC proposes a set of conventions and rules that define **how** statistics should be added, not **which** specific statistics must exist.
 
 ### Who is impacted
 
-- Contributors adding new statistical or observability-related functionality  
-- Maintainers reviewing and approving contributions  
-- Users who rely on DocumentDB system statistics for monitoring and troubleshooting  
+- Contributors adding new statistical or observability-related functionality
+- Maintainers reviewing and approving contributions
+- Users who rely on DocumentDB system statistics for monitoring and troubleshooting
 
 ### Success criteria
 
-- A clear, documented set of rules for adding new statistical views  
-- Consistent naming, schema placement, and column conventions  
-- Controlled permissions and predictable reset behavior  
-- Minimal friction for contributors to follow the pattern  
+- A clear, documented set of rules for adding new statistics
+- Consistent naming and API patterns for statistics
+- Controlled permissions and predictable reset behavior
+- Minimal friction for contributors to follow the pattern
 
 ### Non-goals
 
-- This RFC does **not** design or implement any specific statistical view.
-- This RFC does **not** replace existing PostgreSQL statistical views.
+- This RFC does **not** design or implement any specific statistics.
+- This RFC does **not** replace or modify existing PostgreSQL statistics.
 
 ---
 
 ## Approach
 
-The proposed solution is to define and document a standard onboarding pattern for statistical views in DocumentDB, 
-inspired by established conventions in PostgreSQL (e.g., `pg_stat_*` views) and widely-used extensions (e.g., Citus).
+The approach is inspired by established conventions in PostgreSQL (e.g., `pg_stat_*` views) and widely-used extensions (e.g., Citus).
+
+In DocumentDB, statistics should be exposed through **views**.
+
+- Views may be backed directly by SQL statements.
+- Views may also be backed by one or more underlying helper functions when the logic is complex or requires internal state.
+
+
+This RFC defines:
+- Naming conventions for views and functions
+- Standard patterns for permissions
+- Configuration switches to enable/disable collection
+- Documentation requirements for each statistic
+
+The goal is to provide a predictable and maintainable pattern that aligns with familiar PostgreSQL design.
 
 ---
 
@@ -62,30 +73,68 @@ inspired by established conventions in PostgreSQL (e.g., `pg_stat_*` views) and 
 
 ### API Changes
 
-#### 1. Naming Convention
-**View name**: documentdb_stat_<scope>
-Examples:
-- `documentdb_stat_collections`
-- `documentdb_stat_queries`
-- `documentdb_stat_connections`
+### Views
+Statistcs will be exposed through views.
 
-**Column naming**
-- Columns representing a value must end with a unit suffix:
+**View naming pattern**
+```
+documentdb_stat_<scope>
+```
+
+**Column naming in views**
+- Columns representing a **value** must end with a unit suffix:
   - `_count`
   - `_seconds`
   - `_milliseconds`
   - `_bytes`
   - `_percent`
 
-- Columns representing dimensions (e.g., name, database, collection, user) should **not** use a suffix.
+- Columns representing **dimensions** (e.g., name, database, collection, user) should **not** use a suffix.
 
-TBD
+By default, all statistical views are readable by all users:
+```
+GRANT SELECT ON documentdb_stat_<scope> TO PUBLIC;
+```
+
+All statistical views must be defined in the following location:
+```
+pg_documentdb/sql/stats/stats--<version>.sql
+```
+
+### Helper Functions
+If a view is backed by one or more helper functions, those functions must follow this naming pattern:
+```
+documentdb_stat_get_<scope>
+```
+
+By default, helper functions must be executable by all users:
+```
+GRANT EXECUTE ON FUNCTION documentdb_stat_get_<xxxx>() TO PUBLIC;
+```
+
+#### Reset functions (for cumulative counters)
+
+If a view contains cumulative counters that may need to be reset, a reset function must be provided.
+
+**Naming pattern**
+```
+documentdb_stat_reset_<xxxx>
+```
+By default, this function is restricted to superusers:
+```
+REVOKE EXECUTE ON FUNCTION documentdb_stat_reset_<xxxx>() FROM public;
+```
+Other roles may be explicitly granted permission as needed.
+
 
 ### Configuration Changes
 
 Since collecting statistics introduces overhead, each category of statistical data should be gated behind a configuration flag.
 
-Pattern: documentdb_track_<scope>
+**Naming pattern**
+```
+documentdb_track_<scope>
+```
 
 Examples:
 
@@ -93,7 +142,7 @@ Examples:
 - `documentdb_track_connections`
 - `documentdb_track_collections`
 
-Default value: true
+Default value: `true`
 
 These parameters should be configurable via `postgresql.conf` and/or runtime configuration where supported.
 
@@ -104,21 +153,26 @@ When the flag is set to `false`:
 
 ### Documentation Updates
 
-Update the following documentation to include:
+The following documentation must be updated when new statistics are added:
 
-- List of statistical views
-- Column descriptions and units
-- Reset functions (if any)
-- Related configuration parameters
-
-Target location:
+**Repository**
+```
 https://github.com/documentdb/documentdb.github.io
-/articles/postgresql/stats.md
+```
 
-Each new statistical view must include:
-- Description of purpose
+**File path**
+```
+/articles/postgresql/stats.md
+```
+
+Each new statistic must include:
+
+- Description of the statistic and its purpose
+- Column definitions and units
 - Example query
-- Sample output
+- Example output
+- Related configuration parameters
+- Reset functions (if applicable)
 
 ---
 

--- a/rfcs/0007-stats.md
+++ b/rfcs/0007-stats.md
@@ -54,6 +54,44 @@ This RFC establishes that baseline for DocumentDB. It defines **how** statistics
 - This RFC does **not** replace or modify existing PostgreSQL statistics.
 - This RFC does **not** address using statistics for query planning or optimization. The focus is solely on exposability and monitoring.
 - This RFC does **not** cover statistics exposed through the MongoDB wire protocol (e.g., `collStats`, `dbStats`). Those follow MongoDB API compatibility conventions. This RFC covers only **extension-defined statistics** consumed via SQL by operators and monitoring tools.
+- This RFC covers statistics **instrumentation** (how a contributor defines and exposes a stat as a SQL-queryable view). It does **not** cover metric **collection or emission** — scraping these views and shipping them to an external observability backend (e.g., OpenTelemetry exporters, a metrics sidecar, pre-aggregation, and emission-delay tuning). That is deferred to future work; a stats view is a **pull-based** surface that such a system reads on its own schedule.
+
+---
+
+## When to Build a Stats View
+
+Before following the conventions in this RFC, decide *whether* a stats view is the
+right tool at all. Walk these gates in order; the first "stop" answer wins — don't
+build a view.
+
+**Gate 1 — Is it already exposed?**
+Is the data already available from an existing DocumentDB command, or from a
+standard PostgreSQL facility you can simply surface (a built-in `pg_stat_*` view
+or a common extension such as `pg_stat_statements`)?
+→ **Yes:** point users at that. Do **not** re-implement it.
+
+**Gate 2 — What shape and lifetime is the data?**
+
+| The data is… | Right tool |
+|---|---|
+| **Per-event** detail (each slow query, each error, each auth failure) | Logs |
+| **Historical trends** — how a value changed across the last hour/day/week | External metrics pipeline (poll a view, store in a TSDB) |
+| A **value read on demand** — a current reading or a running total | **Stats view — continue** |
+
+**Gate 3 — Does it earn its keep?**
+Continue only if **both** hold:
+
+- **Operator value**, especially for the managed service — a DBA, SRE, or control
+  plane takes a concrete action from it. Not merely "nice to see."
+- **Bounded** — reduces to a small, fixed set of rows (bounded by `MaxBackends`, a
+  fixed dimension set, or a top-N cap). Does **not** grow with document count,
+  query count, or time.
+
+→ If either is **no**, stop and pick an alternative from Gate 2.
+
+Passed all gates? Build the view following the conventions below. Whether its
+columns are cumulative counters or point-in-time gauges determines the reset
+behavior — see [Reset Functions](#reset-functions).
 
 ---
 
@@ -187,7 +225,20 @@ AS 'MODULE_PATHNAME', $$documentdb_stat_get_<scope>$$;
 
 #### Reset Functions
 
-If a view contains cumulative counters that may need to be reset, a reset function must be provided.
+A view's **value columns** (the ones carrying a measured value, not dimension or
+metadata columns) fall into two kinds, which determine the reset obligation:
+
+- **Counter** — a value that **accumulates as events occur** (e.g., total queries,
+  cumulative latency). Counter columns require a reset function and a `stats_reset`
+  timestamp column.
+- **Gauge** — a **current-state** value read on demand (e.g., active connections,
+  live sizes). Gauge columns require **no** reset function and **no** `stats_reset`
+  column.
+
+A view may mix counter and gauge value columns; the reset obligation applies
+per-column. How the underlying value is stored and collected (shared memory,
+atomics, a GUC kill-switch, etc.) is an implementation choice — see
+[Performance Considerations](#performance-considerations) for guidance.
 
 **Naming pattern**
 ```


### PR DESCRIPTION
## Summary

This PR establishes standardized conventions for contributors to add new statistics to DocumentDB.

## Motivation

DocumentDB currently lacks consistent guidance for exposing runtime, performance, and usage statistics. This leads to fragmented implementations, inconsistent APIs, and friction for both contributors and reviewers.

## What's Included

- **Naming conventions**: Standardized patterns for views (`documentdb_stat_<scope>`), helper functions, and reset functions
- **Column conventions**: Required unit suffixes (`_count`, `_seconds`, `_bytes`, etc.) for value columns, suffix-free dimension columns
- **Permission model**: Public SELECT for views, restricted EXECUTE for reset functions
- **Configuration flags**: `documentdb_track_<scope>` to enable/disable collection with minimal overhead
- **Documentation requirements**: Mandatory updates to stats.md for each new statistic

## Non-Goals

- Does not implement specific statistics
- Does not modify PostgreSQL's existing statistics system
- Does not address query planner optimizations