### PR TITLE
Reduce documentdb-local image size

### DIFF
--- a/.github/containers/Build-Ubuntu/Dockerfile_gateway
+++ b/.github/containers/Build-Ubuntu/Dockerfile_gateway
@@ -63,7 +63,7 @@ ARG BASE_IMAGE
 
 # Install dependencies (conditionally add software-properties-common unless base is debian:trixie-slim)
 RUN apt-get update; \
-    PKGS="jq curl sudo git make build-essential openssl pkg-config libssl-dev upx-ucl"; \
+    PKGS="jq curl sudo git make build-essential openssl pkg-config libssl-dev"; \
     if [ "${BASE_IMAGE}" != "debian:trixie-slim" ]; then \
         PKGS="$PKGS software-properties-common"; \
     else \
@@ -92,8 +92,6 @@ RUN sudo chown -R documentdb:documentdb /home/documentdb/code
 WORKDIR /home/documentdb/code/pg_documentdb_gw
 
 RUN CARGO_MANIFEST_DIR=/home/documentdb/code/pg_documentdb_gw cargo build --profile=release-with-symbols
-RUN upx --best --lzma /home/documentdb/code/pg_documentdb_gw/target/release-with-symbols/documentdb_gateway
-
 # Install mongosh in a throwaway stage so the final image only copies the runtime files.
 FROM prebuild AS mongosh
 

--- a/.github/containers/Build-Ubuntu/Dockerfile_gateway
+++ b/.github/containers/Build-Ubuntu/Dockerfile_gateway
@@ -36,13 +36,18 @@ RUN install -d -m 0755 /etc/apt/keyrings; \
     echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" \
         > /etc/apt/sources.list.d/pgdg.list; \
     apt-get update; \
+    RUM_PKG=""; \
+    if [ "${POSTGRES_VERSION}" -lt 18 ]; then \
+        RUM_PKG="postgresql-${POSTGRES_VERSION}-rum"; \
+    fi; \
     apt-get install -y --no-install-recommends \
         postgresql-${POSTGRES_VERSION} \
         postgresql-${POSTGRES_VERSION}-cron \
         postgresql-${POSTGRES_VERSION}-pgvector \
         postgresql-${POSTGRES_VERSION}-postgis-3 \
-        postgresql-${POSTGRES_VERSION}-rum \
+        $RUM_PKG \
     ; \
+    rm -rf /usr/lib/postgresql/${POSTGRES_VERSION}/lib/bitcode; \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /tmp/install_setup
@@ -58,7 +63,7 @@ ARG BASE_IMAGE
 
 # Install dependencies (conditionally add software-properties-common unless base is debian:trixie-slim)
 RUN apt-get update; \
-    PKGS="jq curl sudo git make build-essential openssl pkg-config libssl-dev"; \
+    PKGS="jq curl sudo git make build-essential openssl pkg-config libssl-dev upx-ucl"; \
     if [ "${BASE_IMAGE}" != "debian:trixie-slim" ]; then \
         PKGS="$PKGS software-properties-common"; \
     else \
@@ -87,24 +92,67 @@ RUN sudo chown -R documentdb:documentdb /home/documentdb/code
 WORKDIR /home/documentdb/code/pg_documentdb_gw
 
 RUN CARGO_MANIFEST_DIR=/home/documentdb/code/pg_documentdb_gw cargo build --profile=release-with-symbols
+RUN upx --best --lzma /home/documentdb/code/pg_documentdb_gw/target/release-with-symbols/documentdb_gateway
+
+# Install mongosh in a throwaway stage so the final image only copies the runtime files.
+FROM prebuild AS mongosh
+
+RUN wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | tee /etc/apt/trusted.gpg.d/server-8.0.asc >/dev/null && \
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" > /etc/apt/sources.list.d/mongodb-org-8.0.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends binutils mongodb-mongosh && \
+    strip --strip-debug /usr/bin/mongosh && \
+    rm -rf /var/lib/apt/lists/*
+
+# ----------- Runtime Base Stage -----------
+FROM ${BASE_IMAGE} AS runtime-base
+ARG DEBIAN_FRONTEND
+ARG POSTGRES_VERSION
+ARG DEB_PACKAGE_REL_PATH
+
+RUN [ -n "${DEB_PACKAGE_REL_PATH}" ] || (echo "ERROR: DEB_PACKAGE_REL_PATH build-arg is required. Example: --build-arg DEB_PACKAGE_REL_PATH=packaging/packages/ubuntu22.04-postgresql-16-documentdb_1.0.0_amd64.deb" >&2; exit 1)
+
+COPY ${DEB_PACKAGE_REL_PATH} /tmp/install_setup/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates locales sudo wget gnupg2 lsb-release jq openssl lsof netcat-openbsd && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen && \
+    install -d -m 0755 /etc/apt/keyrings && \
+    wget -qO /etc/apt/keyrings/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    echo "deb [signed-by=/etc/apt/keyrings/pgdg.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" \
+        > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
+    RUM_PKG="" && \
+    if [ "${POSTGRES_VERSION}" -lt 18 ]; then RUM_PKG="postgresql-${POSTGRES_VERSION}-rum"; fi && \
+    apt-get install -y --no-install-recommends \
+    postgresql-${POSTGRES_VERSION} \
+    postgresql-${POSTGRES_VERSION}-cron \
+    postgresql-${POSTGRES_VERSION}-pgvector \
+    postgresql-${POSTGRES_VERSION}-postgis-3 \
+    $RUM_PKG && \
+    groupmod -g 103 postgres && usermod -u 105 -g 103 postgres && \
+    dpkg -i /tmp/install_setup/$(basename "$DEB_PACKAGE_REL_PATH") && \
+    useradd -ms /bin/bash documentdb -G sudo && \
+    echo "%sudo ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/no-pass-ask && \
+    apt-get purge -y wget gnupg2 lsb-release && \
+    apt-get autoremove -y && \
+    rm -rf \
+    /etc/apt/keyrings/pgdg.asc \
+    /etc/apt/sources.list.d/pgdg.list \
+    /tmp/install_setup \
+    /usr/lib/postgresql/${POSTGRES_VERSION}/lib/bitcode \
+    /usr/share/doc/* \
+    /usr/share/man/* \
+    /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 # ----------- Final Gateway Image -----------
-FROM prebuild AS final
+FROM runtime-base AS final
 ARG POSTGRES_VERSION
 
