### PR TITLE
Implemented listDatabases command for gateway standardization - RFC:0010

### DIFF
--- a/internal/pg_documentdb_distributed/src/test/regress/basic_schedule_core
+++ b/internal/pg_documentdb_distributed/src/test/regress/basic_schedule_core
@@ -126,6 +126,7 @@ test: bson_aggregation_stage_index_stats
 test: commands_validate
 test: command_compact
 test: commands_db_stats
+test: command_list_databases
 test: commands_create_view_tests
 test: commands_killop
 

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/command_list_databases.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/command_list_databases.out
@@ -1,0 +1,154 @@
+SET search_path TO documentdb_core,documentdb_api,documentdb_api_catalog,documentdb_api_internal;
+SET citus.next_shard_id TO 6350000;
+SET documentdb.next_collection_id TO 6350;
+SET documentdb.next_collection_index_id TO 6350;
+SET documentdb_core.bsonUseEJson TO true;
+SET client_min_messages TO WARNING;
+-- Clean up any existing test databases
+SELECT documentdb_api.drop_database('list_db_test1');
+ drop_database 
+---------------------------------------------------------------------
+ 
+(1 row)
+
+SELECT documentdb_api.drop_database('list_db_test2');
+ drop_database 
+---------------------------------------------------------------------
+ 
+(1 row)
+
+SELECT documentdb_api.drop_database('list_db_test3');
+ drop_database 
+---------------------------------------------------------------------
+ 
+(1 row)
+
+-- Test 1: No matching databases exist
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": {"$regex": "^list_db_test"}}, "nameOnly": true}');
+                       list_databases                       
+---------------------------------------------------------------------
+ { "databases" : [  ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+-- Test 2: Create one database, verify it shows up
+SELECT documentdb_api.create_collection('list_db_test1', 'col1');
+ create_collection 
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT documentdb_api.insert_one('list_db_test1', 'col1', '{"a": 1}', NULL);
+                              insert_one                              
+---------------------------------------------------------------------
+ { "n" : { "$numberInt" : "1" }, "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test1"}, "nameOnly": true}');
+                                     list_databases                                     
+---------------------------------------------------------------------
+ { "databases" : [ { "name" : "list_db_test1" } ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+-- Test 3: Create more databases, verify with regex filter
+SELECT documentdb_api.create_collection('list_db_test2', 'col1');
+ create_collection 
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT documentdb_api.insert_one('list_db_test2', 'col1', '{"x": 100}', NULL);
+                              insert_one                              
+---------------------------------------------------------------------
+ { "n" : { "$numberInt" : "1" }, "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+SELECT documentdb_api.create_collection('list_db_test3', 'large_col');
+ create_collection 
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT documentdb_api.insert_one('list_db_test3', 'large_col', '{"id": 1}', NULL);
+                              insert_one                              
+---------------------------------------------------------------------
+ { "n" : { "$numberInt" : "1" }, "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test2"}, "nameOnly": true}');
+                                     list_databases                                     
+---------------------------------------------------------------------
+ { "databases" : [ { "name" : "list_db_test2" } ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test3"}, "nameOnly": true}');
+                                     list_databases                                     
+---------------------------------------------------------------------
+ { "databases" : [ { "name" : "list_db_test3" } ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+-- Test 4: Drop a collection, database should still exist
+SELECT documentdb_api.create_collection('list_db_test2', 'col2');
+ create_collection 
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT documentdb_api.drop_collection('list_db_test2', 'col2');
+ drop_collection 
+---------------------------------------------------------------------
+ t
+(1 row)
+
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test2"}, "nameOnly": true}');
+                                     list_databases                                     
+---------------------------------------------------------------------
+ { "databases" : [ { "name" : "list_db_test2" } ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+-- Test 5: Drop entire database, verify it's gone
+SELECT documentdb_api.drop_database('list_db_test3');
+ drop_database 
+---------------------------------------------------------------------
+ 
+(1 row)
+
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test3"}, "nameOnly": true}');
+                       list_databases                       
+---------------------------------------------------------------------
+ { "databases" : [  ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+-- Test 6: Exact filter match returns only that database
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test1"}, "nameOnly": true}');
+                                     list_databases                                     
+---------------------------------------------------------------------
+ { "databases" : [ { "name" : "list_db_test1" } ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+-- Cleanup
+SELECT documentdb_api.drop_database('list_db_test1');
+ drop_database 
+---------------------------------------------------------------------
+ 
+(1 row)
+
+SELECT documentdb_api.drop_database('list_db_test2');
+ drop_database 
+---------------------------------------------------------------------
+ 
+(1 row)
+
+SELECT documentdb_api.drop_database('list_db_test3');
+ drop_database 
+---------------------------------------------------------------------
+ 
+(1 row)
+
+-- Verify cleanup: no matching databases remain
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": {"$regex": "^list_db_test"}}, "nameOnly": true}');
+                       list_databases                       
+---------------------------------------------------------------------
+ { "databases" : [  ], "ok" : { "$numberDouble" : "1.0" } }
+(1 row)
+
+SET client_min_messages TO DEFAULT;

--- a/internal/pg_documentdb_distributed/src/test/regress/sql/command_list_databases.sql
+++ b/internal/pg_documentdb_distributed/src/test/regress/sql/command_list_databases.sql
@@ -1,0 +1,49 @@
+SET search_path TO documentdb_core,documentdb_api,documentdb_api_catalog,documentdb_api_internal;
+SET citus.next_shard_id TO 6350000;
+SET documentdb.next_collection_id TO 6350;
+SET documentdb.next_collection_index_id TO 6350;
+SET documentdb_core.bsonUseEJson TO true;
+SET client_min_messages TO WARNING;
+
+-- Clean up any existing test databases
+SELECT documentdb_api.drop_database('list_db_test1');
+SELECT documentdb_api.drop_database('list_db_test2');
+SELECT documentdb_api.drop_database('list_db_test3');
+
+-- Test 1: No matching databases exist
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": {"$regex": "^list_db_test"}}, "nameOnly": true}');
+
+-- Test 2: Create one database, verify it shows up
+SELECT documentdb_api.create_collection('list_db_test1', 'col1');
+SELECT documentdb_api.insert_one('list_db_test1', 'col1', '{"a": 1}', NULL);
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test1"}, "nameOnly": true}');
+
+-- Test 3: Create more databases, verify with regex filter
+SELECT documentdb_api.create_collection('list_db_test2', 'col1');
+SELECT documentdb_api.insert_one('list_db_test2', 'col1', '{"x": 100}', NULL);
+SELECT documentdb_api.create_collection('list_db_test3', 'large_col');
+SELECT documentdb_api.insert_one('list_db_test3', 'large_col', '{"id": 1}', NULL);
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test2"}, "nameOnly": true}');
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test3"}, "nameOnly": true}');
+
+-- Test 4: Drop a collection, database should still exist
+SELECT documentdb_api.create_collection('list_db_test2', 'col2');
+SELECT documentdb_api.drop_collection('list_db_test2', 'col2');
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test2"}, "nameOnly": true}');
+
+-- Test 5: Drop entire database, verify it's gone
+SELECT documentdb_api.drop_database('list_db_test3');
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test3"}, "nameOnly": true}');
+
+-- Test 6: Exact filter match returns only that database
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": "list_db_test1"}, "nameOnly": true}');
+
+-- Cleanup
+SELECT documentdb_api.drop_database('list_db_test1');
+SELECT documentdb_api.drop_database('list_db_test2');
+SELECT documentdb_api.drop_database('list_db_test3');
+
+-- Verify cleanup: no matching databases remain
+SELECT documentdb_api.list_databases('{"listDatabases": 1, "filter": {"name": {"$regex": "^list_db_test"}}, "nameOnly": true}');
+
+SET client_min_messages TO DEFAULT;

--- a/pg_documentdb_gw/src/postgres/query_catalog.rs
+++ b/pg_documentdb_gw/src/postgres/query_catalog.rs
@@ -310,9 +310,8 @@ impl QueryCatalog {
         &self.update_bulk
     }
 
-    pub fn list_databases(&self, filter_string: &str) -> String {
-        self.list_databases
-            .replace("{filter_string}", filter_string)
+    pub fn list_databases(&self) -> &str {
+        &self.list_databases
     }
 
     pub fn list_collections(&self) -> &str {
@@ -511,15 +510,7 @@ pub fn create_query_catalog() -> QueryCatalog {
             process_update: "SELECT * FROM documentdb_api.update($1, $2, $3, NULL)".to_string(),
             update_txn_proc: "CALL documentdb_api.update_txn_proc($1, $2, $3, NULL)".to_string(),
             update_bulk: "CALL documentdb_api.update_bulk($1, $2, $3, NULL)".to_string(),
-            list_databases: "WITH r1 AS (SELECT DISTINCT database_name AS name
-                                FROM documentdb_api_catalog.collections),
-                             r2 AS (SELECT documentdb_core.row_get_bson(r1) AS document FROM r1),
-                             r3 AS (SELECT document FROM r2 {filter_string}),
-                             r4 AS (SELECT COALESCE(documentdb_api_catalog.bson_array_agg(r3.document, ''), '{ \"\": [] }') AS \"databases\",
-                                           1.0::float8                                                                        AS \"ok\"
-                                    FROM r3)
-                        SELECT documentdb_core.row_get_bson(r4) AS document
-                        FROM r4".to_string(),
+            list_databases: "SELECT documentdb_api.list_databases($1)".to_string(),
             list_collections: "SELECT cursorPage, continuation, persistConnection, cursorId FROM documentdb_api.list_collections_cursor_first_page($1, $2)".to_string(),
             validate: "SELECT documentdb_api.validate($1, $2)".to_string(),
             find_and_modify: "SELECT * FROM documentdb_api.find_and_modify($1, $2, NULL)".to_string(),


### PR DESCRIPTION
## Description
Related to https://github.com/documentdb/documentdb/pull/440
Implemented full BSON support for the listDatabases command by replacing inline SQL query construction in the gateway with a call to the database API - `SELECT documentdb_api.list_databases`

listDatabases command can take 4 different optional parameters- `filter, nameOnly, authorizedDatabases, comment`,  currently the existing API supports only the `filter` option so the SQL tests are added accordingly to check the correctness of the functionality.

## Testing

### Mongo Test
```
[direct: mongos] test> use testdb1
switched to db testdb1
[direct: mongos] testdb1> db.users.insertOne({ name: "Alice", age: 30, city: "New York" })
{
  acknowledged: true,
  insertedId: ObjectId('6996601cde93b2b6a78ce5b0')
}
[direct: mongos] testdb1> db.users.insertOne({ name: "Bob", age: 25, city: "Boston" })
{
  acknowledged: true,
  insertedId: ObjectId('69966022de93b2b6a78ce5b1')
}
[direct: mongos] testdb1> db.products.insertOne({ name: "Laptop", price: 999 })
{
  acknowledged: true,
  insertedId: ObjectId('69966027de93b2b6a78ce5b2')
}
[direct: mongos] testdb1> use testdb2
switched to db testdb2
[direct: mongos] testdb2> db.orders.insertOne({ orderId: 1, amount: 150, status: "completed" })
{
  acknowledged: true,
  insertedId: ObjectId('69966037de93b2b6a78ce5b3')
}
[direct: mongos] testdb2> db.orders.insertOne({ orderId: 2, amount: 200, status: "pending" })
{
  acknowledged: true,
  insertedId: ObjectId('6996603dde93b2b6a78ce5b4')
}
[direct: mongos] testdb2> db.customers.insertOne({ customerId: 1, name: "Charlie" })
{
  acknowledged: true,
  insertedId: ObjectId('69966041de93b2b6a78ce5b5')
}

[direct: mongos] testdb2> db.adminCommand({ listDatabases: 1 })
{
  databases: [
    { name: 'testdb2', sizeOnDisk: 0, empty: false },
    { name: 'testdb1', sizeOnDisk: 0, empty: false }
  ],
  totalSize: 18736407,
  ok: 1
}

[direct: mongos] testdb2> db.adminCommand({ listDatabases: 1, nameOnly: false })
{
  databases: [
    { name: 'testdb2', sizeOnDisk: 0, empty: false },
    { name: 'testdb1', sizeOnDisk: 0, empty: false }
  ],
  totalSize: 18744599,
  ok: 1
}

[direct: mongos] testdb2> db.adminCommand({ listDatabases: 1, nameOnly: true })
{ databases: [ { name: 'testdb2' }, { name: 'testdb1' } ], ok: 1 }
```

### SQL Test
```
ok 233       - commands_db_stats                       13266 ms
ok 234       - command_list_databases                    241 ms
ok 235       - commands_create_view_tests                322 ms
```

