### PR TITLE
[RFC 0014] Documentdb-Local Emulator Application insights

### DIFF
--- a/rfcs/0006-emulator-application-insights.md
+++ b/rfcs/0006-emulator-application-insights.md
@@ -2,7 +2,7 @@
 rfc: 0006
 title: "Application Insights Telemetry for DocumentDB Local Emulator"
 status: Draft
-owner: "@github-username"
+owner: "@Ritvik-Jayaswal"
 issue: "https://github.com/documentdb/documentdb/issues/XXX"
 discussion: "https://github.com/documentdb/documentdb/discussions/XXX"
 version-target: 1.0

--- a/rfcs/0006-emulator-application-insights.md
+++ b/rfcs/0006-emulator-application-insights.md
@@ -41,40 +41,32 @@ A comparable implementation was completed for the DocumentDB Kubernetes Operator
 4. Users can opt out at any time by omitting the flag or setting `ENABLE_TELEMETRY=false` (which should remain the default).
 5. Telemetry is silently disabled if the Application Insights connection string is absent or malformed, with a single log warning — it must never crash the emulator.
 
-### Non-Goals
-
-- Collecting raw query text, filter values, or document contents.
-- Collecting usernames, passwords, database names, collection names, or index names.
-- Real-time streaming or alerting (Application Insights handles aggregation and alerting on the backend).
-- Exposing telemetry data to end users or external systems other than the team's Application Insights workspace.
-- Replacing or modifying the existing PostgreSQL/gateway logging subsystem.
-
 ---
 
 ## Approach
 
 ### Proposed Solution
 
-Implement a lightweight telemetry client in the gateway (Rust, [`pg_documentdb_gw`](../pg_documentdb_gw)) that:
+Deploy the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as an additional process inside the emulator container, managed entirely by the existing entrypoint script. The collector is configured to:
 
-1. Reads the opt-in flag and Application Insights connection string at startup.
-2. Emits a small set of lifecycle and query-shape events to Application Insights using the [Application Insights REST ingestion API](https://learn.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics), batched and sent asynchronously so the hot path is never blocked.
-3. Hashes or omits all user-identifiable fields before transmission (stable, one-way hash of the container instance to correlate sessions without exposing identity).
+1. **Receive** metrics and log data from PostgreSQL via the `postgresqlreceiver` and `pg_stat_statements`, and from the gateway via its existing log output.
+2. **Process** all data through a scrubbing pipeline (`transformprocessor` / `filterprocessor`) to strip PII before any data leaves the machine.
+3. **Export** the cleaned telemetry to Application Insights via the `azuremonitorexporter`.
 
-The connection string for the team's Application Insights workspace is **baked into the release build** via a CI/CD secret (matching the pattern used in the Kubernetes operator PR), so users never need to supply it. Opt-in/opt-out is purely the `ENABLE_TELEMETRY` flag.
+No changes are made to the gateway or PostgreSQL source code. The only code changes are to the OTel Collector configuration file and the emulator entrypoint script. The Application Insights connection string is **baked into the release build** via a CI/CD secret, so users never need to supply it. Opt-in/opt-out is purely the `ENABLE_TELEMETRY` flag.
 
 ### Key Benefits and Tradeoffs
 
 | Benefit | Tradeoff |
 |---|---|
 | Actionable usage data with zero configuration burden on users | Requires baking a connection string into the release artifact (mitigated: read-only ingestion key, no data exfiltration risk) |
-| Consistent with Application Insights already used across the DocumentDB ecosystem | Adds a new async background task to the gateway process |
+| Consistent with Application Insights already used across the DocumentDB ecosystem | Adds the OTel Collector binary to the emulator container image (~100 MB) |
 | Opt-in by default protects privacy and builds user trust | Opt-in means lower data volume initially; consider defaulting to opt-in with clear disclosure in the future |
 | Query shape data (operators used, pipeline stages) reveals compatibility gaps | Requires careful scrubbing logic to ensure no value leakage |
 
 ### Alignment with Existing Architecture
 
-The gateway process already manages the full lifecycle of the emulator's MongoDB wire protocol layer. Adding telemetry as a background task within the gateway keeps all observable behavior centralized, avoids a separate sidecar process, and reuses the existing `SetupConfiguration.json` config file for any gateway-level telemetry settings.
+The emulator entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh)) already manages the full lifecycle of the PostgreSQL server and gateway process. Adding the OTel Collector as another managed child process follows the same pattern — start on launch, stop on shutdown — without any changes to the gateway or PostgreSQL source code. PostgreSQL's `pg_stat_statements` extension, which is already available in the emulator, provides the query-level statistics needed for usage telemetry.
 
 ---
 
@@ -82,67 +74,64 @@ The gateway process already manages the full lifecycle of the emulator's MongoDB
 
 ### Technical Details
 
-#### Telemetry Client
+#### OTel Collector Pipeline
 
-A new Rust module `documentdb_gateway_core::telemetry` will own all telemetry logic:
+The OpenTelemetry Collector runs as a managed child process of the emulator entrypoint. Its configuration (`otelcol-config.yaml`) defines a three-stage pipeline:
 
-- **Initialization:** On startup, if `ENABLE_TELEMETRY=true`, parse the baked-in (compile-time) Application Insights connection string from an env var injected at build time (`APPINSIGHTS_CONNECTION_STRING`). If absent or malformed, log a single warning and disable telemetry for the process lifetime.
-- **Async sender:** Spawn a Tokio background task that owns an in-memory queue. The hot path (request handling) posts events to the queue without awaiting. The background task batches up to 100 events or flushes every 30 seconds, matching the Kubernetes operator's batching parameters.
-- **Graceful shutdown:** On `SIGTERM`/`SIGINT`, flush any queued events before the gateway exits (best-effort, timeout 5 seconds).
-- **Cloud/environment detection:** Detect whether the emulator is running inside Docker, a devcontainer, GitHub Codespaces, CI (via common env vars like `CI`, `CODESPACES`, `GITHUB_ACTIONS`), or bare-metal, and include this as an anonymized `environment` property on every event.
+**Receivers**
+- `postgresqlreceiver` — connects to the local PostgreSQL instance and collects metrics from `pg_stat_statements` (call counts, total execution time per normalized query fingerprint) and standard `pg_stat_*` tables (connection counts, cache hit ratios, table and index sizes).
+- `filelogreceiver` — tails the existing gateway log file for error-level events, extracting error codes and command types using regex operators. No query values are captured.
+
+**Processors**
+- `transformprocessor` — normalizes query fingerprints produced by `pg_stat_statements` (which already strips literal values) into a bucketed operation type (`find`, `aggregate`, `insert`, `update`, `delete`, `command`) and extracts pipeline stage names for aggregate queries.
+- `filterprocessor` — drops any attribute whose key or value matches a blocklist of known PII patterns (collection names, usernames, hostnames, IP addresses, file paths).
+- `resourceprocessor` — attaches static resource attributes: `emulator.version`, `environment` tag, and a per-run `session.id` (random UUID generated by the entrypoint script and passed via env var).
+- `batchprocessor` — batches up to 100 data points or flushes every 30 seconds before export.
+
+**Exporter**
+- `azuremonitorexporter` — sends processed telemetry to Application Insights. The connection string is provided via the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable, injected from a CI/CD secret at release build time and forwarded by the entrypoint script.
 
 #### Session Correlation
 
-At startup, generate a random UUID (`session_id`) for the process lifetime. This correlates events within a single emulator run without identifying the user across runs. Never persist this value to disk.
+The entrypoint script generates a random UUID at startup (`SESSION_ID=$(uuidgen)`) and passes it to the OTel Collector as an environment variable. The `resourceprocessor` attaches it as a resource attribute on every exported data point. This correlates events within a single emulator run without identifying the user across runs. The value is never written to disk.
 
 #### PII Scrubbing
 
