### PR TITLE
Add Alpine Linux support for package building and testing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ build/
 # packages
 *.deb
 *.rpm
+*.tar.gz
 
 site/
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -55,6 +55,19 @@ This script checks:
 ./packaging/build_packages.sh --os rhel8 --pg 17 --test-clean-install
 ```
 
+## Building Alpine Linux Archive
+
+For Alpine Linux, the script compiles the extension and produces a `.tar.gz` archive containing the installed files.
+
+```sh
+./packaging/build_packages.sh --os alpine --pg 16
+```
+
+Supported Alpine distributions:
+- alpine (Uses `postgres:<version>-alpine` base image)
+
+Supported PG versions: 15, 16, 17
+
 ## Output
 
 Packages can be found at the `packages` directory by default, but it can be configured with the `--output-dir` option.

--- a/packaging/apk/Dockerfile-alpine
+++ b/packaging/apk/Dockerfile-alpine
@@ -1,0 +1,75 @@
+ARG BASE_IMAGE=alpine:3.21
+FROM ${BASE_IMAGE}
+
+ARG POSTGRES_VERSION=16
+ARG DOCUMENTDB_VERSION
+
+ENV POSTGRES_VERSION=${POSTGRES_VERSION}
+ENV DOCUMENTDB_VERSION=${DOCUMENTDB_VERSION}
+ENV USE_PGXS=1
+
+# Install PostgreSQL and build dependencies using Alpine's native packages
+# This ensures all paths are consistent with Alpine's package layout
+RUN apk add --no-cache \
+    build-base \
+    bash \
+    cmake \
+    git \
+    pkgconf \
+    postgresql${POSTGRES_VERSION} \
+    postgresql${POSTGRES_VERSION}-dev \
+    postgresql${POSTGRES_VERSION}-contrib \
+    libbson-dev \
+    libbson-static \
+    pcre2-dev \
+    curl \
+    linux-headers \
+    openssl-dev \
+    krb5-dev \
+    flex \
+    bison \
+    libxml2-dev
+
+# Set PG_CONFIG to point to the correct pg_config for this PG version
+ENV PG_CONFIG=/usr/bin/pg_config
+
+# Fix for bson.h issue
+# Check if bson.h is in /usr/include/libbson-1.0
+RUN if [ ! -f /usr/include/libbson-1.0/bson.h ] && [ -f /usr/include/libbson-1.0/bson/bson.h ]; then \
+        echo "Linking bson.h to /usr/include/libbson-1.0/bson.h"; \
+        ln -s /usr/include/libbson-1.0/bson/bson.h /usr/include/libbson-1.0/bson.h; \
+    fi
+
+WORKDIR /documentdb
+
+# Copy project files
+COPY . .
+
+# Setup environment for dependency installation
+ENV INSTALL_DEPENDENCIES_ROOT=/documentdb/build_deps
+RUN mkdir -p $INSTALL_DEPENDENCIES_ROOT
+ENV INSTALLDESTDIR=/usr
+ENV PKG_CONFIG_INSTALL_PATH=/usr/lib/pkgconfig
+# Ensure pkgconfig path exists
+RUN mkdir -p $PKG_CONFIG_INSTALL_PATH
+
+# Install Intel Decimal Math Library
+# This script builds it from source and installs it
+RUN bash scripts/install_setup_intel_decimal_math_lib.sh
+
+# Also ensure libbson is correctly detected
+# If pkg-config path is not standard, we might need to add it to PKG_CONFIG_PATH
+# Alpine usually uses /usr/lib/pkgconfig or /usr/share/pkgconfig
+
+# Build and Install DocumentDB
+# Using USE_PGXS=1 to compile against installed postgres
+# disabling llvm bitcode generation to avoid clang dependency issues
+RUN make clean && make -j$(nproc) install with_llvm=no
+
+# Create tarball of the installation
+RUN mkdir -p /src/build_output
+RUN make DESTDIR=/src/build_output install with_llvm=no
+RUN cd /src/build_output && tar -czvf /documentdb-${DOCUMENTDB_VERSION}-alpine-pg${POSTGRES_VERSION}.tar.gz .
+
+CMD cp /documentdb-*.tar.gz /output/
+

--- a/packaging/build_packages.sh
+++ b/packaging/build_packages.sh
@@ -13,7 +13,7 @@ function show_help {
     echo "  This script builds extension packages (DEB/RPM) using Docker."
     echo ""
     echo "Mandatory Arguments:"
-    echo "  --os                 OS to build packages for. Possible values: [deb11, deb12, ubuntu22.04, ubuntu24.04, rhel8, rhel9]"
+    echo "  --os                 OS to build packages for. Possible values: [deb11, deb12, ubuntu22.04, ubuntu24.04, rhel8, rhel9, alpine]"
     echo "  --pg                 PG version to build packages for. Possible values: [15, 16, 17, 18]"
     echo ""
     echo "Optional Arguments:"
@@ -46,8 +46,12 @@ while [[ $# -gt 0 ]]; do
                     OS=$1
                     PACKAGE_TYPE="rpm"
                     ;;
+                alpine*)
+                    OS=$1
+                    PACKAGE_TYPE="apk"
+                    ;;
                 *)
-                    echo "Invalid --os value. Allowed values are [deb11, deb12, ubuntu22.04, ubuntu24.04, rhel8, rhel9]"
+                    echo "Invalid --os value. Allowed values are [deb11, deb12, ubuntu22.04, ubuntu24.04, rhel8, rhel9, alpine]"
                     exit 1
                     ;;
             esac
@@ -150,6 +154,9 @@ elif [[ "$PACKAGE_TYPE" == "rpm" ]]; then
             exit 1
             ;;
     esac
+elif [[ "$PACKAGE_TYPE" == "apk" ]]; then
+    DOCKERFILE="${script_dir}/packaging/apk/Dockerfile-alpine"
+    DOCKER_IMAGE="alpine:3.21"
 fi
 
 TAG=documentdb-build-packages-$OS-pg$PG:latest
@@ -176,6 +183,14 @@ elif [[ "$PACKAGE_TYPE" == "rpm" ]]; then
         --build-arg POSTGRES_VERSION="$PG" \
         --build-arg DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" "$script_dir"
     # Run the Docker container to build the packages
+    docker run --rm --env OS="$OS" --env POSTGRES_VERSION="$PG" --env DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" -v "$abs_output_dir:/output" "$TAG"
+elif [[ "$PACKAGE_TYPE" == "apk" ]]; then
+    # Alpine build uses postgres:alpine based image
+    docker build -t "$TAG" -f "$DOCKERFILE" \
+        --build-arg BASE_IMAGE="$DOCKER_IMAGE" \
+        --build-arg POSTGRES_VERSION="$PG" \
+        --build-arg DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" "$script_dir"
+    # Run the Docker container to extract the tarball
     docker run --rm --env OS="$OS" --env POSTGRES_VERSION="$PG" --env DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" -v "$abs_output_dir:/output" "$TAG"
 fi
 
@@ -224,6 +239,28 @@ if [[ $TEST_CLEAN_INSTALL == true ]]; then
             
         # Run the Docker container to test the packages
         docker run --rm --env POSTGRES_VERSION="$PG" documentdb-test-rpm-packages:latest
+
+    elif [[ "$PACKAGE_TYPE" == "apk" ]]; then
+        tarball_name=$(ls "$abs_output_dir" | grep -E "documentdb-${DOCUMENTDB_VERSION}-alpine-pg${PG}.tar.gz" | head -n 1)
+        
+        if [[ -z "$tarball_name" ]]; then
+            echo "Error: Could not find the built Alpine tarball in $abs_output_dir for testing."
+            exit 1
+        fi
+        package_rel_path="$OUTPUT_DIR/$tarball_name"
+
+        echo "Alpine package path passed into Docker build: $package_rel_path"
+
+        # Build the Docker image while showing the output to the console
+        docker build -t documentdb-test-alpine-packages:latest -f "${script_dir}/packaging/test_packages/alpine/Dockerfile-alpine-test" \
+            --build-arg BASE_IMAGE="alpine:3.21" \
+            --build-arg POSTGRES_VERSION="$PG" \
+            --build-arg TARBALL_PATH="$package_rel_path" "$script_dir"
+
+        # Run the Docker container to test the packages
+        docker run --rm --env POSTGRES_VERSION="$PG" documentdb-test-alpine-packages:latest
+            
+        echo "Alpine clean installation test successful!!"
     fi
 
     echo "Clean installation test successful!!"

--- a/packaging/test_packages/alpine/Dockerfile-alpine-test
+++ b/packaging/test_packages/alpine/Dockerfile-alpine-test
@@ -1,0 +1,65 @@
+ARG BASE_IMAGE=alpine:3.21
+FROM ${BASE_IMAGE}
+
+ARG TARBALL_PATH
+ARG POSTGRES_VERSION=16
+
+ENV POSTGRES_VERSION=${POSTGRES_VERSION}
+
+# Install PostgreSQL and build/test dependencies using Alpine's native packages
+# This ensures all paths are consistent with Alpine's package layout
+RUN apk add --no-cache \
+    build-base \
+    bash \
+    cmake \
+    git \
+    pkgconf \
+    postgresql${POSTGRES_VERSION} \
+    postgresql${POSTGRES_VERSION}-dev \
+    postgresql${POSTGRES_VERSION}-contrib \
+    libbson-dev \
+    libbson-static \
+    pcre2-dev \
+    pcre2 \
+    curl \
+    linux-headers \
+    openssl-dev \
+    krb5-dev \
+    krb5-libs \
+    flex \
+    bison \
+    libxml2-dev \
+    libxml2 \
+    icu-libs \
+    python3 \
+    sudo \
+    postgresql-pgvector \
+    postgresql-pg_cron \
+    postgis
+
+# Set PG_CONFIG to point to the correct pg_config
+ENV PG_CONFIG=/usr/bin/pg_config
+
+# Copy and extract the documentdb extension files
+COPY ${TARBALL_PATH} /tmp/documentdb.tar.gz
+RUN tar -xzvf /tmp/documentdb.tar.gz -C /
+
+# Copy source tree for running make check
+WORKDIR /usr/src/documentdb
+COPY . /usr/src/documentdb
+
+# Setup environment for dependency installation (needed for make check to find deps)
+ENV INSTALL_DEPENDENCIES_ROOT=/usr/src/documentdb/build_deps
+RUN mkdir -p $INSTALL_DEPENDENCIES_ROOT
+ENV INSTALLDESTDIR=/usr
+ENV PKG_CONFIG_INSTALL_PATH=/usr/lib/pkgconfig
+RUN mkdir -p $PKG_CONFIG_INSTALL_PATH
+
+# Install Intel Decimal Math Library (needed for make check)
+RUN bash scripts/install_setup_intel_decimal_math_lib.sh
+
+# Copy test entrypoint script
+COPY packaging/test_packages/alpine/test-install-entrypoint-alpine.sh /usr/local/bin/test-install-entrypoint-alpine.sh
+RUN chmod +x /usr/local/bin/test-install-entrypoint-alpine.sh
+
+ENTRYPOINT ["test-install-entrypoint-alpine.sh"]

--- a/packaging/test_packages/alpine/Dockerfile-alpine-test
+++ b/packaging/test_packages/alpine/Dockerfile-alpine-test
@@ -58,6 +58,12 @@ RUN mkdir -p $PKG_CONFIG_INSTALL_PATH
 # Install Intel Decimal Math Library (needed for make check)
 RUN bash scripts/install_setup_intel_decimal_math_lib.sh
 
+# Install RUM extension from source (needed for make check)
+# RUM is not available as a pre-built Alpine package, so we build it from source
+RUN if [ "${POSTGRES_VERSION}" -lt 18 ]; then \
+        bash scripts/install_setup_rum_oss.sh; \
+    fi
+
 # Copy test entrypoint script
 COPY packaging/test_packages/alpine/test-install-entrypoint-alpine.sh /usr/local/bin/test-install-entrypoint-alpine.sh
 RUN chmod +x /usr/local/bin/test-install-entrypoint-alpine.sh

--- a/packaging/test_packages/alpine/test-install-entrypoint-alpine.sh
+++ b/packaging/test_packages/alpine/test-install-entrypoint-alpine.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+echo "Testing Alpine package installation..."
+
+cd /usr/src/documentdb
+
+# Set up environment for make check
+export PG_CONFIG=/usr/bin/pg_config
+export PATH=/usr/bin:$PATH
+
+# Test environment setup first
+echo "=== Testing environment for make check ==="
+
+# Test pg_config
+if [ -x "$PG_CONFIG" ]; then
+    echo "✓ pg_config found: $($PG_CONFIG --version)"
+else
+    echo "✗ pg_config not found at $PG_CONFIG"
+    find /usr -name "pg_config" 2>/dev/null | head -3
+    exit 1
+fi
+
+# Test libbson pkg-config
+if pkg-config --exists libbson-static-1.0; then
+    echo "✓ libbson-static-1.0 pkg-config available"
+else
+    echo "✗ libbson-static-1.0 pkg-config not found"
+    echo "Available pkg-config packages with 'bson':"
+    pkg-config --list-all | grep -i bson || echo "None found"
+    exit 1
+fi
+
+# Test pg_regress
+PGXS=$($PG_CONFIG --pgxs)
+PG_REGRESS_PATH="$(dirname "$PGXS")/../test/regress/pg_regress"
+if [ -x "$PG_REGRESS_PATH" ]; then
+    echo "✓ pg_regress found at $PG_REGRESS_PATH"
+else
+    echo "✗ pg_regress not found at expected path: $PG_REGRESS_PATH"
+    echo "Searching for pg_regress..."
+    find /usr -name "pg_regress" 2>/dev/null | head -3
+    exit 1
+fi
+
+echo "=== Environment tests passed! ==="
+
+# Create a user for running tests (Alpine uses adduser differently)
+adduser -D -s /bin/bash documentdb || true
+chown -R documentdb:documentdb .
+
+# Switch to the documentdb user and run the tests
+echo "Running make check as documentdb user..."
+if ! su documentdb -c "export PG_CONFIG=/usr/bin/pg_config && export PATH=/usr/bin:\$PATH && make check"; then
+    echo "make check failed. Displaying postmaster.log if it exists:"
+    LOG_FILE="/usr/src/documentdb/pg_documentdb/src/test/regress/log/postmaster.log"
+    if [ -f "$LOG_FILE" ]; then
+        echo "=== Contents of $LOG_FILE ==="
+        cat "$LOG_FILE"
+        echo "==============================="
+    else
+        echo "Log file $LOG_FILE not found."
+    fi
+    exit 1
+fi
+
+echo "Alpine package installation test completed successfully!"


### PR DESCRIPTION
This pull request adds support for building and testing the DocumentDB extension as a tarball archive for Alpine Linux, alongside existing DEB and RPM packaging. It introduces new Dockerfiles and scripts to build and test the Alpine package, and updates the documentation and build scripts to reflect these changes.

resolves #414 

**Alpine Linux packaging support:**

* Added a new Dockerfile (`packaging/apk/Dockerfile-alpine`) to build the extension for Alpine Linux, producing a `.tar.gz` archive compatible with Alpine's PostgreSQL package layout.
* Updated the main build script (`packaging/build_packages.sh`) to recognize `alpine` as a valid OS, select the appropriate Dockerfile, and handle the build and test flow for Alpine tarballs.
* Extended the documentation (`packaging/README.md`) with instructions for building Alpine packages and listing supported PostgreSQL versions.

**Alpine Linux testing support:**

* Added a new Dockerfile (`packaging/test_packages/alpine/Dockerfile-alpine-test`) to test the Alpine tarball by installing it in a fresh Alpine container, installing dependencies, and running `make check`.
* Added a test entrypoint script (`packaging/test_packages/alpine/test-install-entrypoint-alpine.sh`) that verifies environment setup, required binaries, and runs the test suite as a non-root user.