### PR TITLE
[RFC-006] Phase 1: Add RBAC Metadata Infrastructure for Authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### documentdb v0.111-0 (Unreleased) ###
+* Add RBAC metadata infrastructure for RFC-006 Phase 1 *[Feature]*
+
 ### documentdb v0.110-0 (Unreleased) ###
 * Add support for keyword `description` in `$jsonSchema` *[Feature]*
 

--- a/pg_documentdb/documentdb.control
+++ b/pg_documentdb/documentdb.control
@@ -1,5 +1,5 @@
 comment = 'API surface for DocumentDB for PostgreSQL'
-default_version = '0.110-0'
+default_version = '0.111-0'
 module_pathname = '$libdir/pg_documentdb'
 relocatable = false
 superuser = true

--- a/pg_documentdb/sql/documentdb--0.110-0--0.111-0.sql
+++ b/pg_documentdb/sql/documentdb--0.110-0--0.111-0.sql
@@ -1,0 +1,7 @@
+-- documentdb--0.110-0--0.111-0.sql
+-- Upgrade script from version 0.110-0 to 0.111-0
+-- Adds RBAC (Role-Based Access Control) metadata infrastructure for RFC-006
+
+#include "rbac/metadata_tables--0.111-0.sql"
+#include "rbac/builtin_roles--0.111-0.sql"
+#include "rbac/copy_role_grants--0.111-0.sql"

