### PR TITLE
Add commitTransaction and abortTransaction admin db error handling

### DIFF
--- a/pg_documentdb_gw/src/context/transaction.rs
+++ b/pg_documentdb_gw/src/context/transaction.rs
@@ -241,7 +241,7 @@ impl TransactionStore {
                 Err(DocumentDBError::documentdb_error(
                     ErrorCode::NoSuchTransaction,
                     format!(
-                        "Cannot continue transaction {}",
+                        "Given transaction number {} does not match any in-progress transactions.",
                         transaction_info.transaction_number
                     ),
                 ))
@@ -269,7 +269,7 @@ impl TransactionStore {
             Err(DocumentDBError::documentdb_error(
                 ErrorCode::NoSuchTransaction,
                 format!(
-                    "Cannot continue transaction {}",
+                    "Given transaction number {} does not match any in-progress transactions.",
                     transaction_info.transaction_number
                 ),
             ))

--- a/pg_documentdb_gw/tests/txn_abort_error_handling_tests.rs
+++ b/pg_documentdb_gw/tests/txn_abort_error_handling_tests.rs
@@ -1,0 +1,157 @@
+/*-------------------------------------------------------------------------
+ * tests/txn_abort_error_handling_tests.rs
+ *
+ * Tests to verify that the expected error messages are thrown when missing various fields in the
+ * abortTransaction admin database command.
+ *
+ * To run this test individually:
+ * cargo test --test txn_abort_error_handling_tests -- --test-threads=1
+ *-------------------------------------------------------------------------
+ */
+pub mod common;
+use crate::common::validation_utils;
+use mongodb::bson::{doc, Binary, Uuid};
+use mongodb::{Client, ClientSession, Database};
+
+async fn setup_transaction_with_insert(db_name: &str) -> (Client, Database, ClientSession) {
+    let client = common::initialize().await;
+    let db = common::setup_db(&client, db_name).await;
+    let coll = db.collection::<mongodb::bson::Document>("test");
+
+    let mut session = client.start_session().await.unwrap();
+    session.start_transaction().await.unwrap();
+
+    coll.insert_one(doc! {"a": 1})
+        .session(&mut session)
+        .await
+        .unwrap();
+
+    (client, db, session)
+}
+
+#[tokio::test]
+async fn test_abort_transaction_success() {
+    let (client, db, mut session) = setup_transaction_with_insert("txn_abort_success").await;
+
+    let admin_db = client.database("admin");
+    let result = admin_db
+        .run_command(doc! {
+            "abortTransaction": 1,
+            "lsid": session.id(),
+            "txnNumber": 1_i64,
+            "autocommit": false
+        })
+        .session(&mut session)
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "Expected successful abortTransaction with all fields present: {:?}",
+        result
+    );
+
+    let coll = db.collection::<mongodb::bson::Document>("test");
+    let doc = coll.find_one(doc! {"a": 1}).await.unwrap();
+    assert!(
+        doc.is_none(),
+        "Expected document {{a: 1}} to not exist after abort"
+    );
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_abort_transaction_missing_multiple_fields() {
+    let (client, db, session) = setup_transaction_with_insert("txn_abort_missing_multiple").await;
+
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {"abortTransaction": 1},
+        125,
+        "AbortTransaction must be run within a transaction.",
+    )
+    .await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_abort_transaction_missing_lsid() {
+    let (client, db, session) = setup_transaction_with_insert("txn_abort_missing_lsid").await;
+
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {
+            "abortTransaction": 1,
+            "txnNumber": 1_i64,
+            "autocommit": false
+        },
+        251,
+        "Given transaction number 1 does not match any in-progress transactions.",
+    )
+    .await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_abort_transaction_missing_txn_number() {
+    let (client, db, session) = setup_transaction_with_insert("txn_abort_missing_txn_number").await;
+
+    let uuid = Uuid::new();
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {
+            "abortTransaction": 1,
+            "lsid": {"id": Binary { subtype: mongodb::bson::spec::BinarySubtype::Uuid, bytes: uuid.bytes().to_vec() }},
+            "autocommit": false
+        },
+        72,
+        "'autocommit' field requires a transaction number to also be specified."
+    ).await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_abort_transaction_missing_autocommit() {
+    let (client, db, session) = setup_transaction_with_insert("txn_abort_missing_autocommit").await;
+
+    let uuid = Uuid::new();
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {
+            "abortTransaction": 1,
+            "lsid": {"id": Binary { subtype: mongodb::bson::spec::BinarySubtype::Uuid, bytes: uuid.bytes().to_vec() }},
+            "txnNumber": 1_i64
+        },
+        50768,
+        "txnNumber may only be provided for multi-document transactions and retryable write commands. autocommit:false was not provided, and AbortTransaction is not a retryable write command."
+    ).await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}

--- a/pg_documentdb_gw/tests/txn_commit_error_handling_tests.rs
+++ b/pg_documentdb_gw/tests/txn_commit_error_handling_tests.rs
@@ -1,0 +1,160 @@
+/*-------------------------------------------------------------------------
+ * tests/txn_commit_error_handling_tests.rs
+ *
+ * Tests to verify that the expected error messages are thrown when missing various fields in the
+ * commitTransaction admin database command.
+ *
+ * To run this test individually:
+ * cargo test --test txn_commit_error_handling_tests -- --test-threads=1
+ *-------------------------------------------------------------------------
+ */
+pub mod common;
+use crate::common::validation_utils;
+use mongodb::bson::{doc, Binary, Uuid};
+use mongodb::{Client, ClientSession, Database};
+
+async fn setup_transaction_with_insert(db_name: &str) -> (Client, Database, ClientSession) {
+    let client = common::initialize().await;
+    let db = common::setup_db(&client, db_name).await;
+    let coll = db.collection::<mongodb::bson::Document>("test");
+
+    let mut session = client.start_session().await.unwrap();
+    session.start_transaction().await.unwrap();
+
+    coll.insert_one(doc! {"a": 1})
+        .session(&mut session)
+        .await
+        .unwrap();
+
+    (client, db, session)
+}
+
+#[tokio::test]
+async fn test_commit_transaction_success() {
+    let (client, db, mut session) = setup_transaction_with_insert("txn_commit_success").await;
+
+    let admin_db = client.database("admin");
+    let result = admin_db
+        .run_command(doc! {
+            "commitTransaction": 1,
+            "lsid": session.id(),
+            "txnNumber": 1_i64,
+            "autocommit": false
+        })
+        .session(&mut session)
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "Expected successful commitTransaction with all fields present: {:?}",
+        result
+    );
+
+    let coll = db.collection::<mongodb::bson::Document>("test");
+    let expected_doc = doc! {"a": 1};
+    let doc = coll.find_one(expected_doc).await.unwrap();
+    assert!(
+        doc.is_some(),
+        "Expected to find document {{a:1}} after commit"
+    );
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_commit_transaction_missing_multiple_fields() {
+    let (client, db, session) = setup_transaction_with_insert("txn_commit_missing_multiple").await;
+
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {"commitTransaction": 1},
+        125,
+        "CommitTransaction must be run within a transaction",
+    )
+    .await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_commit_transaction_missing_lsid() {
+    let (client, db, session) = setup_transaction_with_insert("txn_commit_missing_lsid").await;
+
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {
+            "commitTransaction": 1,
+            "txnNumber": 1_i64,
+            "autocommit": false
+        },
+        251,
+        "Given transaction number 1 does not match any in-progress transactions",
+    )
+    .await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_commit_transaction_missing_txn_number() {
+    let (client, db, session) =
+        setup_transaction_with_insert("txn_commit_missing_txn_number").await;
+
+    let uuid = Uuid::new();
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {
+            "commitTransaction": 1,
+            "lsid": {"id": Binary { subtype: mongodb::bson::spec::BinarySubtype::Uuid, bytes: uuid.bytes().to_vec() }},
+            "autocommit": false
+        },
+        72,
+        "'autocommit' field requires a transaction number to also be specified"
+    ).await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn test_commit_transaction_missing_autocommit() {
+    let (client, db, session) =
+        setup_transaction_with_insert("txn_commit_missing_autocommit").await;
+
+    let uuid = Uuid::new();
+    let admin_db = client.database("admin");
+    validation_utils::execute_command_and_validate_error(
+        &admin_db,
+        doc! {
+            "commitTransaction": 1,
+            "lsid": {"id": Binary { subtype: mongodb::bson::spec::BinarySubtype::Uuid, bytes: uuid.bytes().to_vec() }},
+            "txnNumber": 1_i64
+        },
+        50768,
+        "txnNumber may only be provided for multi-document transactions and retryable write commands. autocommit:false was not provided, and CommitTransaction is not a retryable write command."
+    ).await;
+
+    let _ = db
+        .run_command(doc! {
+            "endSessions": [session.id()]
+        })
+        .await;
+}


### PR DESCRIPTION
- Added error handling when missing various fields in the `commitTransaction` and `abortTransaction` admin database commands.
  - More background/context can be found in issue #428 
- Added test files `txn_abort_error_handling_tests.rs` and `txn_commit_error_handling_tests.rs` to test that the expected errors are thrown for each case.

MongoDB error codes for reference: https://www.mongodb.com/docs/manual/reference/error-codes/

`commitTransaction` error handling after the fix:
| Missing field(s)  | Command | MongoDB 8.0 Output | DocumentDB Output |
| ------------- | ------------- | ------------- | ------------- |
| None (has all required fields) | `admin.command('commitTransaction', session=session, autocommit=False, txnNumber=Int64(0))` | `{'ok': 1.0, '$clusterTime': {'clusterTime': Timestamp(1766599789, 4), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599789, 4)}` | `{'ok': 1.0}` |
| Multiple fields (LSID, autocommit, transaction number)  | `admin.command("commitTransaction”)`  | `{'ok': 0.0, 'errmsg': 'commitTransaction must be run within a transaction', 'code': 125, 'codeName': 'CommandFailed', '$clusterTime': {'clusterTime': Timestamp(1766599789, 2), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599789, 2)}` | `{'ok': 0.0, 'code': 125, 'codeName': 'CommandFailed', 'errmsg': 'CommitTransaction must be run within a transaction.'}` |
| LSID  | `admin.command('commitTransaction', autocommit=False, txnNumber=Int64(0))`  |  `{'errorLabels': ['TransientTransactionError'], 'ok': 0.0, 'errmsg': 'Given transaction number 0 on session 3ea74c77-86a9-4ad2-bcce-1151073eed3e - 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU= -  -  using txnRetryCounter 0 does not match any in-progress transactions. The active transaction number is -1', 'code': 251, 'codeName': 'NoSuchTransaction', '$clusterTime': {'clusterTime': Timestamp(1766599789, 3), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599789, 3)}` | `{'ok': 0.0, 'code': 251, 'codeName': 'NoSuchTransaction', 'errmsg': 'Given transaction number 0 does not match any in-progress transactions.'}` |
| Transaction number | `admin.command("commitTransaction", session=session, autocommit=False)` | `{'ok': 0.0, 'errmsg': "'autocommit' field requires a transaction number to also be specified", 'code': 72, 'codeName': 'InvalidOptions', '$clusterTime': {'clusterTime': Timestamp(1766599789, 3), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599789, 3)}`  | `{'ok': 0.0, 'code': 72, 'codeName': 'InvalidOptions', 'errmsg': "'autocommit' field requires a transaction number to also be specified."}` |
| `autocommit` field | `admin.command("commitTransaction", session=session, txnNumber=Int64(0))`  | `{'ok': 0.0, 'errmsg': 'txnNumber may only be provided for multi-document transactions and retryable write commands. autocommit:false was not provided, and commitTransaction is not a retryable write command.', 'code': 50768, 'codeName': 'NotARetryableWriteCommand', '$clusterTime': {'clusterTime': Timestamp(1766599789, 3), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599789, 3)}` | `{'ok': 0.0, 'code': 50768, 'codeName': 'NotARetryableWriteCommand', 'errmsg': 'txnNumber may only be provided for multi-document transactions and retryable write commands. autocommit:false was not provided, and CommitTransaction is not a retryable write command.'}` |


`abortTransaction` error handling after the fix:
| Missing field(s)  | Command | MongoDB 8.0 Output | DocumentDB Output |
| ------------- | ------------- | ------------- | ------------- |
| None (has all required fields) | `admin.command('abortTransaction', session=session, autocommit=False, txnNumber=Int64(1))`| `{'n': 1, 'electionId': ObjectId('7fffffff0000000000000001'), 'opTime': {'ts': Timestamp(1766599827, 8), 't': 1}, 'ok': 1.0, '$clusterTime': {'clusterTime': Timestamp(1766599827, 8), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599827, 8)}` | `{'ok': 1.0}` |
| Multiple fields (LSID, autocommit, transaction number) | `admin.command("abortTransaction")` | `{'ok': 0.0, 'errmsg': 'abortTransaction must be run within a transaction', 'code': 125, 'codeName': 'CommandFailed', '$clusterTime': {'clusterTime': Timestamp(1766599827, 8), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599827, 8)}` | `{'ok': 0.0, 'code': 125, 'codeName': 'CommandFailed', 'errmsg': 'AbortTransaction must be run within a transaction.'}` |
| LSID | `admin.command('abortTransaction', autocommit=False, txnNumber=Int64(1))` | `{'errorLabels': ['TransientTransactionError'], 'ok': 0.0, 'errmsg': 'Given transaction number 1 on session 3b14a6e5-88db-426d-995e-b68846d46297 - 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU= -  -  using txnRetryCounter 0 does not match any in-progress transactions. The active transaction number is -1', 'code': 251, 'codeName': 'NoSuchTransaction', '$clusterTime': {'clusterTime': Timestamp(1766599827, 9), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599827, 9)}` | `{'ok': 0.0, 'code': 251, 'codeName': 'NoSuchTransaction', 'errmsg': 'Given transaction number 1 does not match any in-progress transactions.'}` |
| Transaction number | `admin.command("abortTransaction", session=session, autocommit=False)` |`{'ok': 0.0, 'errmsg': "'autocommit' field requires a transaction number to also be specified", 'code': 72, 'codeName': 'InvalidOptions', '$clusterTime': {'clusterTime': Timestamp(1766599827, 9), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599827, 9)}` | `{'ok': 0.0, 'code': 72, 'codeName': 'InvalidOptions', 'errmsg': "'autocommit' field requires a transaction number to also be specified."}` |
| `autocommit` field | `admin.command("abortTransaction", session=session, txnNumber=Int64(1))` | `{'ok': 0.0, 'errmsg': 'txnNumber may only be provided for multi-document transactions and retryable write commands. autocommit:false was not provided, and abortTransaction is not a retryable write command.', 'code': 50768, 'codeName': 'NotARetryableWriteCommand', '$clusterTime': {'clusterTime': Timestamp(1766599827, 9), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1766599827, 9)}` | `{'ok': 0.0, 'code': 50768, 'codeName': 'NotARetryableWriteCommand', 'errmsg': 'txnNumber may only be provided for multi-document transactions and retryable write commands. autocommit:false was not provided, and AbortTransaction is not a retryable write command.'}` |

Fixes #428