### PR TITLE
feat(gateway): Pluggable Authentication Architecture Phase 1 (RFC-0009)

### DIFF
--- a/pg_documentdb_gw/documentdb_gateway/src/main.rs
+++ b/pg_documentdb_gw/documentdb_gateway/src/main.rs
@@ -97,7 +97,8 @@ async fn start_gateway(setup_configuration: DocumentDBSetupConfiguration) {
         dynamic_configuration,
         connection_pool_manager,
         tls_provider,
-    );
+    )
+    .await;
 
     run_gateway::<DocumentDBDataClient>(service_context, None, shutdown_token)
         .await

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth/handler.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth/handler.rs
@@ -1,0 +1,201 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * documentdb_gateway_core/src/auth/handler.rs
+ *
+ * Registry-based auth handler. Routes SASL requests to the correct
+ * provider via the AuthProviderRegistry.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+use bson::rawdoc;
+
+use crate::{
+    auth_legacy::AuthState,
+    context::ConnectionContext,
+    error::{DocumentDBError, Result},
+    protocol::OK_SUCCEEDED,
+    requests::{Request, RequestType},
+    responses::{RawResponse, Response},
+};
+
+/// Top-level entry point for registry-based authentication.
+/// Routes SaslStart, SaslContinue, and Logout requests.
+pub async fn handle_auth_request(
+    connection_context: &mut ConnectionContext,
+    request: &Request<'_>,
+) -> Result<Option<Response>> {
+    match request.request_type() {
+        RequestType::SaslStart => {
+            Ok(Some(handle_sasl_start(connection_context, request).await?))
+        }
+        RequestType::SaslContinue => {
+            Ok(Some(handle_sasl_continue(connection_context, request).await?))
+        }
+        RequestType::Logout => {
+            handle_logout(connection_context).await;
+            Ok(Some(Response::Raw(RawResponse(rawdoc! {
+                "ok": OK_SUCCEEDED,
+            }))))
+        }
+        _ => Ok(None),
+    }
+}
+
+async fn handle_sasl_start(
+    connection_context: &mut ConnectionContext,
+    request: &Request<'_>,
+) -> Result<Response> {
+    let mechanism = request
+        .document()
+        .get_str("mechanism")
+        .map_err(DocumentDBError::parse_failure())?;
+
+    let registry = connection_context
+        .service_context
+        .auth_provider_registry()
+        .ok_or_else(|| {
+            DocumentDBError::internal_error(
+                "Auth provider registry is not initialized".to_string(),
+            )
+        })?;
+
+    let provider = registry.get_provider(mechanism)?;
+
+    connection_context
+        .auth_state
+        .set_active_mechanism(mechanism);
+
+    let result = provider
+        .handle_sasl_start(connection_context, request)
+        .await;
+
+    log_auth_event(connection_context, mechanism, &result);
+
+    result
+}
+
+async fn handle_sasl_continue(
+    connection_context: &mut ConnectionContext,
+    request: &Request<'_>,
+) -> Result<Response> {
+    let mechanism = connection_context
+        .auth_state
+        .active_mechanism()
+        .ok_or_else(|| {
+            DocumentDBError::authentication_failed(
+                "SaslContinue called without a prior SaslStart".to_string(),
+            )
+        })?
+        .to_string();
+
+    let registry = connection_context
+        .service_context
+        .auth_provider_registry()
+        .ok_or_else(|| {
+            DocumentDBError::internal_error(
+                "Auth provider registry is not initialized".to_string(),
+            )
+        })?;
+
+    let provider = registry.get_provider(&mechanism)?;
+
+    let result = provider
+        .handle_sasl_continue(connection_context, request)
+        .await;
+
+    log_auth_event(connection_context, &mechanism, &result);
+
+    result
+}
+
+async fn handle_logout(connection_context: &mut ConnectionContext) {
+    // Notify the active provider so it can clean up per-connection resources.
+    if let Some(mechanism) = connection_context.auth_state.active_mechanism() {
+        if let Some(registry) = connection_context.service_context.auth_provider_registry() {
+            if let Ok(provider) = registry.get_provider(mechanism) {
+                if let Err(e) = provider.on_connection_close(connection_context).await {
+                    tracing::warn!(
+                        activity_id = connection_context.connection_id.to_string().as_str(),
+                        "on_connection_close failed during logout for provider '{mechanism}': {e}"
+                    );
+                }
+            }
+        }
+    }
+
+    connection_context.auth_state = AuthState::new();
+}
+
+fn log_auth_event(
+    connection_context: &ConnectionContext,
+    mechanism: &str,
+    result: &Result<Response>,
+) {
+    let outcome = if result.is_ok() { "success" } else { "failure" };
+    let username = connection_context.auth_state.username().ok();
+
+    tracing::info!(
+        activity_id = connection_context.connection_id.to_string().as_str(),
+        user = username,
+        mechanism = mechanism,
+        outcome = outcome,
+        ip = connection_context.ip_address.as_str(),
+        "Authentication event"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth_legacy::AuthState;
+
+    #[test]
+    fn active_mechanism_initially_none() {
+        let state = AuthState::new();
+        assert!(state.active_mechanism().is_none());
+    }
+
+    #[test]
+    fn set_active_mechanism_stores_value() {
+        let mut state = AuthState::new();
+        state.set_active_mechanism("SCRAM-SHA-256");
+        assert_eq!(state.active_mechanism(), Some("SCRAM-SHA-256"));
+    }
+
+    #[test]
+    fn set_active_mechanism_can_be_overwritten() {
+        let mut state = AuthState::new();
+        state.set_active_mechanism("SCRAM-SHA-256");
+        state.set_active_mechanism("MONGODB-OIDC");
+        assert_eq!(state.active_mechanism(), Some("MONGODB-OIDC"));
+    }
+
+    #[test]
+    fn logout_resets_active_mechanism() {
+        let mut state = AuthState::new();
+        state.set_active_mechanism("SCRAM-SHA-256");
+        state = AuthState::new();
+        assert!(state.active_mechanism().is_none());
+    }
+
+    #[test]
+    fn new_auth_state_has_no_username() {
+        let state = AuthState::new();
+        assert!(state.username().is_err());
+    }
+
+    #[test]
+    fn connection_close_resets_all_auth_state() {
+        let mut state = AuthState::new();
+        state.set_active_mechanism("SCRAM-SHA-256");
+        state.set_username("testuser");
+        state.user_oid = Some(42);
+
+        state = AuthState::new();
+
+        assert!(state.active_mechanism().is_none());
+        assert!(state.username().is_err());
+        assert!(state.user_oid.is_none());
+    }
+}

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth/mod.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth/mod.rs
@@ -1,0 +1,62 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * documentdb_gateway_core/src/auth/mod.rs
+ *
+ * Pluggable authentication module. Declares submodules for the trait-based,
+ * registry-driven authentication architecture and re-exports legacy types
+ * so that existing code continues to compile unchanged.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+pub mod handler;
+pub mod oidc_provider;
+pub mod provider;
+pub mod registry;
+pub mod scram_provider;
+
+// Re-export the core pluggable auth types for convenient access.
+pub use provider::{AuthProvider, ProviderConfig};
+pub use registry::AuthProviderRegistry;
+
+// Re-export legacy types and functions so that existing `crate::auth::*`
+// imports keep working.
+pub use crate::auth_legacy::{process, AuthKind, AuthState, ScramFirstState};
+
+// ---------------------------------------------------------------------------
+// Shared auth utilities
+// ---------------------------------------------------------------------------
+
+use tokio_postgres::types::Type;
+
+use crate::{
+    context::ConnectionContext,
+    error::{DocumentDBError, Result},
+    requests::request_tracker::RequestTracker,
+};
+
+/// Look up the PostgreSQL role OID for a given username.
+/// Used by both ScramProvider and OidcProvider after successful authentication.
+pub async fn get_user_oid(connection_context: &ConnectionContext, username: &str) -> Result<u32> {
+    let user_oid_rows = connection_context
+        .service_context
+        .connection_pool_manager()
+        .authentication_connection()
+        .await?
+        .query(
+            "SELECT oid from pg_roles WHERE rolname = $1",
+            &[Type::TEXT],
+            &[&username],
+            None,
+            &RequestTracker::new(),
+        )
+        .await?;
+
+    let user_oid = user_oid_rows
+        .first()
+        .ok_or(DocumentDBError::pg_response_empty())?
+        .try_get::<_, tokio_postgres::types::Oid>(0)?;
+
+    Ok(user_oid)
+}

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth/oidc_provider.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth/oidc_provider.rs
@@ -1,0 +1,429 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * documentdb_gateway_core/src/auth/oidc_provider.rs
+ *
+ * OidcProvider — MONGODB-OIDC authentication provider.
+ * Extracted from the monolithic auth handler.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine as _};
+use bson::{rawdoc, spec::BinarySubtype};
+use serde_json::Value;
+use tokio::time::Duration;
+use tokio_postgres::{error::SqlState, types::Type};
+
+use crate::{
+    auth::provider::{AuthProvider, ProviderConfig},
+    auth::get_user_oid,
+    auth_legacy::AuthKind,
+    context::ConnectionContext,
+    error::{DocumentDBError, ErrorCode, Result},
+    protocol::OK_SUCCEEDED,
+    requests::{request_tracker::RequestTracker, Request},
+    responses::{PgResponse, RawResponse, Response},
+};
+
+pub struct OidcProvider {
+    config: Option<ProviderConfig>,
+}
+
+impl OidcProvider {
+    pub fn new() -> Self {
+        OidcProvider { config: None }
+    }
+}
+
+impl Default for OidcProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AuthProvider for OidcProvider {
+    fn mechanism_name(&self) -> &str {
+        "MONGODB-OIDC"
+    }
+
+    fn supports_continue(&self) -> bool {
+        false
+    }
+
+    async fn handle_sasl_start(
+        &self,
+        connection_context: &mut ConnectionContext,
+        request: &Request<'_>,
+    ) -> Result<Response> {
+        let payload = request
+            .document()
+            .get_binary("payload")
+            .map_err(DocumentDBError::parse_failure())?;
+
+        let payload_doc =
+            bson::Document::from_reader(&mut std::io::Cursor::new(payload.bytes)).map_err(
+                |e| {
+                    DocumentDBError::bad_value(format!(
+                        "MONGODB-OIDC: Failed to parse OIDC payload as BSON: {e}"
+                    ))
+                },
+            )?;
+
+        let jwt_token = payload_doc.get_str("jwt").map_err(|_| {
+            DocumentDBError::authentication_failed(
+                "MONGODB-OIDC: JWT token missing from OIDC payload".to_string(),
+            )
+        })?;
+
+        handle_oidc_token_authentication(connection_context, jwt_token).await
+    }
+
+    async fn handle_sasl_continue(
+        &self,
+        _connection_context: &mut ConnectionContext,
+        _request: &Request<'_>,
+    ) -> Result<Response> {
+        Err(DocumentDBError::authentication_failed(
+            "MONGODB-OIDC: saslContinue is not supported for OIDC authentication".to_string(),
+        ))
+    }
+
+    async fn initialize(&mut self, config: &ProviderConfig) -> Result<()> {
+        self.config = Some(config.clone());
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+async fn handle_oidc_token_authentication(
+    connection_context: &mut ConnectionContext,
+    token_string: &str,
+) -> Result<Response> {
+    let (oid, seconds_until_expiry) = parse_and_validate_jwt_token(token_string)?;
+
+    let connection = connection_context
+        .service_context
+        .connection_pool_manager()
+        .authentication_connection()
+        .await?;
+
+    let authentication_token_row = match connection
+        .query(
+            connection_context
+                .service_context
+                .query_catalog()
+                .authenticate_with_token(),
+            &[Type::TEXT, Type::TEXT],
+            &[&oid, &token_string],
+            None,
+            &RequestTracker::new(),
+        )
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            match e {
+                DocumentDBError::PostgresError(pge_error, _) => match pge_error.as_db_error() {
+                    Some(db_error) => {
+                        tracing::error!(
+                            activity_id = connection_context.connection_id.to_string().as_str(),
+                            "MONGODB-OIDC: Backend error during authentication: PostgresError({:?}, {:?})",
+                            db_error.code(),
+                            db_error.hint()
+                        );
+
+                        if let Some((extension_error_code, _)) =
+                            PgResponse::from_known_external_error_code(db_error.code())
+                        {
+                            if extension_error_code == ErrorCode::CommandNotSupported as i32 {
+                                return Err(DocumentDBError::authentication_failed(
+                                    "MONGODB-OIDC: The authentication mechanism provided is not supported in the service.".to_string(),
+                                ));
+                            }
+                        }
+
+                        return match *db_error.code() {
+                            SqlState::INVALID_PASSWORD => {
+                                Err(DocumentDBError::authentication_failed(
+                                    "MONGODB-OIDC: The token provided is not valid.".to_string(),
+                                ))
+                            }
+                            SqlState::UNDEFINED_OBJECT => {
+                                Err(DocumentDBError::authentication_failed(
+                                    "MONGODB-OIDC: External identity is not present in the system."
+                                        .to_string(),
+                                ))
+                            }
+                            _ => Err(DocumentDBError::authentication_failed(
+                                "MONGODB-OIDC: Internal Error.".to_string(),
+                            )),
+                        };
+                    }
+                    None => {
+                        tracing::error!(
+                            activity_id = connection_context.connection_id.to_string().as_str(),
+                            "MONGODB-OIDC: DbError not found in PostgresError, which is unexpected."
+                        );
+                        return Err(DocumentDBError::authentication_failed(
+                            "MONGODB-OIDC: Internal Error.".to_string(),
+                        ));
+                    }
+                },
+                _ => return Err(e),
+            }
+        }
+    };
+
+    let authentication_result: String = authentication_token_row
+        .first()
+        .ok_or(DocumentDBError::pg_response_empty())?
+        .try_get(0)?;
+
+    if authentication_result.trim() != oid {
+        return Err(DocumentDBError::authentication_failed(
+            "MONGODB-OIDC: Token validation failed".to_string(),
+        ));
+    }
+
+    let server_signature = "";
+    let payload = bson::Binary {
+        subtype: BinarySubtype::Generic,
+        bytes: server_signature.as_bytes().to_vec(),
+    };
+
+    connection_context.auth_state.set_username(&oid);
+    connection_context.auth_state.user_oid =
+        Some(get_user_oid(connection_context, &oid).await?);
+
+    *connection_context.auth_state.is_authorized().write().await = true;
+    connection_context
+        .auth_state
+        .set_auth_kind(AuthKind::ExternalIdentity)?;
+
+    connection_context.allocate_data_pool(token_string)?;
+
+    let connection_activity_id = connection_context.connection_id.to_string();
+    let connection_activity_id_as_str = connection_activity_id.as_str();
+    tracing::info!(
+        activity_id = connection_activity_id_as_str,
+        "MONGODB-OIDC: Setting authentication expiry timer for {seconds_until_expiry} seconds until token expiry.",
+    );
+    connection_context
+        .auth_state
+        .initialize_expiry_timer(seconds_until_expiry, connection_activity_id_as_str)
+        .await?;
+
+    Ok(Response::Raw(RawResponse(rawdoc! {
+        "payload": payload,
+        "ok": OK_SUCCEEDED,
+        "conversationId": 1,
+        "done": true
+    })))
+}
+
+fn parse_and_validate_jwt_token(token_string: &str) -> Result<(String, u64)> {
+    let token_parts: Vec<&str> = token_string.split('.').collect();
+    if token_parts.len() != 3 {
+        return Err(DocumentDBError::authentication_failed(
+            "MONGODB-OIDC: Invalid JWT token format.".to_string(),
+        ));
+    }
+
+    let payload_part = token_parts[1];
+    let payload_bytes = general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_part)
+        .map_err(|_| {
+            DocumentDBError::authentication_failed(
+                "MONGODB-OIDC: Invalid JWT token encoding.".to_string(),
+            )
+        })?;
+
+    let payload_json: Value = serde_json::from_slice(&payload_bytes).map_err(|_| {
+        DocumentDBError::authentication_failed(
+            "MONGODB-OIDC: Invalid JWT token payload.".to_string(),
+        )
+    })?;
+
+    let oid = payload_json
+        .get("oid")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            DocumentDBError::authentication_failed(
+                "MONGODB-OIDC: Token does not contain OID.".to_string(),
+            )
+        })?
+        .to_string();
+
+    let aud = payload_json
+        .get("aud")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            DocumentDBError::authentication_failed(
+                "MONGODB-OIDC: Token does not contain audience claim.".to_string(),
+            )
+        })?
+        .to_string();
+
+    let exp = payload_json
+        .get("exp")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| {
+            DocumentDBError::authentication_failed(
+                "MONGODB-OIDC: Token does not contain expiry time.".to_string(),
+            )
+        })?;
+
+    let valid_audiences = ["https://ossrdbms-aad.database.windows.net"];
+    if !valid_audiences.contains(&aud.as_str()) {
+        return Err(DocumentDBError::authentication_failed(
+            "MONGODB-OIDC: The audience claim provided in the token is not valid.".to_string(),
+        ));
+    }
+
+    let exp_datetime = std::time::UNIX_EPOCH + std::time::Duration::from_secs(exp as u64);
+    let now = std::time::SystemTime::now();
+
+    if exp_datetime < now {
+        return Err(DocumentDBError::authentication_failed(
+            "MONGODB-OIDC: The token provided is expired.".to_string(),
+        ));
+    }
+
+    let timeout_seconds = exp_datetime
+        .duration_since(now)
+        .unwrap_or(Duration::from_secs(0))
+        .as_secs();
+
+    Ok((oid, timeout_seconds))
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::provider::{AuthProvider, ProviderConfig};
+    use base64::engine::general_purpose;
+
+    fn make_jwt(payload_json: &str) -> String {
+        let header = general_purpose::URL_SAFE_NO_PAD.encode(r#"{"alg":"RS256","typ":"JWT"}"#);
+        let payload = general_purpose::URL_SAFE_NO_PAD.encode(payload_json);
+        let signature = general_purpose::URL_SAFE_NO_PAD.encode("fake-signature");
+        format!("{header}.{payload}.{signature}")
+    }
+
+    #[test]
+    fn mechanism_name_returns_mongodb_oidc() {
+        assert_eq!(OidcProvider::new().mechanism_name(), "MONGODB-OIDC");
+    }
+
+    #[test]
+    fn supports_continue_returns_false() {
+        assert!(!OidcProvider::new().supports_continue());
+    }
+
+    #[tokio::test]
+    async fn initialize_stores_config() {
+        let mut provider = OidcProvider::new();
+        assert!(provider.config.is_none());
+        provider.initialize(&ProviderConfig::default()).await.unwrap();
+        assert!(provider.config.is_some());
+    }
+
+    #[test]
+    fn jwt_invalid_format_not_three_parts() {
+        assert!(parse_and_validate_jwt_token("only.two").is_err());
+    }
+
+    #[test]
+    fn jwt_invalid_format_single_string() {
+        assert!(parse_and_validate_jwt_token("notajwt").is_err());
+    }
+
+    #[test]
+    fn jwt_invalid_base64_payload() {
+        assert!(parse_and_validate_jwt_token("header.!!!invalid!!!.sig").is_err());
+    }
+
+    #[test]
+    fn jwt_invalid_json_payload() {
+        let bad = general_purpose::URL_SAFE_NO_PAD.encode("not json");
+        assert!(parse_and_validate_jwt_token(&format!("h.{bad}.s")).is_err());
+    }
+
+    #[test]
+    fn jwt_missing_oid() {
+        let token = make_jwt(r#"{"aud":"https://ossrdbms-aad.database.windows.net","exp":9999999999}"#);
+        let err = parse_and_validate_jwt_token(&token).unwrap_err();
+        assert!(format!("{err}").contains("OID"));
+    }
+
+    #[test]
+    fn jwt_missing_audience() {
+        let token = make_jwt(r#"{"oid":"x","exp":9999999999}"#);
+        let err = parse_and_validate_jwt_token(&token).unwrap_err();
+        assert!(format!("{err}").contains("audience"));
+    }
+
+    #[test]
+    fn jwt_missing_expiry() {
+        let token = make_jwt(r#"{"oid":"x","aud":"https://ossrdbms-aad.database.windows.net"}"#);
+        let err = parse_and_validate_jwt_token(&token).unwrap_err();
+        assert!(format!("{err}").contains("expiry"));
+    }
+
+    #[test]
+    fn jwt_expired_token() {
+        let token = make_jwt(r#"{"oid":"x","aud":"https://ossrdbms-aad.database.windows.net","exp":1000000}"#);
+        let err = parse_and_validate_jwt_token(&token).unwrap_err();
+        assert!(format!("{err}").contains("expired"));
+    }
+
+    #[test]
+    fn jwt_invalid_audience() {
+        let exp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() + 3600;
+        let token = make_jwt(&format!(r#"{{"oid":"x","aud":"https://bad.example.com","exp":{exp}}}"#));
+        assert!(parse_and_validate_jwt_token(&token).is_err());
+    }
+
+    #[test]
+    fn jwt_valid_token_parses_successfully() {
+        let exp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() + 3600;
+        let token = make_jwt(&format!(r#"{{"oid":"test-oid","aud":"https://ossrdbms-aad.database.windows.net","exp":{exp}}}"#));
+        let (oid, timeout) = parse_and_validate_jwt_token(&token).unwrap();
+        assert_eq!(oid, "test-oid");
+        assert!(timeout > 0);
+    }
+
+    fn assert_error_contains_provider_name(err: DocumentDBError) {
+        assert!(format!("{err}").contains("MONGODB-OIDC"), "Error should contain 'MONGODB-OIDC'");
+    }
+
+    #[test]
+    fn error_invalid_format_contains_provider_name() {
+        assert_error_contains_provider_name(parse_and_validate_jwt_token("bad").unwrap_err());
+    }
+
+    #[test]
+    fn error_invalid_base64_contains_provider_name() {
+        assert_error_contains_provider_name(parse_and_validate_jwt_token("a.!!!.b").unwrap_err());
+    }
+
+    #[test]
+    fn error_expired_token_contains_provider_name() {
+        let token = make_jwt(r#"{"oid":"x","aud":"https://ossrdbms-aad.database.windows.net","exp":1000000}"#);
+        assert_error_contains_provider_name(parse_and_validate_jwt_token(&token).unwrap_err());
+    }
+
+    #[test]
+    fn error_invalid_audience_contains_provider_name() {
+        let exp = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() + 3600;
+        let token = make_jwt(&format!(r#"{{"oid":"x","aud":"https://bad.example.com","exp":{exp}}}"#));
+        assert_error_contains_provider_name(parse_and_validate_jwt_token(&token).unwrap_err());
+    }
+}

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth/provider.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth/provider.rs
@@ -1,0 +1,76 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * documentdb_gateway_core/src/auth/provider.rs
+ *
+ * Defines the AuthProvider trait and ProviderConfig struct.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::{
+    context::ConnectionContext,
+    error::Result,
+    requests::Request,
+    responses::Response,
+};
+
+/// Configuration for an individual authentication provider.
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    /// Whether this provider should be registered.
+    pub enabled: bool,
+    /// Provider-specific configuration (opaque JSON value).
+    pub custom: Value,
+}
+
+impl Default for ProviderConfig {
+    fn default() -> Self {
+        ProviderConfig {
+            enabled: true,
+            custom: Value::Null,
+        }
+    }
+}
+
+/// Core trait that all authentication providers must implement.
+#[async_trait]
+pub trait AuthProvider: Send + Sync {
+    /// Returns the SASL mechanism name (e.g., "SCRAM-SHA-256").
+    fn mechanism_name(&self) -> &str;
+
+    /// Returns true if this provider supports multi-step auth (saslContinue).
+    fn supports_continue(&self) -> bool {
+        false
+    }
+
+    /// Handle the initial saslStart command.
+    async fn handle_sasl_start(
+        &self,
+        connection_context: &mut ConnectionContext,
+        request: &Request<'_>,
+    ) -> Result<Response>;
+
+    /// Handle subsequent saslContinue commands.
+    async fn handle_sasl_continue(
+        &self,
+        connection_context: &mut ConnectionContext,
+        request: &Request<'_>,
+    ) -> Result<Response>;
+
+    /// Called once during registration. Validate config and initialize resources.
+    async fn initialize(&mut self, config: &ProviderConfig) -> Result<()>;
+
+    /// Called once during graceful gateway shutdown. 30s timeout enforced by registry.
+    async fn shutdown(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called when a connection closes. Clean up per-connection state.
+    async fn on_connection_close(&self, _connection_context: &ConnectionContext) -> Result<()> {
+        Ok(())
+    }
+}

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth/registry.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth/registry.rs
@@ -1,0 +1,399 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * documentdb_gateway_core/src/auth/registry.rs
+ *
+ * AuthProviderRegistry — central registry for provider lookup.
+ * Read-only after initialization; uses a plain HashMap (no locks
+ * needed for concurrent reads).
+ *
+ *-------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bson::RawArrayBuf;
+use tokio::time::{timeout, Duration};
+
+use crate::error::{DocumentDBError, Result};
+
+use super::provider::{AuthProvider, ProviderConfig};
+
+/// Timeout applied to each provider's `shutdown()` call.
+const SHUTDOWN_TIMEOUT_SECS: u64 = 30;
+
+/// Central registry mapping SASL mechanism names to provider implementations.
+/// Read-only after initialization — no locks needed for concurrent reads.
+pub struct AuthProviderRegistry {
+    providers: HashMap<String, Arc<dyn AuthProvider>>,
+    /// Cached list of mechanism names, built during registration.
+    enabled_mechanisms: Vec<String>,
+    /// Pre-built BSON array for the Hello/isMaster response.
+    mechanisms_bson: RawArrayBuf,
+}
+
+impl Default for AuthProviderRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuthProviderRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        AuthProviderRegistry {
+            providers: HashMap::new(),
+            enabled_mechanisms: Vec::new(),
+            mechanisms_bson: RawArrayBuf::new(),
+        }
+    }
+
+    /// Register a provider. If the provider's config has `enabled: false`,
+    /// registration is silently skipped. Otherwise the provider is
+    /// initialized, and on success inserted into the map.
+    pub async fn register(
+        &mut self,
+        mut provider: Box<dyn AuthProvider>,
+        config: &ProviderConfig,
+    ) -> Result<()> {
+        if !config.enabled {
+            tracing::info!(
+                "Provider '{}' is disabled — skipping registration",
+                provider.mechanism_name()
+            );
+            return Ok(());
+        }
+
+        let mechanism = provider.mechanism_name().to_string();
+
+        if self.providers.contains_key(&mechanism) {
+            return Err(DocumentDBError::internal_error(format!(
+                "Duplicate auth provider registration for mechanism '{mechanism}'"
+            )));
+        }
+
+        match provider.initialize(config).await {
+            Ok(()) => {
+                tracing::info!("Auth provider '{mechanism}' initialized successfully");
+                self.enabled_mechanisms.push(mechanism.clone());
+                self.mechanisms_bson.push(mechanism.as_str());
+                self.providers.insert(mechanism, Arc::from(provider));
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Auth provider '{mechanism}' failed to initialize: {e} — skipping"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// O(1) lookup by SASL mechanism name.
+    pub fn get_provider(&self, mechanism: &str) -> Result<Arc<dyn AuthProvider>> {
+        self.providers.get(mechanism).cloned().ok_or_else(|| {
+            let supported: Vec<&str> = self.providers.keys().map(|s| s.as_str()).collect();
+            DocumentDBError::authentication_failed(format!(
+                "Mechanism '{mechanism}' is not supported. Supported mechanisms: {supported:?}"
+            ))
+        })
+    }
+
+    /// Returns the names of all registered (enabled) mechanisms.
+    pub fn list_enabled_mechanisms(&self) -> &[String] {
+        &self.enabled_mechanisms
+    }
+
+    /// Returns a pre-built BSON array of mechanism names for the Hello response.
+    pub fn mechanisms_bson(&self) -> &RawArrayBuf {
+        &self.mechanisms_bson
+    }
+
+    /// Gracefully shut down every registered provider with a 30-second
+    /// timeout per provider.
+    pub async fn shutdown_all(&mut self) {
+        let providers = std::mem::take(&mut self.providers);
+        self.enabled_mechanisms.clear();
+        self.mechanisms_bson = RawArrayBuf::new();
+
+        for (mechanism, mut arc_provider) in providers {
+            if let Some(provider) = Arc::get_mut(&mut arc_provider) {
+                match timeout(
+                    Duration::from_secs(SHUTDOWN_TIMEOUT_SECS),
+                    provider.shutdown(),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
+                        tracing::info!("Auth provider '{mechanism}' shut down successfully");
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            "Auth provider '{mechanism}' shutdown returned error: {e}"
+                        );
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "Auth provider '{mechanism}' shutdown timed out after {SHUTDOWN_TIMEOUT_SECS}s"
+                        );
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    "Auth provider '{mechanism}' has outstanding references — cannot call shutdown"
+                );
+            }
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use async_trait::async_trait;
+
+    struct TestProvider {
+        name: String,
+        should_fail_init: bool,
+        init_called: Arc<AtomicBool>,
+        shutdown_called: Arc<AtomicBool>,
+    }
+
+    impl TestProvider {
+        fn new(name: &str, should_fail_init: bool) -> Self {
+            TestProvider {
+                name: name.to_string(),
+                should_fail_init,
+                init_called: Arc::new(AtomicBool::new(false)),
+                shutdown_called: Arc::new(AtomicBool::new(false)),
+            }
+        }
+
+        fn new_tracked(
+            name: &str,
+            should_fail_init: bool,
+            init_called: Arc<AtomicBool>,
+            shutdown_called: Arc<AtomicBool>,
+        ) -> Self {
+            TestProvider {
+                name: name.to_string(),
+                should_fail_init,
+                init_called,
+                shutdown_called,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AuthProvider for TestProvider {
+        fn mechanism_name(&self) -> &str {
+            &self.name
+        }
+
+        async fn handle_sasl_start(
+            &self,
+            _ctx: &mut crate::context::ConnectionContext,
+            _req: &crate::requests::Request<'_>,
+        ) -> Result<crate::responses::Response> {
+            unimplemented!("not used in registry tests")
+        }
+
+        async fn handle_sasl_continue(
+            &self,
+            _ctx: &mut crate::context::ConnectionContext,
+            _req: &crate::requests::Request<'_>,
+        ) -> Result<crate::responses::Response> {
+            unimplemented!("not used in registry tests")
+        }
+
+        async fn initialize(&mut self, _config: &ProviderConfig) -> Result<()> {
+            self.init_called.store(true, Ordering::SeqCst);
+            if self.should_fail_init {
+                Err(DocumentDBError::internal_error(format!(
+                    "Simulated init failure for '{}'", self.name
+                )))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn shutdown(&mut self) -> Result<()> {
+            self.shutdown_called.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — Registry initialization
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn register_calls_initialize_on_enabled_providers() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        let init_a = Arc::new(AtomicBool::new(false));
+        let init_b = Arc::new(AtomicBool::new(false));
+        let pa = TestProvider::new_tracked("MECH-A", false, init_a.clone(), Arc::new(AtomicBool::new(false)));
+        let pb = TestProvider::new_tracked("MECH-B", false, init_b.clone(), Arc::new(AtomicBool::new(false)));
+        registry.register(Box::new(pa), &config).await.unwrap();
+        registry.register(Box::new(pb), &config).await.unwrap();
+        assert!(init_a.load(Ordering::SeqCst));
+        assert!(init_b.load(Ordering::SeqCst));
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — Failed initialization
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn failed_init_skips_provider_without_affecting_others() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("GOOD", false)), &config).await.unwrap();
+        registry.register(Box::new(TestProvider::new("BAD", true)), &config).await.unwrap();
+        assert!(registry.get_provider("GOOD").is_ok());
+        assert!(registry.get_provider("BAD").is_err());
+    }
+
+    #[tokio::test]
+    async fn failed_init_does_not_block_subsequent_registrations() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("FAILS", true)), &config).await.unwrap();
+        registry.register(Box::new(TestProvider::new("WORKS", false)), &config).await.unwrap();
+        assert!(registry.get_provider("WORKS").is_ok());
+        assert!(registry.get_provider("FAILS").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — Duplicate registration
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn duplicate_mechanism_registration_is_rejected() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("SCRAM-SHA-256", false)), &config).await.unwrap();
+        let result = registry.register(Box::new(TestProvider::new("SCRAM-SHA-256", false)), &config).await;
+        assert!(result.is_err());
+        assert!(registry.get_provider("SCRAM-SHA-256").is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — Lookup correctness
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn get_provider_returns_correct_provider() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("SCRAM-SHA-256", false)), &config).await.unwrap();
+        registry.register(Box::new(TestProvider::new("MONGODB-OIDC", false)), &config).await.unwrap();
+        assert_eq!(registry.get_provider("SCRAM-SHA-256").unwrap().mechanism_name(), "SCRAM-SHA-256");
+        assert_eq!(registry.get_provider("MONGODB-OIDC").unwrap().mechanism_name(), "MONGODB-OIDC");
+    }
+
+    #[tokio::test]
+    async fn get_provider_returns_error_for_unknown_mechanism() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("SCRAM-SHA-256", false)), &config).await.unwrap();
+        assert!(registry.get_provider("UNKNOWN").is_err());
+    }
+
+    #[tokio::test]
+    async fn get_provider_on_empty_registry_returns_error() {
+        let registry = AuthProviderRegistry::new();
+        assert!(registry.get_provider("ANYTHING").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — list_enabled_mechanisms
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_enabled_mechanisms_returns_all_registered() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("SCRAM-SHA-256", false)), &config).await.unwrap();
+        registry.register(Box::new(TestProvider::new("MONGODB-OIDC", false)), &config).await.unwrap();
+        let mut mechs: Vec<&str> = registry.list_enabled_mechanisms().iter().map(|s| s.as_str()).collect();
+        mechs.sort();
+        assert_eq!(mechs, vec!["MONGODB-OIDC", "SCRAM-SHA-256"]);
+    }
+
+    #[tokio::test]
+    async fn list_enabled_mechanisms_empty_registry() {
+        let registry = AuthProviderRegistry::new();
+        assert!(registry.list_enabled_mechanisms().is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_enabled_mechanisms_excludes_failed_providers() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("GOOD", false)), &config).await.unwrap();
+        registry.register(Box::new(TestProvider::new("BAD", true)), &config).await.unwrap();
+        assert_eq!(registry.list_enabled_mechanisms(), vec!["GOOD"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — Disabled providers
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn disabled_provider_is_not_registered() {
+        let mut registry = AuthProviderRegistry::new();
+        let disabled = ProviderConfig { enabled: false, ..Default::default() };
+        let init_flag = Arc::new(AtomicBool::new(false));
+        let p = TestProvider::new_tracked("DISABLED", false, init_flag.clone(), Arc::new(AtomicBool::new(false)));
+        registry.register(Box::new(p), &disabled).await.unwrap();
+        assert!(registry.get_provider("DISABLED").is_err());
+        assert!(!init_flag.load(Ordering::SeqCst));
+        assert!(registry.list_enabled_mechanisms().is_empty());
+    }
+
+    #[tokio::test]
+    async fn disabled_provider_does_not_affect_enabled_ones() {
+        let mut registry = AuthProviderRegistry::new();
+        let enabled = ProviderConfig::default();
+        let disabled = ProviderConfig { enabled: false, ..Default::default() };
+        registry.register(Box::new(TestProvider::new("ENABLED", false)), &enabled).await.unwrap();
+        registry.register(Box::new(TestProvider::new("DISABLED", false)), &disabled).await.unwrap();
+        assert!(registry.get_provider("ENABLED").is_ok());
+        assert!(registry.get_provider("DISABLED").is_err());
+        assert_eq!(registry.list_enabled_mechanisms(), vec!["ENABLED"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — Shutdown
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn shutdown_all_calls_shutdown_on_all_providers() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        let sa = Arc::new(AtomicBool::new(false));
+        let sb = Arc::new(AtomicBool::new(false));
+        let pa = TestProvider::new_tracked("A", false, Arc::new(AtomicBool::new(false)), sa.clone());
+        let pb = TestProvider::new_tracked("B", false, Arc::new(AtomicBool::new(false)), sb.clone());
+        registry.register(Box::new(pa), &config).await.unwrap();
+        registry.register(Box::new(pb), &config).await.unwrap();
+        registry.shutdown_all().await;
+        assert!(sa.load(Ordering::SeqCst));
+        assert!(sb.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn shutdown_all_empties_the_registry() {
+        let mut registry = AuthProviderRegistry::new();
+        let config = ProviderConfig::default();
+        registry.register(Box::new(TestProvider::new("A", false)), &config).await.unwrap();
+        registry.shutdown_all().await;
+        assert!(registry.list_enabled_mechanisms().is_empty());
+        assert!(registry.get_provider("A").is_err());
+    }
+}

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth/scram_provider.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth/scram_provider.rs
@@ -1,0 +1,560 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * documentdb_gateway_core/src/auth/scram_provider.rs
+ *
+ * ScramProvider — SCRAM-SHA-256 authentication provider.
+ * Extracted from the monolithic auth handler.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+use std::str::from_utf8;
+
+use async_trait::async_trait;
+use bson::{rawdoc, spec::BinarySubtype};
+use rand::Rng;
+use tokio_postgres::types::Type;
+
+use crate::{
+    auth::provider::{AuthProvider, ProviderConfig},
+    auth::get_user_oid,
+    auth_legacy::{AuthKind, ScramFirstState},
+    context::ConnectionContext,
+    error::{DocumentDBError, ErrorCode, Result},
+    postgres::PgDocument,
+    protocol::OK_SUCCEEDED,
+    requests::{request_tracker::RequestTracker, Request},
+    responses::{RawResponse, Response},
+};
+
+const NONCE_LENGTH: usize = 2;
+
+pub struct ScramProvider {
+    config: Option<ProviderConfig>,
+}
+
+impl ScramProvider {
+    pub fn new() -> Self {
+        ScramProvider { config: None }
+    }
+}
+
+impl Default for ScramProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AuthProvider for ScramProvider {
+    fn mechanism_name(&self) -> &str {
+        "SCRAM-SHA-256"
+    }
+
+    fn supports_continue(&self) -> bool {
+        true
+    }
+
+    async fn handle_sasl_start(
+        &self,
+        connection_context: &mut ConnectionContext,
+        request: &Request<'_>,
+    ) -> Result<Response> {
+        let payload = parse_sasl_payload(request, true)?;
+
+        let username = payload
+            .username
+            .ok_or(DocumentDBError::authentication_failed(
+                "SCRAM-SHA-256: Username missing from SaslStart.".to_string(),
+            ))?;
+
+        let client_nonce = payload.nonce.ok_or(DocumentDBError::authentication_failed(
+            "SCRAM-SHA-256: Nonce missing from SaslStart.".to_string(),
+        ))?;
+
+        let server_nonce = generate_server_nonce(client_nonce);
+
+        let (salt, iterations) =
+            get_salt_and_iteration(connection_context, username).await?;
+        let response = format!("r={server_nonce},s={salt},i={iterations}");
+
+        connection_context.auth_state.first_state = Some(ScramFirstState {
+            nonce: server_nonce,
+            first_message_bare: format!("n={username},r={client_nonce}"),
+            first_message: response.clone(),
+        });
+
+        connection_context.auth_state.username = Some(username.to_string());
+
+        connection_context
+            .auth_state
+            .set_auth_kind(AuthKind::Native)?;
+
+        let binary_response = bson::Binary {
+            subtype: BinarySubtype::Generic,
+            bytes: response.as_bytes().to_vec(),
+        };
+
+        Ok(Response::Raw(RawResponse(rawdoc! {
+            "payload": binary_response,
+            "ok": OK_SUCCEEDED,
+            "conversationId": 1,
+            "done": false
+        })))
+    }
+
+    async fn handle_sasl_continue(
+        &self,
+        connection_context: &mut ConnectionContext,
+        request: &Request<'_>,
+    ) -> Result<Response> {
+        let payload = parse_sasl_payload(request, false)?;
+
+        if let Some(first_state) = connection_context.auth_state.first_state.as_ref() {
+            let mechanism_result = request.document().get_str("mechanism");
+
+            if let Ok(mechanism) = mechanism_result {
+                if mechanism == "MONGODB-OIDC" {
+                    return Err(DocumentDBError::authentication_failed(
+                        "SCRAM-SHA-256: Auth mechanism MONGODB-OIDC is not supported in SaslContinue".to_string(),
+                    ));
+                }
+            } else {
+                tracing::warn!("SCRAM-SHA-256: Auth mechanism not provided in SaslContinue");
+            }
+
+            let client_nonce =
+                payload.nonce.ok_or(DocumentDBError::authentication_failed(
+                    "SCRAM-SHA-256: Nonce missing from SaslContinue.".to_string(),
+                ))?;
+            let proof = payload.proof.ok_or(DocumentDBError::authentication_failed(
+                "SCRAM-SHA-256: Proof missing from SaslContinue.".to_string(),
+            ))?;
+            let channel_binding =
+                payload
+                    .channel_binding
+                    .ok_or(DocumentDBError::authentication_failed(
+                        "SCRAM-SHA-256: Channel binding missing from SaslContinue.".to_string(),
+                    ))?;
+            let username = payload
+                .username
+                .or(connection_context.auth_state.username.as_deref())
+                .ok_or(DocumentDBError::internal_error(
+                    "SCRAM-SHA-256: Username missing from SaslContinue".to_string(),
+                ))?;
+
+            if client_nonce != first_state.nonce {
+                return Err(DocumentDBError::authentication_failed(
+                    "SCRAM-SHA-256: Nonce did not match expected nonce.".to_string(),
+                ));
+            }
+
+            let auth_message = format!(
+                "{},{},c={},r={}",
+                first_state.first_message_bare,
+                first_state.first_message,
+                channel_binding,
+                client_nonce
+            );
+
+            let scram_sha256_row = connection_context
+                .service_context
+                .connection_pool_manager()
+                .authentication_connection()
+                .await?
+                .query(
+                    connection_context
+                        .service_context
+                        .query_catalog()
+                        .authenticate_with_scram_sha256(),
+                    &[Type::TEXT, Type::TEXT, Type::TEXT],
+                    &[&username, &auth_message, &proof],
+                    None,
+                    &RequestTracker::new(),
+                )
+                .await?;
+
+            let scram_sha256_doc: PgDocument = scram_sha256_row
+                .first()
+                .ok_or(DocumentDBError::pg_response_empty())?
+                .try_get(0)?;
+
+            if scram_sha256_doc
+                .0
+                .get_i32("ok")
+                .map_err(DocumentDBError::pg_response_invalid)?
+                != 1
+            {
+                return Err(DocumentDBError::authentication_failed(
+                    "SCRAM-SHA-256: Invalid key".to_string(),
+                ));
+            }
+
+            let server_signature = scram_sha256_doc
+                .0
+                .get_str("ServerSignature")
+                .map_err(DocumentDBError::pg_response_invalid)?;
+
+            let payload = bson::Binary {
+                subtype: BinarySubtype::Generic,
+                bytes: format!("v={server_signature}").as_bytes().to_vec(),
+            };
+
+            connection_context.auth_state.user_oid =
+                Some(get_user_oid(connection_context, username).await?);
+
+            *connection_context.auth_state.is_authorized().write().await = true;
+            connection_context.allocate_data_pool("")?;
+
+            Ok(Response::Raw(RawResponse(rawdoc! {
+                "payload": payload,
+                "ok": OK_SUCCEEDED,
+                "conversationId": 1,
+                "done": true
+            })))
+        } else {
+            Err(DocumentDBError::authentication_failed(
+                "SCRAM-SHA-256: SaslContinue called without SaslStart state.".to_string(),
+            ))
+        }
+    }
+
+    async fn initialize(&mut self, config: &ProviderConfig) -> Result<()> {
+        self.config = Some(config.clone());
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+fn generate_server_nonce(client_nonce: &str) -> String {
+    const CHARSET: &[u8] = b"!\"#$%&'()*+-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    let mut rng = rand::thread_rng();
+
+    let mut result = String::with_capacity(NONCE_LENGTH);
+    for _ in 0..NONCE_LENGTH {
+        let idx = rng.gen_range(0..CHARSET.len());
+        result.push(CHARSET[idx] as char);
+    }
+
+    format!("{client_nonce}{result}")
+}
+
+#[derive(Debug)]
+struct ScramPayload<'a> {
+    username: Option<&'a str>,
+    nonce: Option<&'a str>,
+    proof: Option<&'a str>,
+    channel_binding: Option<&'a str>,
+}
+
+fn parse_sasl_payload<'a, 'b: 'a>(
+    request: &'b Request<'a>,
+    with_header: bool,
+) -> Result<ScramPayload<'a>> {
+    let payload = request
+        .document()
+        .get_binary("payload")
+        .map_err(DocumentDBError::parse_failure())?;
+    let mut payload = from_utf8(payload.bytes).map_err(|e| {
+        DocumentDBError::bad_value(format!(
+            "SCRAM-SHA-256: Sasl payload couldn't be converted to utf-8: {e}"
+        ))
+    })?;
+
+    if with_header {
+        if payload.len() < 3 {
+            return Err(DocumentDBError::authentication_failed(
+                "SCRAM-SHA-256: Sasl payload invalid.".to_string(),
+            ));
+        }
+        match &payload[0..=2] {
+            "n,," => (),
+            "p,," => (),
+            "y,," => (),
+            _ => {
+                return Err(DocumentDBError::authentication_failed(
+                    "SCRAM-SHA-256: Sasl payload invalid.".to_string(),
+                ))
+            }
+        }
+        payload = &payload[3..];
+    }
+
+    let mut username: Option<&str> = None;
+    let mut nonce: Option<&str> = None;
+    let mut proof: Option<&str> = None;
+    let mut channel_binding: Option<&str> = None;
+
+    for value in payload.split(',') {
+        let idx = value.find('=').ok_or(DocumentDBError::authentication_failed(
+            "SCRAM-SHA-256: Sasl payload invalid.".to_string(),
+        ))?;
+
+        let k = &value[..idx];
+        let v = &value[idx + 1..];
+        match k {
+            "n" => username = Some(v),
+            "r" => nonce = Some(v),
+            "p" => proof = Some(v),
+            "c" => channel_binding = Some(v),
+            _ => {
+                return Err(DocumentDBError::authentication_failed(
+                    "SCRAM-SHA-256: Sasl payload was invalid.".to_string(),
+                ))
+            }
+        }
+    }
+
+    Ok(ScramPayload {
+        username,
+        nonce,
+        proof,
+        channel_binding,
+    })
+}
+
+async fn get_salt_and_iteration(
+    connection_context: &ConnectionContext,
+    username: &str,
+) -> Result<(String, i32)> {
+    for blocked_prefix in connection_context
+        .service_context
+        .setup_configuration()
+        .blocked_role_prefixes()
+    {
+        if username
+            .to_lowercase()
+            .starts_with(&blocked_prefix.to_lowercase())
+        {
+            return Err(DocumentDBError::authentication_failed(
+                "SCRAM-SHA-256: Username is invalid.".to_string(),
+            ));
+        }
+    }
+
+    let results = connection_context
+        .service_context
+        .connection_pool_manager()
+        .authentication_connection()
+        .await?
+        .query(
+            connection_context
+                .service_context
+                .query_catalog()
+                .salt_and_iterations(),
+            &[Type::TEXT],
+            &[&username],
+            None,
+            &RequestTracker::new(),
+        )
+        .await?;
+
+    let doc: PgDocument = results
+        .first()
+        .ok_or(DocumentDBError::pg_response_empty())?
+        .try_get(0)?;
+    if doc
+        .0
+        .get_i32("ok")
+        .map_err(|e| DocumentDBError::internal_error(e.to_string()))?
+        != 1
+    {
+        return Err(DocumentDBError::documentdb_error(
+            ErrorCode::AuthenticationFailed,
+            "SCRAM-SHA-256: Invalid account: User details not found in the database".to_string(),
+        ));
+    }
+
+    let iterations = doc
+        .0
+        .get_i32("iterations")
+        .map_err(DocumentDBError::pg_response_invalid)?;
+    let salt = doc
+        .0
+        .get_str("salt")
+        .map_err(DocumentDBError::pg_response_invalid)?;
+
+    Ok((salt.to_string(), iterations))
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::provider::{AuthProvider, ProviderConfig};
+    use crate::requests::RequestType;
+    use bson::{rawdoc, spec::BinarySubtype};
+
+    fn make_sasl_request(payload_str: &str) -> Request<'static> {
+        let binary = bson::Binary {
+            subtype: BinarySubtype::Generic,
+            bytes: payload_str.as_bytes().to_vec(),
+        };
+        let doc = rawdoc! {
+            "saslStart": 1,
+            "mechanism": "SCRAM-SHA-256",
+            "payload": binary,
+            "$db": "admin"
+        };
+        Request::RawBuf(RequestType::SaslStart, doc)
+    }
+
+    #[test]
+    fn mechanism_name_returns_scram_sha_256() {
+        let provider = ScramProvider::new();
+        assert_eq!(provider.mechanism_name(), "SCRAM-SHA-256");
+    }
+
+    #[test]
+    fn supports_continue_returns_true() {
+        let provider = ScramProvider::new();
+        assert!(provider.supports_continue());
+    }
+
+    #[tokio::test]
+    async fn initialize_stores_config() {
+        let mut provider = ScramProvider::new();
+        assert!(provider.config.is_none());
+        let config = ProviderConfig::default();
+        provider.initialize(&config).await.unwrap();
+        assert!(provider.config.is_some());
+    }
+
+    #[test]
+    fn server_nonce_starts_with_client_nonce() {
+        let client_nonce = "rOprNGfwEbeRWgbNEkqO";
+        let server_nonce = generate_server_nonce(client_nonce);
+        assert!(server_nonce.starts_with(client_nonce));
+    }
+
+    #[test]
+    fn server_nonce_is_longer_than_client_nonce() {
+        let client_nonce = "abc123";
+        let server_nonce = generate_server_nonce(client_nonce);
+        assert_eq!(server_nonce.len(), client_nonce.len() + NONCE_LENGTH);
+    }
+
+    #[test]
+    fn server_nonce_appended_chars_are_printable() {
+        let client_nonce = "test";
+        for _ in 0..50 {
+            let server_nonce = generate_server_nonce(client_nonce);
+            let appended = &server_nonce[client_nonce.len()..];
+            for c in appended.chars() {
+                assert!(c.is_ascii_graphic());
+            }
+        }
+    }
+
+    #[test]
+    fn parse_valid_gs2_header_n() {
+        let request = make_sasl_request("n,,n=user,r=nonce123");
+        let payload = parse_sasl_payload(&request, true).unwrap();
+        assert_eq!(payload.username, Some("user"));
+        assert_eq!(payload.nonce, Some("nonce123"));
+    }
+
+    #[test]
+    fn parse_valid_gs2_header_p() {
+        let request = make_sasl_request("p,,n=user,r=nonce123");
+        let payload = parse_sasl_payload(&request, true).unwrap();
+        assert_eq!(payload.username, Some("user"));
+    }
+
+    #[test]
+    fn parse_valid_gs2_header_y() {
+        let request = make_sasl_request("y,,n=user,r=nonce123");
+        let payload = parse_sasl_payload(&request, true).unwrap();
+        assert_eq!(payload.username, Some("user"));
+    }
+
+    #[test]
+    fn parse_invalid_gs2_header_rejected() {
+        let request = make_sasl_request("x,,n=user,r=nonce123");
+        assert!(parse_sasl_payload(&request, true).is_err());
+    }
+
+    #[test]
+    fn parse_too_short_payload_rejected() {
+        let request = make_sasl_request("n,");
+        assert!(parse_sasl_payload(&request, true).is_err());
+    }
+
+    #[test]
+    fn parse_without_header() {
+        let request = make_sasl_request("n=user,r=nonce123");
+        let payload = parse_sasl_payload(&request, false).unwrap();
+        assert_eq!(payload.username, Some("user"));
+        assert_eq!(payload.nonce, Some("nonce123"));
+    }
+
+    #[test]
+    fn parse_continue_payload_with_proof() {
+        let request = make_sasl_request("c=biws,r=nonce123,p=dHVyYm8=");
+        let payload = parse_sasl_payload(&request, false).unwrap();
+        assert_eq!(payload.channel_binding, Some("biws"));
+        assert_eq!(payload.nonce, Some("nonce123"));
+        assert_eq!(payload.proof, Some("dHVyYm8="));
+    }
+
+    #[test]
+    fn parse_unknown_key_rejected() {
+        let request = make_sasl_request("n,,n=user,r=nonce,z=bad");
+        assert!(parse_sasl_payload(&request, true).is_err());
+    }
+
+    #[test]
+    fn parse_missing_equals_rejected() {
+        let request = make_sasl_request("n,,nuser");
+        assert!(parse_sasl_payload(&request, true).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Error message tests — verify provider name is included
+    // -----------------------------------------------------------------------
+
+    fn assert_error_contains_provider_name(err: DocumentDBError) {
+        let err_str = format!("{err}");
+        assert!(err_str.contains("SCRAM-SHA-256"), "Error should contain 'SCRAM-SHA-256', got: {err_str}");
+    }
+
+    #[test]
+    fn error_invalid_gs2_header_contains_provider_name() {
+        let request = make_sasl_request("x,,n=user,r=nonce");
+        assert_error_contains_provider_name(parse_sasl_payload(&request, true).unwrap_err());
+    }
+
+    #[test]
+    fn error_too_short_payload_contains_provider_name() {
+        let request = make_sasl_request("n,");
+        assert_error_contains_provider_name(parse_sasl_payload(&request, true).unwrap_err());
+    }
+
+    #[test]
+    fn error_unknown_key_contains_provider_name() {
+        let request = make_sasl_request("n,,n=user,r=nonce,z=bad");
+        assert_error_contains_provider_name(parse_sasl_payload(&request, true).unwrap_err());
+    }
+
+    #[test]
+    fn error_missing_equals_contains_provider_name() {
+        let request = make_sasl_request("n,,nuser");
+        assert_error_contains_provider_name(parse_sasl_payload(&request, true).unwrap_err());
+    }
+
+    #[test]
+    fn error_empty_payload_contains_provider_name() {
+        let request = make_sasl_request("");
+        assert_error_contains_provider_name(parse_sasl_payload(&request, true).unwrap_err());
+    }
+
+    #[test]
+    fn error_garbage_payload_contains_provider_name() {
+        let request = make_sasl_request("!!!garbage!!!");
+        assert_error_contains_provider_name(parse_sasl_payload(&request, true).unwrap_err());
+    }
+}

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth_legacy.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth_legacy.rs
@@ -37,18 +37,19 @@ pub enum AuthKind {
 }
 
 pub struct ScramFirstState {
-    nonce: String,
-    first_message_bare: String,
-    first_message: String,
+    pub nonce: String,
+    pub first_message_bare: String,
+    pub first_message: String,
 }
 
 pub struct AuthState {
     authorized: Arc<RwLock<bool>>,
-    first_state: Option<ScramFirstState>,
-    username: Option<String>,
-    user_oid: Option<u32>,
+    pub first_state: Option<ScramFirstState>,
+    pub username: Option<String>,
+    pub user_oid: Option<u32>,
     auth_kind: Option<AuthKind>,
     timer_initialized: Arc<RwLock<bool>>,
+    active_mechanism: Option<String>,
 }
 
 impl Default for AuthState {
@@ -66,6 +67,7 @@ impl AuthState {
             user_oid: None,
             auth_kind: None,
             timer_initialized: Arc::new(RwLock::new(false)),
+            active_mechanism: None,
         }
     }
 
@@ -112,7 +114,15 @@ impl AuthState {
         }
     }
 
-    async fn initialize_expiry_timer(
+    pub fn set_active_mechanism(&mut self, mechanism: &str) {
+        self.active_mechanism = Some(mechanism.to_string());
+    }
+
+    pub fn active_mechanism(&self) -> Option<&str> {
+        self.active_mechanism.as_deref()
+    }
+
+    pub async fn initialize_expiry_timer(
         &self,
         timeout_secs: u64,
         connection_activity_id: &str,
@@ -175,6 +185,16 @@ async fn handle_auth_request(
     connection_context: &mut ConnectionContext,
     request: &Request<'_>,
 ) -> Result<Option<Response>> {
+    // GUC toggle: route to pluggable auth handler when enabled
+    if connection_context
+        .service_context
+        .dynamic_configuration()
+        .use_pluggable_auth()
+    {
+        return crate::auth::handler::handle_auth_request(connection_context, request).await;
+    }
+
+    // Legacy monolithic handler
     match request.request_type() {
         RequestType::SaslStart => Ok(Some(handle_sasl_start(connection_context, request).await?)),
         RequestType::SaslContinue => Ok(Some(

--- a/pg_documentdb_gw/documentdb_gateway_core/src/configuration/dynamic.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/configuration/dynamic.rs
@@ -141,6 +141,12 @@ pub trait DynamicConfiguration: Send + Sync + Debug {
         self.get_i32("slowQueryLogIntervalInMilliseconds", -1)
     }
 
+    /// Whether to use the new pluggable auth architecture (RFC-0009).
+    /// Default: false (use legacy monolithic handler).
+    fn use_pluggable_auth(&self) -> bool {
+        self.get_bool("documentdb_gateway.use_pluggable_auth", false)
+    }
+
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "")
     }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/context/service.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/context/service.rs
@@ -9,6 +9,7 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::{
+    auth::AuthProviderRegistry,
     configuration::{DynamicConfiguration, SetupConfiguration},
     context::{CursorStore, TransactionStore},
     postgres::{conn_mgmt::PoolManager, QueryCatalog},
@@ -22,6 +23,7 @@ pub struct ServiceContextInner {
     pub cursor_store: CursorStore,
     pub transaction_store: TransactionStore,
     pub tls_provider: TlsProvider,
+    pub auth_provider_registry: Option<AuthProviderRegistry>,
 }
 
 #[derive(Clone)]
@@ -33,6 +35,7 @@ impl ServiceContext {
         dynamic_configuration: Arc<dyn DynamicConfiguration>,
         connection_pool_manager: Arc<PoolManager>,
         tls_provider: TlsProvider,
+        auth_provider_registry: Option<AuthProviderRegistry>,
     ) -> Self {
         let timeout_secs = setup_configuration.transaction_timeout_secs();
         let cursor_store = CursorStore::new(dynamic_configuration.clone(), true);
@@ -44,6 +47,7 @@ impl ServiceContext {
             cursor_store,
             transaction_store: TransactionStore::new(Duration::from_secs(timeout_secs)),
             tls_provider,
+            auth_provider_registry,
         };
         ServiceContext(Arc::new(inner))
     }
@@ -74,5 +78,9 @@ impl ServiceContext {
 
     pub fn connection_pool_manager(&self) -> &PoolManager {
         &self.0.connection_pool_manager
+    }
+
+    pub fn auth_provider_registry(&self) -> Option<&AuthProviderRegistry> {
+        self.0.auth_provider_registry.as_ref()
     }
 }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/lib.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/lib.rs
@@ -7,6 +7,7 @@
  */
 
 pub mod auth;
+pub mod auth_legacy;
 pub mod bson;
 pub mod configuration;
 pub mod context;
@@ -564,6 +565,21 @@ where
                         "Couldn't reply with error {e:?}."
                     );
                     break;
+                }
+            }
+        }
+    }
+
+    // Connection cleanup: call on_connection_close() on the active provider
+    // if authentication was completed through the pluggable auth path.
+    if let Some(mechanism) = connection_context.auth_state.active_mechanism() {
+        if let Some(registry) = connection_context.service_context.auth_provider_registry() {
+            if let Ok(provider) = registry.get_provider(mechanism) {
+                if let Err(e) = provider.on_connection_close(&connection_context).await {
+                    tracing::warn!(
+                        activity_id = connection_activity_id_as_str,
+                        "on_connection_close failed for provider '{mechanism}': {e}"
+                    );
                 }
             }
         }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
@@ -464,7 +464,7 @@ pub fn create_query_catalog() -> QueryCatalog {
             authenticate_with_token: "SELECT documentdb_api_internal.authenticate_token($1, $2)".to_string(),
 
             // dynamic.rs
-            pg_settings: "SELECT name, setting FROM pg_settings WHERE name LIKE 'documentdb.%' OR name IN ('max_connections', 'default_transaction_read_only')".to_string(),
+            pg_settings: "SELECT name, setting FROM pg_settings WHERE name LIKE 'documentdb.%' OR name LIKE 'documentdb\\_gateway.%' OR name IN ('max_connections', 'default_transaction_read_only')".to_string(),
             pg_is_in_recovery: "SELECT pg_is_in_recovery()".to_string(),
 
             // explain/mod.rs

--- a/pg_documentdb_gw/documentdb_gateway_core/src/processor/ismaster.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/processor/ismaster.rs
@@ -13,6 +13,8 @@ use std::{
 
 use bson::rawdoc;
 
+use once_cell::sync::Lazy;
+
 use crate::{
     configuration::DynamicConfiguration,
     context::{ConnectionContext, RequestContext},
@@ -20,6 +22,13 @@ use crate::{
     protocol::{MAX_BSON_OBJECT_SIZE, MAX_MESSAGE_SIZE_BYTES, OK_SUCCEEDED},
     responses::{RawResponse, Response},
 };
+
+/// Pre-built BSON array for the legacy (GUC disabled) path.
+static DEFAULT_MECHANISMS: Lazy<bson::RawArrayBuf> = Lazy::new(|| {
+    let mut arr = bson::RawArrayBuf::new();
+    arr.push("SCRAM-SHA-256");
+    arr
+});
 
 pub fn process(
     request_context: &RequestContext<'_>,
@@ -48,6 +57,18 @@ pub fn process(
         connection_context.client_information = Some(client.to_raw_document_buf());
     }
 
+    // saslSupportedMechs: use prebuilt BSON array from registry when GUC
+    // enabled, otherwise use the static default.
+    let mechs = if dynamic_configuration.use_pluggable_auth() {
+        connection_context
+            .service_context
+            .auth_provider_registry()
+            .map(|r| r.mechanisms_bson().clone())
+            .unwrap_or_else(|| DEFAULT_MECHANISMS.clone())
+    } else {
+        DEFAULT_MECHANISMS.clone()
+    };
+
     let mut response_doc = rawdoc! {
         writeable_primary_field: true,
         "msg": "isdbgrid",
@@ -60,7 +81,7 @@ pub fn process(
         "maxWireVersion": dynamic_configuration.server_version().max_wire_protocol(),
         "readOnly": dynamic_configuration.read_only(),
         "connectionId": connection_context.get_connection_id_hash(),
-        "saslSupportedMechs": ["SCRAM-SHA-256"],
+        "saslSupportedMechs": mechs,
         "internal": dynamic_configuration.topology(),
         "ok": OK_SUCCEEDED,
     };

--- a/pg_documentdb_gw/documentdb_gateway_core/src/startup.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/startup.rs
@@ -11,6 +11,12 @@ use std::sync::Arc;
 use tokio::time::{Duration, Instant};
 
 use crate::{
+    auth::{
+        oidc_provider::OidcProvider,
+        provider::ProviderConfig,
+        registry::AuthProviderRegistry,
+        scram_provider::ScramProvider,
+    },
     configuration::{DynamicConfiguration, SetupConfiguration},
     context::ServiceContext,
     error::Result,
@@ -18,7 +24,7 @@ use crate::{
     service::TlsProvider,
 };
 
-pub fn get_service_context(
+pub async fn get_service_context(
     setup_configuration: Box<dyn SetupConfiguration>,
     dynamic_configuration: Arc<dyn DynamicConfiguration>,
     connection_pool_manager: Arc<PoolManager>,
@@ -26,16 +32,34 @@ pub fn get_service_context(
 ) -> ServiceContext {
     tracing::info!("Initial dynamic configuration: {dynamic_configuration:?}");
 
+    let auth_provider_registry = init_auth_provider_registry().await;
+
     let service_context = ServiceContext::new(
         setup_configuration.clone(),
         Arc::clone(&dynamic_configuration),
         connection_pool_manager,
         tls_provider,
+        Some(auth_provider_registry),
     );
 
     conn_mgmt::clean_unused_pools(service_context.clone());
 
     service_context
+}
+
+/// Build and initialize the auth provider registry with the default providers.
+async fn init_auth_provider_registry() -> AuthProviderRegistry {
+    let mut registry = AuthProviderRegistry::new();
+    let config = ProviderConfig::default();
+
+    if let Err(e) = registry.register(Box::new(ScramProvider::new()), &config).await {
+        tracing::error!("Failed to register ScramProvider: {e}");
+    }
+    if let Err(e) = registry.register(Box::new(OidcProvider::new()), &config).await {
+        tracing::error!("Failed to register OidcProvider: {e}");
+    }
+
+    registry
 }
 
 pub async fn create_postgres_object<T, F, Fut>(

--- a/pg_documentdb_gw/documentdb_tests/src/test_setup/gateway.rs
+++ b/pg_documentdb_gw/documentdb_tests/src/test_setup/gateway.rs
@@ -52,7 +52,8 @@ pub async fn run_test_gateway(
         dynamic_configuration,
         connection_pool_manager,
         tls_provider,
-    );
+    )
+    .await;
 
     ready_flag.store(true, Ordering::SeqCst);
     ready_notify.notify_waiters();

--- a/pg_documentdb_gw_host/src/bgworker.rs
+++ b/pg_documentdb_gw_host/src/bgworker.rs
@@ -123,7 +123,8 @@ async fn run_docdb_gateway(setup_configuration_file: &str) {
         dynamic_configuration,
         connection_pool_manager,
         tls_provider,
-    );
+    )
+    .await;
 
     run_gateway::<DocumentDBDataClient>(service_context, None, shutdown_token)
         .await

--- a/pg_documentdb_gw_host/src/gucs.rs
+++ b/pg_documentdb_gw_host/src/gucs.rs
@@ -7,6 +7,9 @@ pub(crate) static PG_DOCUMENTDB_GATEWAY_DATABASE: GucSetting<Option<CString>> =
 pub(crate) static PG_DOCUMENTDB_SETUP_CONFIGURATION: GucSetting<Option<CString>> =
     GucSetting::<Option<CString>>::new(None);
 
+pub(crate) static PG_DOCUMENTDB_USE_PLUGGABLE_AUTH: GucSetting<bool> =
+    GucSetting::<bool>::new(false);
+
 pub fn init() {
     GucRegistry::define_string_guc(
         c"documentdb_gateway.database",
@@ -21,6 +24,14 @@ pub fn init() {
         c"The setup configuration file for the pg_documentdb_gateway BGWorker",
         c"This should be the path to the setup configuration file",
         &PG_DOCUMENTDB_SETUP_CONFIGURATION,
+        GucContext::Postmaster,
+        GucFlags::SUPERUSER_ONLY,
+    );
+    GucRegistry::define_bool_guc(
+        c"documentdb_gateway.use_pluggable_auth",
+        c"Enable the pluggable authentication architecture (RFC-0009)",
+        c"When true, authentication requests are routed through the AuthProviderRegistry. Requires restart.",
+        &PG_DOCUMENTDB_USE_PLUGGABLE_AUTH,
         GucContext::Postmaster,
         GucFlags::SUPERUSER_ONLY,
     );


### PR DESCRIPTION
Refactor monolithic auth handler into trait-based, registry-driven architecture with GUC toggle for staged rollout. Extract SCRAM-SHA-256 and MONGODB-OIDC into standalone providers behind AuthProvider trait. Add AuthProviderRegistry, auth handler routing, Hello command integration, connection lifecycle cleanup, and unit tests. Disabled by default via documentdb_gateway.use_pluggable_auth GUC.