-All event properties must pass through a scrubbing layer before being enqueued:
+The `filterprocessor` and `transformprocessor` enforce the following rules:
 
-- **Never included:** usernames, passwords, database names, collection names, field names, index names, hostnames, IP addresses, file paths.
-- **Hashed (one-way SHA-256, truncated to 8 bytes, hex-encoded):** The `session_id` only. No other identifier is hashed and transmitted.
-- **Included as-is:** emulator version, OS family (Linux/Windows/macOS — not version string), environment tag, operation type enum, pipeline stage names (these are part of the MongoDB specification, not user data), error code integers, duration buckets.
+- **Never included:** raw query text, literal values, database names, collection names, field names, index names, usernames, hostnames, IP addresses, file paths.
+- **Safe to include:** emulator version, OS family, environment tag (`docker` / `codespaces` / `ci` / `bare-metal` / `unknown`), normalized operation type, pipeline stage names (MongoDB spec names, not user data), error code integers, duration histograms, `pg_stat_statements` query fingerprint hash (integer `queryid`, not text).
 
-#### Query Shape Telemetry
+`pg_stat_statements` already normalizes queries by replacing literal values with `$1`, `$2`, … placeholders before computing the `queryid` hash, so literal values never enter the OTel pipeline.
 
-Wire protocol command handlers will emit a `QueryExecuted` event (non-blocking enqueue) containing:
+#### Metrics and Events Collected
 
-```
-{
-  "name": "QueryExecuted",
-  "properties": {
-    "session_id": "<hex>",
-    "emulator_version": "1.2.3",
-    "operation": "find" | "aggregate" | "insert" | "update" | "delete" | "findAndModify" | "count" | "distinct" | "command",
-    "pipeline_stages": ["$match", "$group", "$sort"],   // aggregate only; stage names only, no values
-    "has_filter": true | false,
-    "has_projection": true | false,
-    "has_sort": true | false,
-    "has_limit": true | false,
-    "has_skip": true | false,
-    "index_used": true | false,
-    "duration_bucket_ms": "0-1" | "1-10" | "10-100" | "100-1000" | "1000+",
-    "success": true | false,
-    "error_code": 2,                                    // only when success=false; integer wire protocol code
-    "environment": "docker" | "codespaces" | "ci" | "bare-metal" | "unknown"
-  }
-}
-```
+**Query usage metrics** (sourced from `pg_stat_statements`, aggregated per flush interval):
 
-#### Lifecycle Events
-
-| Event | When Emitted | Key Properties |
+| Metric | Type | Description |
 |---|---|---|
-| `EmulatorStarted` | Gateway ready to accept connections | `emulator_version`, `session_id`, `environment`, `tls_enabled`, `custom_port` (bool), `extended_rum_enabled` |
-| `EmulatorStopped` | Graceful shutdown complete | `session_id`, `uptime_bucket_minutes` |
+| `documentdb.query.calls` | Counter | Number of executions per operation type |
+| `documentdb.query.duration` | Histogram | Execution time distribution per operation type |
+| `documentdb.query.errors` | Counter | Failed executions per error code |
+
+**Resource metrics** (sourced from `pg_stat_*` tables):
+
+| Metric | Type | Description |
+|---|---|---|
+| `documentdb.connections.active` | Gauge | Active client connections |
+| `documentdb.cache.hit_ratio` | Gauge | Buffer cache hit ratio |
+
+**Lifecycle events** (emitted by the entrypoint script to a log file read by `filelogreceiver`):
+
+| Event | When Emitted | Key Attributes |
+|---|---|---|
+| `EmulatorStarted` | Gateway ready to accept connections | `emulator_version`, `session_id`, `environment`, `tls_enabled`, `extended_rum_enabled` |
+| `EmulatorStopped` | Graceful shutdown signal received | `session_id`, `uptime_seconds` |
 | `InitDataLoaded` | Sample or custom init data loaded | `session_id`, `data_source` (`sample` / `custom`) |
-| `QueryExecuted` | Each wire protocol command completes | (see above) |
 
 ### API Changes
 
-No public-facing API changes. The `--enable-telemetry` flag and `ENABLE_TELEMETRY` environment variable already exist in the entrypoint; this RFC gives them a real implementation.
-
-A new optional key `AppInsightsConnectionString` will be recognized in `SetupConfiguration.json` so the gateway can receive the connection string from the entrypoint when needed for local development and testing. In release builds this is provided via build-time injection, not the config file.
+No public-facing API changes and no changes to the gateway or PostgreSQL source code. The `--enable-telemetry` flag and `ENABLE_TELEMETRY` environment variable already exist in the entrypoint; this RFC gives them a real implementation by starting and stopping the OTel Collector process.
 
 ### Database Schema Changes
 
@@ -152,18 +141,21 @@ None.
 
 | Setting | Where | Default | Description |
 |---|---|---|---|
-| `ENABLE_TELEMETRY` | Env var / `--enable-telemetry` CLI flag | `false` | Master opt-in switch. Must be `true` to emit any data. |
-| `APPINSIGHTS_CONNECTION_STRING` | Build-time env var (CI secret) | *(injected at release build)* | Application Insights ingestion endpoint + key. Never user-facing. |
-| `AppInsightsConnectionString` | `SetupConfiguration.json` (optional) | *(empty)* | Override for local development / testing only. Ignored in release builds when the build-time value is present. |
+| `ENABLE_TELEMETRY` | Env var / `--enable-telemetry` CLI flag | `false` | Master opt-in switch. Must be `true` to start the OTel Collector. |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Build-time env var (CI secret) | *(injected at release build)* | Application Insights ingestion endpoint + key. Never user-facing. |
+| `SESSION_ID` | Generated by entrypoint at startup | *(random UUID per run)* | Passed to the OTel Collector as a resource attribute for session correlation. |
 
-The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh)) will be updated to forward `ENABLE_TELEMETRY` and (when present) `APPINSIGHTS_CONNECTION_STRING` to the gateway via the `SetupConfiguration.json` config file, mirroring how `GatewayListenPort` and `PostgresPort` are already injected.
+The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh)) will be updated to:
+1. Generate `SESSION_ID` via `uuidgen` at startup.
+2. If `ENABLE_TELEMETRY=true`, start the OTel Collector as a background process with `otelcol-config.yaml` and the above env vars.
+3. On shutdown (in the existing `cleanup` function), send `SIGTERM` to the OTel Collector and wait up to 5 seconds for it to flush.
 
 ### Testing Strategy
 
-- **Unit tests:** PII scrubbing logic (verify field names, values, and paths are not present in the serialized event payload). Query shape extraction (verify no values leak, verify stage names are correctly enumerated). Connection string parsing (whitespace, malformed strings, missing key).
-- **Integration tests:** Start the emulator with `ENABLE_TELEMETRY=false` and verify no outbound HTTP traffic to Application Insights endpoints. Start with a mock HTTP server in place of Application Insights and verify event schema matches the spec above.
-- **Regression tests:** Telemetry failures (network unavailable, bad connection string) must not crash the emulator or affect query results.
-- **PII audit:** Automated test fixture that runs a set of queries containing known sentinel values and asserts those sentinels are absent from every serialized event.
+- **OTel Collector config validation:** Use `otelcol validate --config otelcol-config.yaml` in CI to catch configuration errors before they reach users.
+- **Integration tests:** Start the emulator with `ENABLE_TELEMETRY=false` and verify the OTel Collector process is not spawned and no outbound HTTP traffic is produced. Start with `ENABLE_TELEMETRY=true` and a mock OTLP receiver in place of Application Insights; verify that exported metric names and attributes match the spec above.
+- **PII audit:** Automated test that runs a set of queries containing known sentinel string values and asserts those sentinels are absent from every metric attribute exported by the OTel Collector (inspected via the mock OTLP receiver).
+- **Resilience tests:** Verify that if the OTel Collector crashes or the Application Insights endpoint is unreachable, the emulator continues serving queries without error.
 
 ### Migration Path
 