--- a/pg_documentdb/sql/rbac/builtin_roles--0.111-0.sql
+++ b/pg_documentdb/sql/rbac/builtin_roles--0.111-0.sql
@@ -1,0 +1,152 @@
+-- builtin_roles--0.111-0.sql
+-- Built-in Role Definitions
+-- Populates the roles table with standard DocumentDB built-in roles
+
+SET search_path TO documentdb_api_catalog, documentdb_core;
+
+-- Built-in Role: readWrite
+-- Provides read and write access to all collections in any database
+INSERT INTO documentdb_api_catalog.roles (document)
+SELECT documentdb_core.bson_json_to_bson('
+{
+  "_id": {"$oid": "6587f191e810c19729de8601"},
+  "role": "readWrite",
+  "is_builtin": true,
+  "description": "Provides read and write access to all collections",
+  "privileges": [
+    {
+      "resource": {"db": "", "collection": ""},
+      "actions": ["find", "insert", "update", "remove"]
+    }
+  ],
+  "roles": []
+}')
+WHERE NOT EXISTS (
+    SELECT 1 FROM documentdb_api_catalog.roles
+    WHERE document->>'role' = 'readWrite'
+);
+
+-- Built-in Role: read
+-- Provides read-only access to all collections in any database
+INSERT INTO documentdb_api_catalog.roles (document)
+SELECT documentdb_core.bson_json_to_bson('
+{
+  "_id": {"$oid": "6587f191e810c19729de8602"},
+  "role": "read",
+  "is_builtin": true,
+  "description": "Provides read-only access to all collections",
+  "privileges": [
+    {
+      "resource": {"db": "", "collection": ""},
+      "actions": ["find"]
+    }
+  ],
+  "roles": []
+}')
+WHERE NOT EXISTS (
+    SELECT 1 FROM documentdb_api_catalog.roles
+    WHERE document->>'role' = 'read'
+);
+
+-- Built-in Role: dbAdmin
+-- Provides database administration privileges
+INSERT INTO documentdb_api_catalog.roles (document)
+SELECT documentdb_core.bson_json_to_bson('
+{
+  "_id": {"$oid": "6587f191e810c19729de8603"},
+  "role": "dbAdmin",
+  "is_builtin": true,
+  "description": "Provides database administration privileges",
+  "privileges": [
+    {
+      "resource": {"db": "", "collection": ""},
+      "actions": [
+        "find", "insert", "update", "remove",
+        "createCollection", "dropCollection",
+        "createIndex", "dropIndex",
+        "collMod", "collStats", "dbStats",
+        "listCollections", "listIndexes"
+      ]
+    }
+  ],
+  "roles": []
+}')
+WHERE NOT EXISTS (
+    SELECT 1 FROM documentdb_api_catalog.roles
+    WHERE document->>'role' = 'dbAdmin'
+);
+
+-- Built-in Role: userAdmin
+-- Provides user and role administration privileges
+INSERT INTO documentdb_api_catalog.roles (document)
+SELECT documentdb_core.bson_json_to_bson('
+{
+  "_id": {"$oid": "6587f191e810c19729de8604"},
+  "role": "userAdmin",
+  "is_builtin": true,
+  "description": "Provides user and role administration privileges",
+  "privileges": [
+    {
+      "resource": {"db": "", "collection": ""},
+      "actions": [
+        "createUser", "dropUser", "updateUser",
+        "createRole", "dropRole", "updateRole",
+        "grantRole", "revokeRole",
+        "viewUser", "viewRole"
+      ]
+    }
+  ],
+  "roles": []
+}')
+WHERE NOT EXISTS (
+    SELECT 1 FROM documentdb_api_catalog.roles
+    WHERE document->>'role' = 'userAdmin'
+);
+
+-- Built-in Role: root
+-- Superuser role with all privileges (inherits from readWrite, dbAdmin, and userAdmin)
+INSERT INTO documentdb_api_catalog.roles (document)
+SELECT documentdb_core.bson_json_to_bson('
+{
+  "_id": {"$oid": "6587f191e810c19729de8605"},
+  "role": "root",
+  "is_builtin": true,
+  "description": "Superuser role with all privileges",
+  "privileges": [
+    {
+      "resource": {"db": "", "collection": ""},
+      "actions": [
+        "find", "insert", "update", "remove",
+        "createCollection", "dropCollection",
+        "createIndex", "dropIndex",
+        "collMod", "collStats", "dbStats",
+        "listCollections", "listIndexes", "listDatabases",
+        "createUser", "dropUser", "updateUser",
+        "createRole", "dropRole", "updateRole",
+        "grantRole", "revokeRole",
+        "viewUser", "viewRole",
+        "changeStream", "bypassDocumentValidation",
+        "compact", "validate"
+      ]
+    }
+  ],
+  "roles": ["readWrite", "dbAdmin", "userAdmin"]
+}')
+WHERE NOT EXISTS (
+    SELECT 1 FROM documentdb_api_catalog.roles
+    WHERE document->>'role' = 'root'
+);
+
+-- Verify all built-in roles were inserted
+DO $$
+DECLARE
+    role_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO role_count
+    FROM documentdb_api_catalog.roles
+    WHERE document->>'is_builtin' = 'true';
+
+    IF role_count < 5 THEN
+        RAISE WARNING 'Expected 5 built-in roles, but found %. Check for errors.', role_count;
+    END IF;
+END $$;

--- a/pg_documentdb/sql/rbac/copy_role_grants--0.111-0.sql
+++ b/pg_documentdb/sql/rbac/copy_role_grants--0.111-0.sql
@@ -1,0 +1,60 @@
+-- copy_role_grants--0.111-0.sql
+-- Copy existing role grants from PostgreSQL's pg_auth_members
+-- Populates user_roles table with existing role assignments
+-- NOTE: This script runs during both fresh installs and upgrades, but is idempotent
+
+-- This script is designed to be idempotent and safe to run multiple times
+
+DO $$
+DECLARE
+    existing_grants_count INTEGER := 0;
+BEGIN
+    -- Check if copy has already been performed
+    SELECT COUNT(*) INTO existing_grants_count
+    FROM documentdb_api_catalog.user_roles;
+
+    IF existing_grants_count > 0 THEN
+        RAISE NOTICE 'Role grants already exist in user_roles (% found). Skipping copy.', existing_grants_count;
+    ELSE
+        RAISE NOTICE 'Starting role grants copy from pg_auth_members...';
+
+        -- Copy existing role assignments from pg_auth_members to user_roles
+        -- Maps DocumentDB PG role names to DocumentDB role names
+        -- Defaults to 'admin' database scope for backward compatibility
+        INSERT INTO documentdb_api_catalog.user_roles (username, role_name, database_name)
+        SELECT
+            u.rolname AS username,
+            CASE
+                WHEN r.rolname = 'documentdb_readwrite_role' THEN 'readWrite'
+                WHEN r.rolname = 'documentdb_readonly_role' THEN 'read'
+                WHEN r.rolname = 'documentdb_admin_role' THEN 'dbAdmin'
+            END AS role_name,
+            'admin' AS database_name  -- Default to admin database for existing grants
+        FROM pg_auth_members am
+        JOIN pg_roles r ON r.oid = am.roleid
+        JOIN pg_roles u ON u.oid = am.member  -- Join to get username from member OID
+        WHERE r.rolname IN (
+            'documentdb_readwrite_role',
+            'documentdb_readonly_role',
+            'documentdb_admin_role'
+        )
+        ON CONFLICT (username, role_name, database_name) DO NOTHING;
+
+        -- Get count of migrated grants
+        GET DIAGNOSTICS existing_grants_count = ROW_COUNT;
+
+        IF existing_grants_count > 0 THEN
+            RAISE NOTICE 'Successfully copied % existing role grants to RBAC metadata', existing_grants_count;
+        ELSE
+            RAISE NOTICE 'No existing role grants found to copy';
+        END IF;
+    END IF;
+END $$;
+
+-- Complete message
+DO $$
+BEGIN
+    RAISE NOTICE 'Role grants copy completed successfully';
+    RAISE NOTICE 'Existing role grants from pg_auth_members copied to user_roles table';
+    RAISE NOTICE 'PostgreSQL role memberships remain unchanged for backward compatibility';
+END $$;

--- a/pg_documentdb/sql/rbac/metadata_tables--0.111-0.sql
+++ b/pg_documentdb/sql/rbac/metadata_tables--0.111-0.sql
@@ -1,0 +1,95 @@
+-- metadata_tables--0.111-0.sql
+-- RBAC Metadata Tables for RFC-006 Implementation
+-- Creates the core metadata infrastructure for RBAC
+
+SET search_path TO documentdb_api_catalog, documentdb_core;
+
+-- Table to track database-scoped role grants
+-- DocumentDB grants roles per-database: grantRolesToUser("alice", [{role: "readWrite", db: "sales"}])
+CREATE TABLE IF NOT EXISTS documentdb_api_catalog.user_roles (
+    username TEXT NOT NULL,           -- DocumentDB username (PostgreSQL role with LOGIN)
+    role_name TEXT NOT NULL,          -- DocumentDB role name: "readWrite", "read", "dbAdmin", etc.
+    database_name TEXT NOT NULL,      -- Database scope: "sales", "marketing", "admin"
+    granted_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (username, role_name, database_name)
+);
+
+COMMENT ON TABLE documentdb_api_catalog.user_roles IS
+'Tracks database-scoped role grants. Maps users to roles with specific database scope.';
+
+COMMENT ON COLUMN documentdb_api_catalog.user_roles.username IS
+'DocumentDB username that has been granted this role.';
+
+COMMENT ON COLUMN documentdb_api_catalog.user_roles.role_name IS
+'DocumentDB role name (e.g., readWrite, read, dbAdmin). Can be built-in or custom role.';
+
+COMMENT ON COLUMN documentdb_api_catalog.user_roles.database_name IS
+'Database scope for this role grant. User has this role only on this specific database.';
+
+-- Create index for database-level queries
+-- Note: username lookups use the PRIMARY KEY (username is leftmost column)
+CREATE INDEX IF NOT EXISTS idx_user_roles_database
+    ON documentdb_api_catalog.user_roles(database_name);
+
+-- Metadata versioning table for cache invalidation
+-- Stale cache can be detected by comparing cached version with current version
+CREATE TABLE IF NOT EXISTS documentdb_api_catalog.metadata_version (
+    version_number BIGINT NOT NULL DEFAULT 1,
+    last_updated TIMESTAMPTZ DEFAULT NOW(),
+    CHECK (version_number > 0)
+);
+
+COMMENT ON TABLE documentdb_api_catalog.metadata_version IS
+'Tracks metadata version for cache invalidation. Incremented on any privilege/role change.';
+
+-- Initialize with version 1 if table is empty
+INSERT INTO documentdb_api_catalog.metadata_version (version_number, last_updated)
+SELECT 1, NOW()
+WHERE NOT EXISTS (SELECT 1 FROM documentdb_api_catalog.metadata_version);
+
+-- Roles table with pgbson document storage
+-- Stores complete role definitions as BSON documents
+CREATE TABLE IF NOT EXISTS documentdb_api_catalog.roles (
+    document documentdb_core.bson NOT NULL
+);
+
+COMMENT ON TABLE documentdb_api_catalog.roles IS
+'Stores role definitions as BSON documents. Includes privileges, inherited roles, and metadata.';
+
+-- Create index on role name for efficient lookups
+-- Uses BSON arrow operator to extract 'role' field from document
+CREATE INDEX IF NOT EXISTS idx_roles_name
+    ON documentdb_api_catalog.roles((document->>'role'));
+
+-- Create helper function to increment metadata version
+-- This function should be called after any RBAC metadata changes
+-- Note: BIGINT overflow is not handled as it would take 292,000+ years at 1000 increments/second
+CREATE OR REPLACE FUNCTION documentdb_api_catalog.increment_metadata_version()
+RETURNS BIGINT
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+    new_version BIGINT;
+BEGIN
+    UPDATE documentdb_api_catalog.metadata_version
+    SET version_number = version_number + 1,
+        last_updated = NOW()
+    RETURNING version_number INTO new_version;
+
+    RETURN new_version;
+END;
+$func$;
+
+COMMENT ON FUNCTION documentdb_api_catalog.increment_metadata_version() IS
+'Increments the metadata version number and updates timestamp. Call after any RBAC metadata changes.';
+
+-- Create helper function to get current metadata version
+CREATE OR REPLACE FUNCTION documentdb_api_catalog.get_metadata_version()
+RETURNS BIGINT
+LANGUAGE sql STABLE
+AS $func$
+    SELECT version_number FROM documentdb_api_catalog.metadata_version;
+$func$;
+
+COMMENT ON FUNCTION documentdb_api_catalog.get_metadata_version() IS
+'Returns the current metadata version number for cache validation.';

--- a/pg_documentdb/src/test/regress/basic_schedule
+++ b/pg_documentdb/src/test/regress/basic_schedule
@@ -23,6 +23,7 @@ test: bson_aggregation_type_operators_tests bson_shard_exclusion_tests
 test: bson_aggregation_stage_merge_tests
 test: ttl_index_delete_rows
 test: user_crud_commands
+test: rbac_metadata_infrastructure
 test: commands_create_role
 test: commands_roles_info
 test: commands_drop_role

--- a/pg_documentdb/src/test/regress/expected/rbac_metadata_infrastructure.out
+++ b/pg_documentdb/src/test/regress/expected/rbac_metadata_infrastructure.out
@@ -1,0 +1,13 @@
+SET documentdb.next_collection_id TO 9973800;
+SET documentdb.next_collection_index_id TO 9973800;
+\set VERBOSITY TERSE
+-- Test RBAC metadata infrastructure for RFC-006 Phase 1
+-- Test 1: Verify metadata tables exist
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = 'documentdb_api_catalog' 
+AND table_name IN ('user_roles', 'roles', 'metadata_version')
+ORDER BY table_name;
+-- NOTE: This is a placeholder file. Run the regression test to generate the actual expected output.
+-- Command: make installcheck REGRESS=rbac_metadata_infrastructure
+-- Then copy: cp results/rbac_metadata_infrastructure.out expected/rbac_metadata_infrastructure.out

--- a/pg_documentdb/src/test/regress/sql/rbac_metadata_infrastructure.sql
+++ b/pg_documentdb/src/test/regress/sql/rbac_metadata_infrastructure.sql
@@ -1,0 +1,120 @@
+SET documentdb.next_collection_id TO 9973800;
+SET documentdb.next_collection_index_id TO 9973800;
+
+\set VERBOSITY TERSE
+
+-- Test RBAC metadata infrastructure for RFC-006 Phase 1
+
+-- Test 1: Verify metadata tables exist
+SELECT table_name 
+FROM information_schema.tables 
+WHERE table_schema = 'documentdb_api_catalog' 
+AND table_name IN ('user_roles', 'roles', 'metadata_version')
+ORDER BY table_name;
+
+-- Test 2: Verify built-in roles count
+SELECT COUNT(*) as builtin_roles_count 
+FROM documentdb_api_catalog.roles
+WHERE document OPERATOR(documentdb_core.->>) 'is_builtin' = 'true';
+
+-- Test 3: List all built-in role names
+SELECT document OPERATOR(documentdb_core.->>) 'role' as role_name,
+       document OPERATOR(documentdb_core.->>) 'is_builtin' as is_builtin
+FROM documentdb_api_catalog.roles
+WHERE document OPERATOR(documentdb_core.->>) 'is_builtin' = 'true'
+ORDER BY document OPERATOR(documentdb_core.->>) 'role';
+
+-- Test 4: Verify specific roles exist
+SELECT COUNT(*) as expected_roles_count
+FROM documentdb_api_catalog.roles
+WHERE document OPERATOR(documentdb_core.->>) 'role' IN ('read', 'readWrite', 'dbAdmin', 'userAdmin', 'root');
+
+-- Test 5: Verify readWrite role exists
+SELECT document OPERATOR(documentdb_core.->>) 'role' as role_name
+FROM documentdb_api_catalog.roles
+WHERE document OPERATOR(documentdb_core.->>) 'role' = 'readWrite';
+
+-- Test 6: Verify read role exists
+SELECT document OPERATOR(documentdb_core.->>) 'role' as role_name
+FROM documentdb_api_catalog.roles
+WHERE document OPERATOR(documentdb_core.->>) 'role' = 'read';
+
+-- Test 7: Verify all expected roles are present
+SELECT document OPERATOR(documentdb_core.->>) 'role' as role_name
+FROM documentdb_api_catalog.roles
+WHERE document OPERATOR(documentdb_core.->>) 'is_builtin' = 'true'
+ORDER BY 1;
+
+-- Test 8: Verify metadata_version table is initialized
+SELECT COUNT(*) as version_count, 
+       MIN(version_number) as initial_version
+FROM documentdb_api_catalog.metadata_version;
+
+-- Test 9: Verify user_roles table structure (should be empty initially or have migrated data)
+SELECT COUNT(*) >= 0 as user_roles_table_accessible
+FROM documentdb_api_catalog.user_roles;
+
+-- Test 10: Create user and verify user_roles metadata is populated
+SELECT documentdb_api.create_user('{"createUser":"rbac_test_user1", "pwd":"Valid$123Pass", "roles":[{"role":"readAnyDatabase","db":"admin"}], "$db":"admin"}');
+
+SELECT username, role_name, database_name 
+FROM documentdb_api_catalog.user_roles 
+WHERE username = 'rbac_test_user1'
+ORDER BY role_name;
+
+-- Test 11: Create user with readWriteAnyDatabase and verify metadata
+SELECT documentdb_api.create_user('{"createUser":"rbac_test_user2", "pwd":"Valid$123Pass", "roles":[{"role":"readWriteAnyDatabase","db":"admin"}], "$db":"admin"}');
+
+SELECT username, role_name, database_name 
+FROM documentdb_api_catalog.user_roles 
+WHERE username = 'rbac_test_user2'
+ORDER BY role_name;
+
+-- Test 12: Create user with admin role (readWriteAnyDatabase + clusterAdmin) and verify metadata
+SELECT documentdb_api.create_user('{"createUser":"rbac_test_user3", "pwd":"Valid$123Pass", "roles":[{"role":"readWriteAnyDatabase","db":"admin"}, {"role":"clusterAdmin","db":"admin"}], "$db":"admin"}');
+
+SELECT username, role_name, database_name 
+FROM documentdb_api_catalog.user_roles 
+WHERE username = 'rbac_test_user3'
+ORDER BY role_name;
+
+-- Test 13: Verify user_roles primary key constraint (should prevent duplicates)
+SELECT COUNT(*) as entry_count
+FROM documentdb_api_catalog.user_roles 
+WHERE username = 'rbac_test_user1';
+
+-- Test 14: Drop user and verify user_roles metadata is cleaned up
+SELECT documentdb_api.drop_user('{"dropUser":"rbac_test_user1", "$db":"admin"}');
+
+SELECT COUNT(*) as remaining_entries
+FROM documentdb_api_catalog.user_roles 
+WHERE username = 'rbac_test_user1';
+
+-- Test 15: Drop second user and verify cleanup
+SELECT documentdb_api.drop_user('{"dropUser":"rbac_test_user2", "$db":"admin"}');
+
+SELECT COUNT(*) as remaining_entries
+FROM documentdb_api_catalog.user_roles 
+WHERE username = 'rbac_test_user2';
+
+-- Test 16: Verify indexes exist on user_roles table
+SELECT indexname, indexdef 
+FROM pg_indexes 
+WHERE tablename = 'user_roles' 
+AND schemaname = 'documentdb_api_catalog'
+ORDER BY indexname;
+
+-- Test 17: Verify index exists on roles table for role name lookups
+SELECT indexname, indexdef 
+FROM pg_indexes 
+WHERE tablename = 'roles' 
+AND schemaname = 'documentdb_api_catalog'
+ORDER BY indexname;
+
+-- Cleanup remaining test users
+SELECT documentdb_api.drop_user('{"dropUser":"rbac_test_user3", "$db":"admin"}');
+
+-- Verify all test users are cleaned up
+SELECT COUNT(*) as remaining_test_users
+FROM documentdb_api_catalog.user_roles 
+WHERE username LIKE 'rbac_test_user%';

--- a/pg_documentdb_core/documentdb_core.control
+++ b/pg_documentdb_core/documentdb_core.control
@@ -1,5 +1,5 @@
 comment = 'Core API surface for DocumentDB on PostgreSQL'
-default_version = '0.110-0'
+default_version = '0.111-0'
 module_pathname = '$libdir/pg_documentdb_core'
 relocatable = false
 superuser = true

--- a/pg_documentdb_core/sql/documentdb_core--0.110-0--0.111-0.sql
+++ b/pg_documentdb_core/sql/documentdb_core--0.110-0--0.111-0.sql
@@ -1,0 +1,4 @@
+-- documentdb_core--0.110-0--0.111-0.sql
+-- Upgrade script from version 0.110-0 to 0.111-0
+-- Version bump to stay in sync with pg_documentdb extension
+-- No functional changes in this release for documentdb_core


### PR DESCRIPTION
Implements Phase 1 of RFC-006 by adding metadata infrastructure for Role-Based Access Control. This lays the groundwork for MongoDB-compatible authorization without modifying enforcement logic.
