### PR TITLE
MJ: always check for conflicts on insertUpdate even with no-ops; upda…

### DIFF
--- a/pg_documentdb/src/test/regress/expected/bson_update_document_tests.out
+++ b/pg_documentdb/src/test/regress/expected/bson_update_document_tests.out
@@ -1877,6 +1877,19 @@ SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": {
 ERROR:  Modifying the path 'a.b.c.d.e.f' will result in a conflict occurring at 'a.b.c.d.e'
 SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": { "$set": { "a.b.c.d.e": 1 }, "$inc": {"a.b": 1 } } }', '{}');
 ERROR:  Modifying the path 'a.b' will result in a conflict occurring at 'a.b'
+-- test conflicting update operator paths involving $setOnInsert
+-- $mul + $setOnInsert on same field (reported bug: should error regardless of upsert)
+SELECT documentdb_api_internal.bson_update_document('{"foo": "bar"}', '{ "": { "$mul": { "y": -21621 }, "$setOnInsert": { "y": true } } }', '{}');
+ERROR:  Modifying the path 'y' will result in a conflict occurring at 'y'
+-- $set + $setOnInsert on same field
+SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": { "$set": { "a": 1 }, "$setOnInsert": { "a": 2 } } }', '{}');
+ERROR:  Modifying the path 'a' will result in a conflict occurring at 'a'
+-- $setOnInsert + $inc on same field (operators in reverse order)
+SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": { "$setOnInsert": { "a": 1 }, "$inc": { "a": 1 } } }', '{}');
+ERROR:  Modifying the path 'a' will result in a conflict occurring at 'a'
+-- same conflict must also fire on a true upsert (empty source doc)
+SELECT documentdb_api_internal.bson_update_document('{}', '{ "": { "$mul": { "y": 1 }, "$setOnInsert": { "y": true } } }', '{}');
+ERROR:  Modifying the path 'y' will result in a conflict occurring at 'y'
 -- update scenario tests: $currentDate
 -- -- Function that extracts date / timestamp value of a given key in a json obj, and returns the equivalent epoch in ms
 CREATE OR REPLACE FUNCTION get_epochms_from_key(obj json, qkey text, is_date bool)

--- a/pg_documentdb/src/test/regress/sql/bson_update_document_tests.sql
+++ b/pg_documentdb/src/test/regress/sql/bson_update_document_tests.sql
@@ -565,6 +565,16 @@ SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": {
 SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": { "$set": { "a.b.c.d.e": 1 }, "$unset": {"a.b.c.d.e.f": 1 } } }', '{}');
 SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": { "$set": { "a.b.c.d.e": 1 }, "$inc": {"a.b": 1 } } }', '{}');
 
+-- test conflicting update operator paths involving $setOnInsert
+-- $mul + $setOnInsert on same field (reported bug: should error regardless of upsert)
+SELECT documentdb_api_internal.bson_update_document('{"foo": "bar"}', '{ "": { "$mul": { "y": -21621 }, "$setOnInsert": { "y": true } } }', '{}');
+-- $set + $setOnInsert on same field
+SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": { "$set": { "a": 1 }, "$setOnInsert": { "a": 2 } } }', '{}');
+-- $setOnInsert + $inc on same field (operators in reverse order)
+SELECT documentdb_api_internal.bson_update_document('{"data": "data"}', '{ "": { "$setOnInsert": { "a": 1 }, "$inc": { "a": 1 } } }', '{}');
+-- same conflict must also fire on a true upsert (empty source doc)
+SELECT documentdb_api_internal.bson_update_document('{}', '{ "": { "$mul": { "y": 1 }, "$setOnInsert": { "y": true } } }', '{}');
+
 -- update scenario tests: $currentDate
 
 -- -- Function that extracts date / timestamp value of a given key in a json obj, and returns the equivalent epoch in ms

--- a/pg_documentdb/src/update/bson_update_operators_workflow.c
+++ b/pg_documentdb/src/update/bson_update_operators_workflow.c
@@ -1381,7 +1381,8 @@ HandleUnsetUpdateTree(BsonIntermediatePathNode *tree,
 
 
 /*
- * $setOnInsert is a no-op for non-upserts. For upserts, handle it like a basic update tree.
+ * $setOnInsert paths must always be added to the tree so that conflicts -  
+ * even for no-ops when !isUpsert - are detected and reported. 
  */
 static void
 HandleSetOnInsertUpdateTree(BsonIntermediatePathNode *tree, bson_iter_t *updateSpec,
@@ -1390,11 +1391,6 @@ HandleSetOnInsertUpdateTree(BsonIntermediatePathNode *tree, bson_iter_t *updateS
 							const PositionalUpdateSpec *positionalSpec,
 							bool isUpsert)
 {
-	if (!isUpsert)
-	{
-		return;
-	}
-
 	HandleBasicUpdateTree(tree, updateSpec, valuesFunc, stateFunc,
 						  positionalSpec, isUpsert);
 }


### PR DESCRIPTION
## Github Issue: 
https://github.com/documentdb/documentdb/issues/510

## Fix: detect path conflicts involving `$setOnInsert` regardless of upsert mode

### Problem

When an update operation combined `$setOnInsert` with another operator that targeted the same field (e.g., `$set`, `$inc`, `$mul`), the conflict was silently ignored on non-upsert updates. This is because `HandleSetOnInsertUpdateTree` returned early when `isUpsert` was `false`, skipping the path conflict check entirely.

For example, this should always error but previously did not when the document existed:

```js
db.col.update({ foo: "bar" }, { $mul: { y: -21621 }, $setOnInsert: { y: true } })
```

### Root Cause

In `bson_update_operators_workflow.c`, `HandleSetOnInsertUpdateTree` short-circuited with an early `return` for non-upserts before walking the update tree. Path conflict detection happens during tree construction, so the conflicting path was never registered.

### Fix

Remove the early `return` guard so that `$setOnInsert` paths are always added to the update tree. This ensures path conflict detection fires correctly in all cases. The `isUpsert` flag is still forwarded to `HandleBasicUpdateTree`, which uses it to decide whether to actually apply the `$setOnInsert` values.

### Tests

Added regression tests covering:
- `$mul` + `$setOnInsert` on the same field (the originally reported bug)
- `$set` + `$setOnInsert` on the same field
- `$setOnInsert` + `$inc` on the same field (reverse operator order)
- The same conflict on a true upsert (empty source document)

All cases now correctly return:
```
ERROR: Modifying the path 'y' will result in a conflict occurring at 'y'
```