@@ -186,11 +178,9 @@ The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_en
 
 ### Implementation PRs
 
-- [ ] PR #XXX: Telemetry client module in `documentdb_gateway_core` (batching, PII scrubbing, Application Insights HTTP sender)
-- [ ] PR #XXX: Wire `EmulatorStarted` / `EmulatorStopped` lifecycle events into the gateway startup/shutdown path
-- [ ] PR #XXX: Wire `QueryExecuted` events into wire protocol command handlers
-- [ ] PR #XXX: Forward `ENABLE_TELEMETRY` and connection string from `emulator_entrypoint.sh` to gateway config
-- [ ] PR #XXX: CI/CD secret injection of `APPINSIGHTS_CONNECTION_STRING` for release builds
+- [ ] PR #XXX: Add `otelcol-config.yaml` (OTel Collector pipeline: `postgresqlreceiver`, `filelogreceiver`, processors, `azuremonitorexporter`)
+- [ ] PR #XXX: Update `scripts/emulator_entrypoint.sh` to generate `SESSION_ID`, start/stop the OTel Collector process, and emit lifecycle log events
+- [ ] PR #XXX: CI/CD secret injection of `APPLICATIONINSIGHTS_CONNECTION_STRING` for release builds and inclusion of the OTel Collector binary in the container image
 - [ ] PR #XXX: Documentation and README updates
 
 ### Status Updates
@@ -212,6 +202,6 @@ The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_en
 
 *Capture important decisions or learnings during implementation*
 
-- **Decision [2026-03-10]:** Use Application Insights REST ingestion API directly rather than an SDK, to avoid adding a heavy dependency to the Rust gateway. The ingestion endpoint accepts standard HTTP POST with JSON payloads and the connection string provides the endpoint URL and instrumentation key.
-  - **Context:** The Kubernetes operator used the Go Application Insights SDK; Rust has no official Microsoft SDK, so a thin HTTP client wrapper is more appropriate.
-  - **Alternatives:** `appinsights` crate (community, not officially maintained).
+- **Decision [2026-03-10]:** Use the OpenTelemetry Collector rather than embedding a telemetry SDK in the gateway, so that zero changes are needed to the gateway or PostgreSQL source code.
+  - **Context:** The Kubernetes operator embedded the Go Application Insights SDK directly in the controller binary. For the emulator, the OTel Collector provides equivalent functionality as a standalone process, keeps the gateway source clean, and allows the telemetry pipeline to be updated by changing a YAML configuration file rather than recompiling the gateway.
+  - **Alternatives:** Embedding the `opentelemetry` Rust crate or a custom Application Insights HTTP client in the gateway — rejected to avoid gateway source changes.