-RUN sudo groupmod -g 103 postgres && sudo usermod -u 105 -g 103 postgres
-RUN sudo apt-get update && \
-    sudo apt-get install -y --no-install-recommends \
-    jq openssl lsof wget gnupg netcat-openbsd && \
-    sudo apt-get upgrade -y && \
-    sudo rm -rf /var/lib/apt/lists/*
-
-RUN wget -qO- https://www.mongodb.org/static/pgp/server-8.0.asc | sudo tee /etc/apt/trusted.gpg.d/server-8.0.asc && \
-    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list && \
-    sudo apt-get update && \
-    sudo apt-get install -y mongodb-mongosh && \
-    sudo apt-get clean && \
-    sudo rm -rf /var/lib/apt/lists/*
 
 ENV LANGUAGE=en_US.UTF-8 \
     TERM=xterm-256color
@@ -135,6 +183,7 @@ RUN sudo mkdir -p /var/run/postgresql && \
     
 COPY --from=stage /home/documentdb/code/pg_documentdb_gw/target/release-with-symbols/documentdb_gateway \
                   /home/documentdb/gateway/pg_documentdb_gw/target/release-with-symbols/documentdb_gateway
+COPY --from=mongosh /usr/bin/mongosh /usr/bin/mongosh
 COPY --from=stage /home/documentdb/code/pg_documentdb_gw/SetupConfiguration.json /home/documentdb/gateway/pg_documentdb_gw/SetupConfiguration.json
 COPY --from=stage /home/documentdb/code/scripts/start_oss_server.sh /home/documentdb/gateway/scripts/start_oss_server.sh
 COPY --from=stage /home/documentdb/code/scripts/build_and_start_gateway.sh /home/documentdb/gateway/scripts/build_and_start_gateway.sh

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -79,6 +79,57 @@ jobs:
           --build-arg DEB_PACKAGE_REL_PATH=downloaded-artifacts/$(ls downloaded-artifacts | grep -v 'dbgsym')  \
           -t ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:$TAG \
           -f .github/containers/Build-Ubuntu/Dockerfile_gateway .
+    - name: Smoke test ${{ matrix.arch }} Image
+      run: |
+        set -euo pipefail
+        TAG=${{ env.IMAGE_TAG }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+        IMAGE=ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:$TAG
+        CONTAINER_NAME=documentdb-local-smoke-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+        SMOKE_DIR=$(mktemp -d)
+        dump_logs=true
+        cleanup() {
+          if [ "$dump_logs" = "true" ]; then
+            docker logs "$CONTAINER_NAME" || true
+          fi
+          docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          rm -rf "$SMOKE_DIR"
+        }
+        wait_for_log() {
+          local pattern="$1"
+          local timeout_seconds="$2"
+          local waited=0
+
+          while ! docker logs "$CONTAINER_NAME" 2>&1 | grep -Fq "$pattern"; do
+            running=$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || echo false)
+            if [ "$running" != "true" ]; then
+              echo "Container exited before log pattern appeared: $pattern" >&2
+              return 1
+            fi
+
+            sleep 2
+            waited=$((waited + 2))
+            if [ "$waited" -ge "$timeout_seconds" ]; then
+              echo "Timed out waiting for log pattern: $pattern" >&2
+              return 1
+            fi
+          done
+        }
+        trap cleanup EXIT
+
+        cat > "$SMOKE_DIR/001-gateway-smoke-init.js" <<'EOF'
+        const smokeDb = db.getSiblingDB('gateway_smoke');
+        smokeDb.image_smoke.deleteMany({});
+        smokeDb.image_smoke.insertOne({ name: 'documentdb-local-smoke', ok: true });
+        EOF
+
+        docker run -d --name "$CONTAINER_NAME" --mount "type=bind,source=$SMOKE_DIR,target=/init_doc_db.d,readonly" "$IMAGE" --username docdb_admin --password 123456 --init-data-path /init_doc_db.d
+
+        wait_for_log "=== DocumentDB is ready ===" 240
+        wait_for_log "Custom data initialization completed." 180
+
+        docker exec "$CONTAINER_NAME" mongosh "localhost:10260" -u docdb_admin -p 123456 --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --quiet --eval 'const count = db.getSiblingDB("gateway_smoke").image_smoke.countDocuments({ name: "documentdb-local-smoke", ok: true }); if (count !== 1) { print(`expected 1 document, found ${count}`); quit(1); }'
+
+        dump_logs=false
     - name: Push ${{ matrix.arch }} Image
       if: github.event.inputs.push_images == 'true' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
       run: |


### PR DESCRIPTION
## Summary
- split the gateway image into build and runtime stages so `documentdb-local` no longer ships the full build toolchain and source tree
- keep the final image on the slimmer runtime base while preserving the `mongosh`-based init flow used by the entrypoint
- add a post-build smoke test in `build_gateway.yml` that starts the image, runs custom init data through `mongosh`, and verifies the inserted document

## Testing
- workflow smoke test added to `build_gateway.yml` for each image build
- workflow YAML and smoke-test shell syntax validated locally