--- a/rfcs/0006-emulator-application-insights.md
+++ b/rfcs/0006-emulator-application-insights.md
@@ -1,0 +1,217 @@
+---
+rfc: 0006
+title: "Application Insights Telemetry for DocumentDB Local Emulator"
+status: Draft
+owner: "@github-username"
+issue: "https://github.com/documentdb/documentdb/issues/XXX"
+discussion: "https://github.com/documentdb/documentdb/discussions/XXX"
+version-target: 1.0
+implementations:
+  - "https://github.com/documentdb/documentdb/pull/XXX"
+---
+
+# RFC-0006: Application Insights Telemetry for DocumentDB Local Emulator
+
+## Problem
+
+The DocumentDB local emulator lacks structured, actionable telemetry. Without it, the team has no visibility into how users interact with the emulator: which features they exercise, what kinds of queries they run, where they encounter errors, and whether the emulator is being used at all or abandoned quickly.
+
+### Who Is Impacted
+
+- **Product and engineering teams** — cannot make data-driven decisions about which features to prioritize, which bugs matter most, or where the emulator diverges from customer expectations.
+- **Customers** — indirectly affected when compatibility gaps and pain points are invisible to the team and therefore remain unresolved.
+
+### Consequences of Not Solving This
+
+- Investment is allocated to features that aren't being used, while real friction points remain invisible.
+- Query incompatibilities or emulator bugs that affect large numbers of users go undetected until customers escalate manually.
+- There is no baseline to measure the impact of improvements.
+
+### Current State
+
+The emulator entrypoint already exposes an `--enable-telemetry` flag (and `ENABLE_TELEMETRY` environment variable) in [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh), but the flag is only validated — it is never forwarded to the gateway process or used to enable any telemetry pipeline. No telemetry data is currently collected or transmitted.
+
+A comparable implementation was completed for the DocumentDB Kubernetes Operator ([PR #237](https://github.com/documentdb/documentdb-kubernetes-operator/pull/237)), which integrated the Microsoft Application Insights Go SDK, wired telemetry into controllers, and exposed Helm chart configuration for the connection string. This RFC adapts that approach for the emulator context.
+
+### Success Criteria
+
+1. When `--enable-telemetry true` is passed (or `ENABLE_TELEMETRY=true` is set), the emulator emits structured events to Application Insights without any observable impact on functional behavior.
+2. No personally identifiable information (PII), credentials, collection names, field names, or raw query values are ever transmitted.
+3. Query shape telemetry captures the *types* of operations customers run (find, aggregate, insert, update, delete, command) and the pipeline stages or operators involved, without capturing actual values.
+4. Users can opt out at any time by omitting the flag or setting `ENABLE_TELEMETRY=false` (which should remain the default).
+5. Telemetry is silently disabled if the Application Insights connection string is absent or malformed, with a single log warning — it must never crash the emulator.
+
+### Non-Goals
+
+- Collecting raw query text, filter values, or document contents.
+- Collecting usernames, passwords, database names, collection names, or index names.
+- Real-time streaming or alerting (Application Insights handles aggregation and alerting on the backend).
+- Exposing telemetry data to end users or external systems other than the team's Application Insights workspace.
+- Replacing or modifying the existing PostgreSQL/gateway logging subsystem.
+
+---
+
+## Approach
+
+### Proposed Solution
+
+Implement a lightweight telemetry client in the gateway (Rust, [`pg_documentdb_gw`](../pg_documentdb_gw)) that:
+
+1. Reads the opt-in flag and Application Insights connection string at startup.
+2. Emits a small set of lifecycle and query-shape events to Application Insights using the [Application Insights REST ingestion API](https://learn.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics), batched and sent asynchronously so the hot path is never blocked.
+3. Hashes or omits all user-identifiable fields before transmission (stable, one-way hash of the container instance to correlate sessions without exposing identity).
+
+The connection string for the team's Application Insights workspace is **baked into the release build** via a CI/CD secret (matching the pattern used in the Kubernetes operator PR), so users never need to supply it. Opt-in/opt-out is purely the `ENABLE_TELEMETRY` flag.
+
+### Key Benefits and Tradeoffs
+
+| Benefit | Tradeoff |
+|---|---|
+| Actionable usage data with zero configuration burden on users | Requires baking a connection string into the release artifact (mitigated: read-only ingestion key, no data exfiltration risk) |
+| Consistent with Application Insights already used across the DocumentDB ecosystem | Adds a new async background task to the gateway process |
+| Opt-in by default protects privacy and builds user trust | Opt-in means lower data volume initially; consider defaulting to opt-in with clear disclosure in the future |
+| Query shape data (operators used, pipeline stages) reveals compatibility gaps | Requires careful scrubbing logic to ensure no value leakage |
+
+### Alignment with Existing Architecture
+
+The gateway process already manages the full lifecycle of the emulator's MongoDB wire protocol layer. Adding telemetry as a background task within the gateway keeps all observable behavior centralized, avoids a separate sidecar process, and reuses the existing `SetupConfiguration.json` config file for any gateway-level telemetry settings.
+
+---
+
+## Detailed Design
+
+### Technical Details
+
+#### Telemetry Client
+
+A new Rust module `documentdb_gateway_core::telemetry` will own all telemetry logic:
+
+- **Initialization:** On startup, if `ENABLE_TELEMETRY=true`, parse the baked-in (compile-time) Application Insights connection string from an env var injected at build time (`APPINSIGHTS_CONNECTION_STRING`). If absent or malformed, log a single warning and disable telemetry for the process lifetime.
+- **Async sender:** Spawn a Tokio background task that owns an in-memory queue. The hot path (request handling) posts events to the queue without awaiting. The background task batches up to 100 events or flushes every 30 seconds, matching the Kubernetes operator's batching parameters.
+- **Graceful shutdown:** On `SIGTERM`/`SIGINT`, flush any queued events before the gateway exits (best-effort, timeout 5 seconds).
+- **Cloud/environment detection:** Detect whether the emulator is running inside Docker, a devcontainer, GitHub Codespaces, CI (via common env vars like `CI`, `CODESPACES`, `GITHUB_ACTIONS`), or bare-metal, and include this as an anonymized `environment` property on every event.
+
+#### Session Correlation
+
+At startup, generate a random UUID (`session_id`) for the process lifetime. This correlates events within a single emulator run without identifying the user across runs. Never persist this value to disk.
+
+#### PII Scrubbing
+
+All event properties must pass through a scrubbing layer before being enqueued:
+
+- **Never included:** usernames, passwords, database names, collection names, field names, index names, hostnames, IP addresses, file paths.
+- **Hashed (one-way SHA-256, truncated to 8 bytes, hex-encoded):** The `session_id` only. No other identifier is hashed and transmitted.
+- **Included as-is:** emulator version, OS family (Linux/Windows/macOS — not version string), environment tag, operation type enum, pipeline stage names (these are part of the MongoDB specification, not user data), error code integers, duration buckets.
+
+#### Query Shape Telemetry
+
+Wire protocol command handlers will emit a `QueryExecuted` event (non-blocking enqueue) containing:
+
+```
+{
+  "name": "QueryExecuted",
+  "properties": {
+    "session_id": "<hex>",
+    "emulator_version": "1.2.3",
+    "operation": "find" | "aggregate" | "insert" | "update" | "delete" | "findAndModify" | "count" | "distinct" | "command",
+    "pipeline_stages": ["$match", "$group", "$sort"],   // aggregate only; stage names only, no values
+    "has_filter": true | false,
+    "has_projection": true | false,
+    "has_sort": true | false,
+    "has_limit": true | false,
+    "has_skip": true | false,
+    "index_used": true | false,
+    "duration_bucket_ms": "0-1" | "1-10" | "10-100" | "100-1000" | "1000+",
+    "success": true | false,
+    "error_code": 2,                                    // only when success=false; integer wire protocol code
+    "environment": "docker" | "codespaces" | "ci" | "bare-metal" | "unknown"
+  }
+}
+```
+
+#### Lifecycle Events
+
+| Event | When Emitted | Key Properties |
+|---|---|---|
+| `EmulatorStarted` | Gateway ready to accept connections | `emulator_version`, `session_id`, `environment`, `tls_enabled`, `custom_port` (bool), `extended_rum_enabled` |
+| `EmulatorStopped` | Graceful shutdown complete | `session_id`, `uptime_bucket_minutes` |
+| `InitDataLoaded` | Sample or custom init data loaded | `session_id`, `data_source` (`sample` / `custom`) |
+| `QueryExecuted` | Each wire protocol command completes | (see above) |
+
+### API Changes
+
+No public-facing API changes. The `--enable-telemetry` flag and `ENABLE_TELEMETRY` environment variable already exist in the entrypoint; this RFC gives them a real implementation.
+
+A new optional key `AppInsightsConnectionString` will be recognized in `SetupConfiguration.json` so the gateway can receive the connection string from the entrypoint when needed for local development and testing. In release builds this is provided via build-time injection, not the config file.
+
+### Database Schema Changes
+
+None.
+
+### Configuration Changes
+
+| Setting | Where | Default | Description |
+|---|---|---|---|
+| `ENABLE_TELEMETRY` | Env var / `--enable-telemetry` CLI flag | `false` | Master opt-in switch. Must be `true` to emit any data. |
+| `APPINSIGHTS_CONNECTION_STRING` | Build-time env var (CI secret) | *(injected at release build)* | Application Insights ingestion endpoint + key. Never user-facing. |
+| `AppInsightsConnectionString` | `SetupConfiguration.json` (optional) | *(empty)* | Override for local development / testing only. Ignored in release builds when the build-time value is present. |
+
+The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh)) will be updated to forward `ENABLE_TELEMETRY` and (when present) `APPINSIGHTS_CONNECTION_STRING` to the gateway via the `SetupConfiguration.json` config file, mirroring how `GatewayListenPort` and `PostgresPort` are already injected.
+
+### Testing Strategy
+
+- **Unit tests:** PII scrubbing logic (verify field names, values, and paths are not present in the serialized event payload). Query shape extraction (verify no values leak, verify stage names are correctly enumerated). Connection string parsing (whitespace, malformed strings, missing key).
+- **Integration tests:** Start the emulator with `ENABLE_TELEMETRY=false` and verify no outbound HTTP traffic to Application Insights endpoints. Start with a mock HTTP server in place of Application Insights and verify event schema matches the spec above.
+- **Regression tests:** Telemetry failures (network unavailable, bad connection string) must not crash the emulator or affect query results.
+- **PII audit:** Automated test fixture that runs a set of queries containing known sentinel values and asserts those sentinels are absent from every serialized event.
+
+### Migration Path
+
+- No migration required for existing emulator users. The `ENABLE_TELEMETRY` flag defaults to `false`; existing users who do not set it are unaffected.
+- Users who already set `ENABLE_TELEMETRY=true` (expecting future functionality) will begin receiving the telemetry pipeline with no additional configuration.
+- Backwards compatible: the flag will continue to be validated and silently ignored if telemetry is disabled.
+
+### Documentation Updates
+
+- [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh): Update the `--enable-telemetry` help text to accurately describe what data is collected and link to the privacy statement.
+- `README.md` (emulator): Add a "Telemetry" section describing opt-in behavior, what is and is not collected, and how to disable.
+- Release notes: Disclose the telemetry addition clearly in the changelog entry for the first release containing this feature.
+- Internal runbook: Document how to query the Application Insights workspace for usage and query shape reports.
+
+---
+
+## Implementation Tracking
+
+*This section SHALL be populated during the Implementation phase.*
+
+### Implementation PRs
+
+- [ ] PR #XXX: Telemetry client module in `documentdb_gateway_core` (batching, PII scrubbing, Application Insights HTTP sender)
+- [ ] PR #XXX: Wire `EmulatorStarted` / `EmulatorStopped` lifecycle events into the gateway startup/shutdown path
+- [ ] PR #XXX: Wire `QueryExecuted` events into wire protocol command handlers
+- [ ] PR #XXX: Forward `ENABLE_TELEMETRY` and connection string from `emulator_entrypoint.sh` to gateway config
+- [ ] PR #XXX: CI/CD secret injection of `APPINSIGHTS_CONNECTION_STRING` for release builds
+- [ ] PR #XXX: Documentation and README updates
+
+### Status Updates
+
+**2026-03-10:** RFC created and submitted for initial feedback.
+
+### Open Questions
+
+- [ ] **Opt-in vs. opt-out default:** Should telemetry default to `true` (opt-out) with a clear first-run disclosure banner, or remain `false` (opt-in)? Opt-out would yield significantly more data but requires legal/privacy review.
+  - Discussion: TBD
+- [ ] **Query shape granularity for `command`:** For generic `command` operations (e.g., `listCollections`, `createIndexes`, `dropDatabase`), should we emit the command name as a property (it is part of the spec, not user data) or group all under `"command"`?
+  - Discussion: TBD
+- [ ] **Duration bucket resolution:** Are five duration buckets (0–1 ms, 1–10 ms, 10–100 ms, 100–1000 ms, 1000+ ms) sufficient, or should we include sub-millisecond and multi-second finer buckets?
+  - Discussion: TBD
+- [ ] **Windows emulator support:** The emulator currently targets Linux containers. If a native Windows build is added in the future, the environment detection and build-time secret injection strategy will need re-evaluation.
+  - Discussion: TBD
+
+### Implementation Notes
+
+*Capture important decisions or learnings during implementation*
+
+- **Decision [2026-03-10]:** Use Application Insights REST ingestion API directly rather than an SDK, to avoid adding a heavy dependency to the Rust gateway. The ingestion endpoint accepts standard HTTP POST with JSON payloads and the connection string provides the endpoint URL and instrumentation key.
+  - **Context:** The Kubernetes operator used the Go Application Insights SDK; Rust has no official Microsoft SDK, so a thin HTTP client wrapper is more appropriate.
+  - **Alternatives:** `appinsights` crate (community, not officially maintained).

--- a/rfcs/0014-emulator-application-insights.md
+++ b/rfcs/0014-emulator-application-insights.md
@@ -29,16 +29,16 @@ The DocumentDB local emulator lacks structured, actionable telemetry. Without it
 
 ### Current State
 
-The emulator entrypoint already exposes a `--disable-telemetry` flag (and `USAGE_TRACKING` environment variable) in [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh), but the flag is only validated — it is never forwarded to the gateway component or used to enable any telemetry pipeline. No telemetry data is currently collected or transmitted.
+The emulator entrypoint already exposes an `--enable-telemetry` flag (and `ENABLE_TELEMETRY` environment variable) in [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh), but the flag is only validated — it is never forwarded to the gateway component or used to enable any telemetry pipeline. No telemetry data is currently collected or transmitted. This RFC proposes renaming the flag to `--disable-telemetry` (with `USAGE_TRACKING` as the environment variable) to reflect the opt-out model described below.
 
 A comparable implementation was completed for the DocumentDB Kubernetes Operator ([PR #237](https://github.com/documentdb/documentdb-kubernetes-operator/pull/237)), which integrated the Microsoft Application Insights Go SDK, wired telemetry into controllers, and exposed Helm chart configuration for the connection string. This RFC adapts that approach for the emulator context.
 
 ### Success Criteria
 
-1. By default (when `USAGE_TRACKING=true` or `--disable-telemetry` is not passed), the emulator emits structured events to Application Insights without any observable impact on functional behavior.
+1. By default (telemetry is enabled unless explicitly disabled), the emulator emits structured events to Application Insights without any observable impact on functional behavior.
 2. No personally identifiable information (PII), credentials, collection names, field names, or raw query values are ever transmitted.
 3. Telemetry captures all MongoDB operation types (find, aggregate, insert, update, delete, and all command subtypes) with a focus on operations that produce errors, without capturing actual values.
-4. Users can opt out at any time by passing `--disable-telemetry` or setting `USAGE_TRACKING=false`.
+4. Users can opt out at any time by passing `--disable-telemetry` or setting `USAGE_TRACKING=false` (proposed rename from the existing `ENABLE_TELEMETRY`).
 5. Telemetry is silently disabled if the Application Insights connection string is absent or malformed, with a single log warning — it must never crash the emulator.
 
 ---
@@ -47,7 +47,7 @@ A comparable implementation was completed for the DocumentDB Kubernetes Operator
 
 ### Proposed Solution
 
-Deploy the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as an additional component inside the emulator container, managed entirely by the existing entrypoint script. The collector hosts **two independent pipelines**:
+Deploy the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as an additional component inside the emulator container, managed entirely by the existing entrypoint script. The collector hosts **two independent pipelines** because they have fundamentally different data handling requirements — data sent to App Insights leaves the user's machine and must be PII-scrubbed, while data for the user's own debugging stays local and should retain full detail:
 
 1. **Application Insights pipeline** (PII-scrubbed) — collects gateway operation data and entrypoint lifecycle events, processes them through a scrubbing pipeline to strip all PII, and exports to Application Insights via the `azuremonitorexporter`. This is the focus of this RFC.
 2. **User observability pipeline** (no PII restrictions) — forwards gateway logs, PostgreSQL logs, and script logs to a local endpoint or stdout for the user's own debugging and monitoring. This pipeline has no PII filtering since the data never leaves the user's machine.
@@ -73,9 +73,9 @@ The emulator entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/em
 
 ### Technical Details
 
-#### OTel Collector Pipeline
+#### OTel Collector Configuration
 
-The OpenTelemetry Collector runs as a managed child component of the emulator entrypoint. Its configuration (`otelcol-config.yaml`) defines two independent pipelines:
+The OpenTelemetry Collector is a single binary that runs as a managed child component of the emulator entrypoint. Its configuration file (`otelcol-config.yaml`) defines two independent *pipelines* — a pipeline being an OTel Collector concept consisting of receivers, processors, and exporters wired together:
 
 ##### Pipeline 1: Application Insights (PII-scrubbed)
 

--- a/rfcs/0014-emulator-application-insights.md
+++ b/rfcs/0014-emulator-application-insights.md
@@ -29,16 +29,16 @@ The DocumentDB local emulator lacks structured, actionable telemetry. Without it
 
 ### Current State
 
-The emulator entrypoint already exposes an `--enable-telemetry` flag (and `ENABLE_TELEMETRY` environment variable) in [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh), but the flag is only validated — it is never forwarded to the gateway process or used to enable any telemetry pipeline. No telemetry data is currently collected or transmitted.
+The emulator entrypoint already exposes a `--disable-telemetry` flag (and `USAGE_TRACKING` environment variable) in [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh), but the flag is only validated — it is never forwarded to the gateway component or used to enable any telemetry pipeline. No telemetry data is currently collected or transmitted.
 
 A comparable implementation was completed for the DocumentDB Kubernetes Operator ([PR #237](https://github.com/documentdb/documentdb-kubernetes-operator/pull/237)), which integrated the Microsoft Application Insights Go SDK, wired telemetry into controllers, and exposed Helm chart configuration for the connection string. This RFC adapts that approach for the emulator context.
 
 ### Success Criteria
 
-1. When `--enable-telemetry true` is passed (or `ENABLE_TELEMETRY=true` is set), the emulator emits structured events to Application Insights without any observable impact on functional behavior.
+1. By default (when `USAGE_TRACKING=true` or `--disable-telemetry` is not passed), the emulator emits structured events to Application Insights without any observable impact on functional behavior.
 2. No personally identifiable information (PII), credentials, collection names, field names, or raw query values are ever transmitted.
-3. Query shape telemetry captures the *types* of operations customers run (find, aggregate, insert, update, delete, command) and the pipeline stages or operators involved, without capturing actual values.
-4. Users can opt out at any time by omitting the flag or setting `ENABLE_TELEMETRY=false` (which should remain the default).
+3. Telemetry captures all MongoDB operation types (find, aggregate, insert, update, delete, and all command subtypes) with a focus on operations that produce errors, without capturing actual values.
+4. Users can opt out at any time by passing `--disable-telemetry` or setting `USAGE_TRACKING=false`.
 5. Telemetry is silently disabled if the Application Insights connection string is absent or malformed, with a single log warning — it must never crash the emulator.
 
 ---
@@ -47,13 +47,12 @@ A comparable implementation was completed for the DocumentDB Kubernetes Operator
 
 ### Proposed Solution
 
-Deploy the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as an additional process inside the emulator container, managed entirely by the existing entrypoint script. The collector is configured to:
+Deploy the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as an additional component inside the emulator container, managed entirely by the existing entrypoint script. The collector hosts **two independent pipelines**:
 
-1. **Receive** metrics and log data from PostgreSQL via the `postgresqlreceiver` and `pg_stat_statements`, and from the gateway via its existing log output.
-2. **Process** all data through a scrubbing pipeline (`transformprocessor` / `filterprocessor`) to strip PII before any data leaves the machine.
-3. **Export** the cleaned telemetry to Application Insights via the `azuremonitorexporter`.
+1. **Application Insights pipeline** (PII-scrubbed) — collects gateway operation data and entrypoint lifecycle events, processes them through a scrubbing pipeline to strip all PII, and exports to Application Insights via the `azuremonitorexporter`. This is the focus of this RFC.
+2. **User observability pipeline** (no PII restrictions) — forwards gateway logs, PostgreSQL logs, and script logs to a local endpoint or stdout for the user's own debugging and monitoring. This pipeline has no PII filtering since the data never leaves the user's machine.
 
-No changes are made to the gateway or PostgreSQL source code. The only code changes are to the OTel Collector configuration file and the emulator entrypoint script. The Application Insights connection string is **baked into the release build** via a CI/CD secret, so users never need to supply it. Opt-in/opt-out is purely the `ENABLE_TELEMETRY` flag.
+In the first phase, no changes are made to the gateway or PostgreSQL source code. The only code changes are to the OTel Collector configuration file and the emulator entrypoint script. The Application Insights connection string is **baked into the release build** via a CI/CD secret, so users never need to supply it. Opt-in/opt-out is controlled by the `USAGE_TRACKING` environment variable (default: `true`) or the `--disable-telemetry` flag.
 
 ### Key Benefits and Tradeoffs
 
@@ -61,12 +60,12 @@ No changes are made to the gateway or PostgreSQL source code. The only code chan
 |---|---|
 | Actionable usage data with zero configuration burden on users | Requires baking a connection string into the release artifact (mitigated: read-only ingestion key, no data exfiltration risk) |
 | Consistent with Application Insights already used across the DocumentDB ecosystem | Adds the OTel Collector binary to the emulator container image (~100 MB) |
-| Opt-in by default protects privacy and builds user trust | Opt-in means lower data volume initially; consider defaulting to opt-in with clear disclosure in the future |
-| Query shape data (operators used, pipeline stages) reveals compatibility gaps | Requires careful scrubbing logic to ensure no value leakage |
+| Enabled by default maximizes data coverage and issue detection | Users must explicitly opt out; clear disclosure at first run required |
+| Tracking all Mongo operations (especially errors) reveals compatibility gaps | Requires careful scrubbing logic to ensure no value leakage |
 
 ### Alignment with Existing Architecture
 
-The emulator entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh)) already manages the full lifecycle of the PostgreSQL server and gateway process. Adding the OTel Collector as another managed child process follows the same pattern — start on launch, stop on shutdown — without any changes to the gateway or PostgreSQL source code. PostgreSQL's `pg_stat_statements` extension, which is already available in the emulator, provides the query-level statistics needed for usage telemetry.
+The emulator entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh)) already manages the full lifecycle of the PostgreSQL server and gateway component. Adding the OTel Collector as another managed child component follows the same pattern — start on launch, stop on shutdown — without any changes to the gateway or PostgreSQL source code.
 
 ---
 
@@ -76,62 +75,80 @@ The emulator entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/em
 
 #### OTel Collector Pipeline
 
-The OpenTelemetry Collector runs as a managed child process of the emulator entrypoint. Its configuration (`otelcol-config.yaml`) defines a three-stage pipeline:
+The OpenTelemetry Collector runs as a managed child component of the emulator entrypoint. Its configuration (`otelcol-config.yaml`) defines two independent pipelines:
+
+##### Pipeline 1: Application Insights (PII-scrubbed)
+
+This pipeline is the primary focus of this RFC. It collects gateway and lifecycle telemetry, scrubs all PII, and exports to Application Insights.
 
 **Receivers**
-- `postgresqlreceiver` — connects to the local PostgreSQL instance and collects metrics from `pg_stat_statements` (call counts, total execution time per normalized query fingerprint) and standard `pg_stat_*` tables (connection counts, cache hit ratios, table and index sizes).
-- `filelogreceiver` — tails the existing gateway log file for error-level events, extracting error codes and command types using regex operators. No query values are captured.
+- `filelogreceiver` (gateway logs) — tails the gateway log file, extracting MongoDB operation types, error codes, and command names using regex operators. This is the primary data source for App Insights. No query values are captured.
+- `filelogreceiver` (entrypoint lifecycle) — reads structured lifecycle events (`EmulatorStarted`, `EmulatorStopped`, `InitDataLoaded`) emitted by the entrypoint script to a dedicated log file.
+- `filelogreceiver` (PostgreSQL logs) — tails PostgreSQL log files to capture crash reports and fatal errors for reliability tracking.
 
 **Processors**
-- `transformprocessor` — normalizes query fingerprints produced by `pg_stat_statements` (which already strips literal values) into a bucketed operation type (`find`, `aggregate`, `insert`, `update`, `delete`, `command`) and extracts pipeline stage names for aggregate queries.
+- `transformprocessor` — normalizes gateway log entries into a bucketed MongoDB operation type (`find`, `aggregate`, `insert`, `update`, `delete`, `getMore`, `listCollections`, `createIndexes`, `dropDatabase`, and all other command subtypes) and extracts pipeline stage names for aggregate queries.
 - `filterprocessor` — drops any attribute whose key or value matches a blocklist of known PII patterns (collection names, usernames, hostnames, IP addresses, file paths).
-- `resourceprocessor` — attaches static resource attributes: `emulator.version`, `environment` tag, and a per-run `session.id` (random UUID generated by the entrypoint script and passed via env var).
+- `resourceprocessor` — attaches static resource attributes: `emulator.version`, `environment` tag, and `container.id` (the Docker container ID, read from `$HOSTNAME`).
 - `batchprocessor` — batches up to 100 data points or flushes every 30 seconds before export.
 
 **Exporter**
 - `azuremonitorexporter` — sends processed telemetry to Application Insights. The connection string is provided via the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable, injected from a CI/CD secret at release build time and forwarded by the entrypoint script.
 
-#### Session Correlation
+##### Pipeline 2: User Observability (no PII restrictions)
 
-The entrypoint script generates a random UUID at startup (`SESSION_ID=$(uuidgen)`) and passes it to the OTel Collector as an environment variable. The `resourceprocessor` attaches it as a resource attribute on every exported data point. This correlates events within a single emulator run without identifying the user across runs. The value is never written to disk.
+This pipeline forwards all logs to the user's local environment for debugging. Since data never leaves the user's machine, no PII filtering is applied.
+
+**Receivers**
+- `filelogreceiver` — tails gateway logs, PostgreSQL logs, and entrypoint script logs.
+
+**Processors**
+- `resourceprocessor` — attaches `emulator.version` and `container.id` for context.
+
+**Exporter**
+- Logs are written to stdout / a local log file. In the future, this pipeline can be extended to support user-configured OTLP endpoints.
+
+#### Container Correlation
+
+The entrypoint script reads the Docker container ID from the `$HOSTNAME` environment variable (which Docker sets to the container's short ID by default) and passes it to the OTel Collector as `CONTAINER_ID`. The `resourceprocessor` attaches it as the `container.id` resource attribute on every exported data point. This correlates events within a single container instance. The container ID changes on every `docker run`, so it does not track users across separate container invocations.
 
 #### PII Scrubbing
 
-The `filterprocessor` and `transformprocessor` enforce the following rules:
+The `filterprocessor` and `transformprocessor` in the App Insights pipeline enforce the following rules:
 
 - **Never included:** raw query text, literal values, database names, collection names, field names, index names, usernames, hostnames, IP addresses, file paths.
-- **Safe to include:** emulator version, OS family, environment tag (`docker` / `codespaces` / `ci` / `bare-metal` / `unknown`), normalized operation type, pipeline stage names (MongoDB spec names, not user data), error code integers, duration histograms, `pg_stat_statements` query fingerprint hash (integer `queryid`, not text).
+- **Safe to include:** emulator version, OS family, environment tag (`docker` / `codespaces` / `ci` / `bare-metal` / `unknown`), normalized MongoDB operation type (e.g., `find`, `aggregate`, `createIndexes`), pipeline stage names (MongoDB spec names, not user data), error code integers, duration histograms, container ID.
 
-`pg_stat_statements` already normalizes queries by replacing literal values with `$1`, `$2`, … placeholders before computing the `queryid` hash, so literal values never enter the OTel pipeline.
+These rules apply **only to the App Insights pipeline**. The user observability pipeline has no PII restrictions since all data stays on the user's machine.
 
 #### Metrics and Events Collected
 
-**Query usage metrics** (sourced from `pg_stat_statements`, aggregated per flush interval):
+**MongoDB operation metrics** (sourced from gateway logs, aggregated per flush interval):
 
 | Metric | Type | Description |
 |---|---|---|
-| `documentdb.query.calls` | Counter | Number of executions per operation type |
-| `documentdb.query.duration` | Histogram | Execution time distribution per operation type |
-| `documentdb.query.errors` | Counter | Failed executions per error code |
+| `documentdb.operation.count` | Counter | Number of executions per MongoDB operation type (find, aggregate, insert, update, delete, getMore, listCollections, createIndexes, etc.) |
+| `documentdb.operation.duration` | Histogram | Execution time distribution per operation type |
+| `documentdb.operation.errors` | Counter | Failed operations per error code and operation type — **primary signal for compatibility gap detection** |
+| `documentdb.operation.error_ratio` | Gauge | Ratio of failed to total operations per type, for alerting |
 
-**Resource metrics** (sourced from `pg_stat_*` tables):
-
-| Metric | Type | Description |
-|---|---|---|
-| `documentdb.connections.active` | Gauge | Active client connections |
-| `documentdb.cache.hit_ratio` | Gauge | Buffer cache hit ratio |
-
-**Lifecycle events** (emitted by the entrypoint script to a log file read by `filelogreceiver`):
+**Lifecycle events** (emitted by the entrypoint script to a dedicated log file read by `filelogreceiver`):
 
 | Event | When Emitted | Key Attributes |
 |---|---|---|
-| `EmulatorStarted` | Gateway ready to accept connections | `emulator_version`, `session_id`, `environment`, `tls_enabled`, `extended_rum_enabled` |
-| `EmulatorStopped` | Graceful shutdown signal received | `session_id`, `uptime_seconds` |
-| `InitDataLoaded` | Sample or custom init data loaded | `session_id`, `data_source` (`sample` / `custom`) |
+| `EmulatorStarted` | Gateway ready to accept connections | `emulator_version`, `container_id`, `environment`, `tls_enabled`, `extended_rum_enabled` |
+| `EmulatorStopped` | Graceful shutdown signal received | `container_id`, `uptime_seconds` |
+| `InitDataLoaded` | Sample or custom init data loaded | `container_id`, `data_source` (`sample` / `custom`) |
+
+**PostgreSQL crash reports** (sourced from PostgreSQL log files, optional):
+
+| Event | When Emitted | Key Attributes |
+|---|---|---|
+| `PostgresFatalError` | PostgreSQL emits a FATAL or PANIC log entry | `container_id`, `error_code`, `error_severity` |
 
 ### API Changes
 
-No public-facing API changes and no changes to the gateway or PostgreSQL source code. The `--enable-telemetry` flag and `ENABLE_TELEMETRY` environment variable already exist in the entrypoint; this RFC gives them a real implementation by starting and stopping the OTel Collector process.
+No public-facing API changes and no changes to the gateway or PostgreSQL source code. The `--disable-telemetry` flag and `USAGE_TRACKING` environment variable replace the existing `--enable-telemetry` / `ENABLE_TELEMETRY` in the entrypoint; this RFC gives them a real implementation by starting and stopping the OTel Collector component.
 
 ### Database Schema Changes
 
@@ -141,32 +158,32 @@ None.
 
 | Setting | Where | Default | Description |
 |---|---|---|---|
-| `ENABLE_TELEMETRY` | Env var / `--enable-telemetry` CLI flag | `false` | Master opt-in switch. Must be `true` to start the OTel Collector. |
+| `USAGE_TRACKING` | Env var / `--disable-telemetry` CLI flag | `true` | Master switch for Application Insights telemetry. Set to `false` or pass `--disable-telemetry` to opt out. |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | Build-time env var (CI secret) | *(injected at release build)* | Application Insights ingestion endpoint + key. Never user-facing. |
-| `SESSION_ID` | Generated by entrypoint at startup | *(random UUID per run)* | Passed to the OTel Collector as a resource attribute for session correlation. |
+| `CONTAINER_ID` | Read from `$HOSTNAME` at startup | *(Docker container short ID)* | Passed to the OTel Collector as the `container.id` resource attribute. |
 
 The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh)) will be updated to:
-1. Generate `SESSION_ID` via `uuidgen` at startup.
-2. If `ENABLE_TELEMETRY=true`, start the OTel Collector as a background process with `otelcol-config.yaml` and the above env vars.
+1. Read `CONTAINER_ID` from `$HOSTNAME` at startup.
+2. Unless `--disable-telemetry` is passed or `USAGE_TRACKING=false`, start the OTel Collector as a background component with `otelcol-config.yaml` and the above env vars.
 3. On shutdown (in the existing `cleanup` function), send `SIGTERM` to the OTel Collector and wait up to 5 seconds for it to flush.
 
 ### Testing Strategy
 
 - **OTel Collector config validation:** Use `otelcol validate --config otelcol-config.yaml` in CI to catch configuration errors before they reach users.
-- **Integration tests:** Start the emulator with `ENABLE_TELEMETRY=false` and verify the OTel Collector process is not spawned and no outbound HTTP traffic is produced. Start with `ENABLE_TELEMETRY=true` and a mock OTLP receiver in place of Application Insights; verify that exported metric names and attributes match the spec above.
+- **Integration tests:** Start the emulator with `USAGE_TRACKING=false` and verify the OTel Collector component is not spawned and no outbound HTTP traffic is produced. Start with `USAGE_TRACKING=true` (the default) and a mock OTLP receiver in place of Application Insights; verify that exported metric names and attributes match the spec above.
 - **PII audit:** Automated test that runs a set of queries containing known sentinel string values and asserts those sentinels are absent from every metric attribute exported by the OTel Collector (inspected via the mock OTLP receiver).
 - **Resilience tests:** Verify that if the OTel Collector crashes or the Application Insights endpoint is unreachable, the emulator continues serving queries without error.
 
 ### Migration Path
 
-- No migration required for existing emulator users. The `ENABLE_TELEMETRY` flag defaults to `false`; existing users who do not set it are unaffected.
-- Users who already set `ENABLE_TELEMETRY=true` (expecting future functionality) will begin receiving the telemetry pipeline with no additional configuration.
-- Backwards compatible: the flag will continue to be validated and silently ignored if telemetry is disabled.
+- Telemetry is enabled by default (`USAGE_TRACKING=true`). Existing users who previously set `ENABLE_TELEMETRY=true` should migrate to `USAGE_TRACKING=true` (or simply remove the setting, since `true` is now the default).
+- Users who previously set `ENABLE_TELEMETRY=false` should migrate to `USAGE_TRACKING=false` or pass `--disable-telemetry`.
+- The old `ENABLE_TELEMETRY` variable and `--enable-telemetry` flag will be accepted as deprecated aliases for one release cycle, with a deprecation warning logged at startup.
 
 ### Documentation Updates
 
-- [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh): Update the `--enable-telemetry` help text to accurately describe what data is collected and link to the privacy statement.
-- `README.md` (emulator): Add a "Telemetry" section describing opt-in behavior, what is and is not collected, and how to disable.
+- [`scripts/emulator_entrypoint.sh`](../scripts/emulator_entrypoint.sh): Replace `--enable-telemetry` with `--disable-telemetry`, update help text to describe what data is collected, and link to the privacy statement.
+- `README.md` (emulator): Add a "Telemetry" section describing that usage tracking is enabled by default, what is and is not collected, and how to disable via `--disable-telemetry` or `USAGE_TRACKING=false`.
 - Release notes: Disclose the telemetry addition clearly in the changelog entry for the first release containing this feature.
 - Internal runbook: Document how to query the Application Insights workspace for usage and query shape reports.
 
@@ -178,8 +195,8 @@ The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_en
 
 ### Implementation PRs
 
-- [ ] PR #XXX: Add `otelcol-config.yaml` (OTel Collector pipeline: `postgresqlreceiver`, `filelogreceiver`, processors, `azuremonitorexporter`)
-- [ ] PR #XXX: Update `scripts/emulator_entrypoint.sh` to generate `SESSION_ID`, start/stop the OTel Collector process, and emit lifecycle log events
+- [ ] PR #XXX: Add `otelcol-config.yaml` (OTel Collector dual pipeline: App Insights with `filelogreceiver`, processors, `azuremonitorexporter`; user observability with local log output)
+- [ ] PR #XXX: Update `scripts/emulator_entrypoint.sh` to read `CONTAINER_ID` from `$HOSTNAME`, start/stop the OTel Collector component, and emit lifecycle log events
 - [ ] PR #XXX: CI/CD secret injection of `APPLICATIONINSIGHTS_CONNECTION_STRING` for release builds and inclusion of the OTel Collector binary in the container image
 - [ ] PR #XXX: Documentation and README updates
 
@@ -189,13 +206,11 @@ The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_en
 
 ### Open Questions
 
-- [ ] **Opt-in vs. opt-out default:** Should telemetry default to `true` (opt-out) with a clear first-run disclosure banner, or remain `false` (opt-in)? Opt-out would yield significantly more data but requires legal/privacy review.
-  - Discussion: TBD
-- [ ] **Query shape granularity for `command`:** For generic `command` operations (e.g., `listCollections`, `createIndexes`, `dropDatabase`), should we emit the command name as a property (it is part of the spec, not user data) or group all under `"command"`?
-  - Discussion: TBD
+- [x] **Opt-in vs. opt-out default:** ~~Should telemetry default to `true` (opt-out) or remain `false` (opt-in)?~~
+  - **Resolved:** Telemetry defaults to `true`. Users opt out via `--disable-telemetry` or `USAGE_TRACKING=false`.
+- [x] **Query shape granularity for `command`:** ~~Should we emit individual command names or group all under `"command"`?~~
+  - **Resolved:** Emit individual command subtypes (`listCollections`, `createIndexes`, `dropDatabase`, etc.) since these are MongoDB spec names, not user data.
 - [ ] **Duration bucket resolution:** Are five duration buckets (0–1 ms, 1–10 ms, 10–100 ms, 100–1000 ms, 1000+ ms) sufficient, or should we include sub-millisecond and multi-second finer buckets?
-  - Discussion: TBD
-- [ ] **Windows emulator support:** The emulator currently targets Linux containers. If a native Windows build is added in the future, the environment detection and build-time secret injection strategy will need re-evaluation.
   - Discussion: TBD
 
 ### Implementation Notes
@@ -203,5 +218,11 @@ The entrypoint script ([`scripts/emulator_entrypoint.sh`](../scripts/emulator_en
 *Capture important decisions or learnings during implementation*
 
 - **Decision [2026-03-10]:** Use the OpenTelemetry Collector rather than embedding a telemetry SDK in the gateway, so that zero changes are needed to the gateway or PostgreSQL source code.
-  - **Context:** The Kubernetes operator embedded the Go Application Insights SDK directly in the controller binary. For the emulator, the OTel Collector provides equivalent functionality as a standalone process, keeps the gateway source clean, and allows the telemetry pipeline to be updated by changing a YAML configuration file rather than recompiling the gateway.
+  - **Context:** The Kubernetes operator embedded the Go Application Insights SDK directly in the controller binary. For the emulator, the OTel Collector provides equivalent functionality as a standalone component, keeps the gateway source clean, and allows the telemetry pipeline to be updated by changing a YAML configuration file rather than recompiling the gateway.
   - **Alternatives:** Embedding the `opentelemetry` Rust crate or a custom Application Insights HTTP client in the gateway — rejected to avoid gateway source changes.
+- **Decision [2026-03-16]:** Telemetry defaults to enabled (`USAGE_TRACKING=true`), with `--disable-telemetry` flag for opt-out.
+  - **Context:** Per reviewer feedback, maximizing data coverage is critical for detecting compatibility gaps. The env var was renamed from `ENABLE_TELEMETRY` to `USAGE_TRACKING` to avoid overloading the term "telemetry" (which could be confused with OTel observability in general).
+- **Decision [2026-03-16]:** Use Docker container ID (`$HOSTNAME`) instead of a random UUID for session correlation.
+  - **Context:** The container ID is already unique per `docker run` invocation and is more useful for debugging than a random UUID. It does not persist across container restarts.
+- **Decision [2026-03-16]:** The OTel Collector hosts two independent pipelines — one for App Insights (PII-scrubbed) and one for user observability (no PII restrictions, local only).
+  - **Context:** Separating pipelines ensures PII scrubbing logic only applies to data leaving the machine, while users retain full visibility into their emulator's behavior for debugging.

--- a/rfcs/0014-emulator-application-insights.md
+++ b/rfcs/0014-emulator-application-insights.md
@@ -1,5 +1,5 @@
 ---
-rfc: 0006
+rfc: 0014
 title: "Application Insights Telemetry for DocumentDB Local Emulator"
 status: Draft
 owner: "@Ritvik-Jayaswal"
@@ -10,7 +10,7 @@ implementations:
   - "https://github.com/documentdb/documentdb/pull/XXX"
 ---
 
-# RFC-0006: Application Insights Telemetry for DocumentDB Local Emulator
+# RFC-0014: Application Insights Telemetry for DocumentDB Local Emulator
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Adds RFC-0014 proposing Application Insights telemetry integration for the DocumentDB local emulator.

## Changes

- `rfcs/0014-emulator-application-insights.md` — new RFC covering:
  - Opt-out telemetry via the `--disable-telemetry` flag (currently a no-op)
  - `EmulatorStarted`, `EmulatorStopped`, and `QueryExecuted` lifecycle/query-shape events
  - Strict PII scrubbing (no collection names, field names, query values, or credentials ever transmitted)
  - Build-time CI secret injection for the Application Insights connection string

## Why 
The DocumentDB local emulator has no telemetry today. The --enable-telemetry flag in the entrypoint is a no-op — it validates the input but never sends any data. This means the team has zero visibility into which features users exercise, what query patterns they run, or where they hit errors/incompatibilities.

## What
This RFC proposes adding an OpenTelemetry Collector as an additional component inside the emulator container. It collects gateway operation types and error codes from log files (no code changes to the gateway), scrubs all PII, and exports to Application Insights. Users can opt out via --disable-telemetry.

## Related

- Similar implementation in the Kubernetes operator: https://github.com/documentdb/documentdb-kubernetes-operator/pull/237