### PR TITLE
[Gateway] Expose documentdb_versions in buildInfo

### DIFF
--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -79,6 +79,83 @@ jobs:
           --build-arg DEB_PACKAGE_REL_PATH=downloaded-artifacts/$(ls downloaded-artifacts | grep -v 'dbgsym')  \
           -t ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:$TAG \
           -f .github/containers/Build-Ubuntu/Dockerfile_gateway .
+    - name: Smoke test ${{ matrix.arch }} Image
+      run: |
+        python3 -m pip install --user --disable-pip-version-check pymongo
+        TAG=${{ env.IMAGE_TAG }}-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+        IMAGE=ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }}:$TAG
+        CONTAINER_NAME=documentdb-local-smoke-pg${{ matrix.pg_version }}-${{ matrix.arch }}
+        cleanup() {
+          local status=$?
+          if [ $status -ne 0 ]; then
+            docker logs "$CONTAINER_NAME" || true
+          fi
+          docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          exit $status
+        }
+        trap cleanup EXIT
+        docker run -d --rm --name "$CONTAINER_NAME" \
+          -p 127.0.0.1:10260:10260 \
+          "$IMAGE" --username testuser --password testpass123
+        python3 - <<'PY'
+        import time
+
+        from pymongo import MongoClient
+
+
+        URI = (
+            "mongodb://testuser:testpass123@127.0.0.1:10260/"
+            "?tls=true&tlsAllowInvalidCertificates=true"
+            "&authMechanism=SCRAM-SHA-256&directConnection=true"
+        )
+
+
+        def assert_version_metadata(command_name: str, result: dict) -> None:
+            internal = result["internal"]
+            versions = internal["documentdb_versions"]
+            assert isinstance(versions, list), f"{command_name} must return a versions list"
+            assert versions, f"{command_name} documentdb_versions must not be empty"
+            assert all(isinstance(version, str) and version for version in versions), (
+                f"{command_name} documentdb_versions must contain non-empty strings"
+            )
+            assert isinstance(internal["kind"], str) and internal["kind"], (
+                f"{command_name} must include a non-empty internal.kind"
+            )
+
+
+        last_error = None
+        for _ in range(60):
+            client = MongoClient(
+                URI,
+                serverSelectionTimeoutMS=1000,
+                connectTimeoutMS=1000,
+            )
+            try:
+                hello = client.admin.command("hello")
+                build_info = client.admin.command("buildInfo")
+                assert_version_metadata("hello", hello)
+                assert_version_metadata("buildInfo", build_info)
+                assert hello["internal"] == build_info["internal"], (
+                    "hello and buildInfo must report the same internal version metadata"
+                )
+                assert isinstance(build_info["version"], str) and build_info["version"], (
+                    "buildInfo must preserve the Mongo compatibility version"
+                )
+                assert isinstance(build_info["versionArray"], list), (
+                    "buildInfo must preserve versionArray"
+                )
+                print("Smoke test passed")
+                break
+            except Exception as exc:
+                last_error = exc
+                time.sleep(2)
+            finally:
+                client.close()
+        else:
+            raise AssertionError(
+                f"Timed out waiting for documentdb-local image to expose version metadata: {last_error}"
+            )
+        PY
     - name: Push ${{ matrix.arch }} Image
       if: github.event.inputs.push_images == 'true' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Integrate cargo tools to identify dependencies for pg_documentdb_gw *[Feature]* (#263)
 * Add support for killSessions command *[Feature]* (#402)
 * Support arbitrary database user and password *[Feature]* (#306)
+* Expose DocumentDB version metadata via `buildInfo`, matching `hello` / `isMaster` version reporting *[Bugfix]* (#547)
 * Improved performance for `$max` and `$min` accumulators in `$group` and `$setWindowFields` pipeline stages under flag `enableNewMinMaxAccumulators`. (#457)
 * Fix crash in `bson_dollar_lookup_project` when matched documents array contains NULL elements from LEFT JOIN *[Bugfix]* (#465)
 * Fix crash in `$densify` with `partitionByFields` on shard key due to mismatched sort operators for INT8 partition expression *[Bugfix]* (#464)

--- a/pg_documentdb_gw/documentdb_gateway_core/src/processor/constant.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/processor/constant.rs
@@ -34,6 +34,7 @@ pub fn process_build_info(dynamic_config: &Arc<dyn DynamicConfiguration>) -> Res
         "versionArray": version.as_bson_array(),
         "bits": 64,
         "maxBsonObjectSize": protocol::MAX_BSON_OBJECT_SIZE,
+        "internal": dynamic_config.topology(),
         "ok":OK_SUCCEEDED,
     }))
 }
@@ -658,6 +659,90 @@ static SUPPORTED_COMMANDS : [CommandInfo; 62] = [
 		secondary_override_ok: None,
 	}
 ];
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bson::rawbson;
+
+    use super::process_build_info;
+    use crate::configuration::{DynamicConfiguration, Version};
+
+    #[derive(Debug)]
+    struct BuildInfoConfig;
+
+    impl DynamicConfiguration for BuildInfoConfig {
+        fn get_str(&self, key: &str) -> Option<String> {
+            (key == "serverVersion").then(|| Version::Seven.as_str().to_owned())
+        }
+
+        fn get_bool(&self, _: &str, default: bool) -> bool {
+            default
+        }
+
+        fn get_i32(&self, _: &str, default: i32) -> i32 {
+            default
+        }
+
+        fn get_u64(&self, _: &str, default: u64) -> u64 {
+            default
+        }
+
+        fn equals_value(&self, _: &str, _: &str) -> bool {
+            false
+        }
+
+        fn topology(&self) -> bson::RawBson {
+            rawbson!({
+                "documentdb_versions": ["0.110-0", "0.110.0"],
+                "kind": "documentdb"
+            })
+        }
+
+        fn enable_developer_explain(&self) -> bool {
+            false
+        }
+
+        fn max_connections(&self) -> usize {
+            0
+        }
+
+        fn allow_transaction_snapshot(&self) -> bool {
+            false
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[test]
+    fn build_info_includes_documentdb_topology() {
+        let config: Arc<dyn DynamicConfiguration> = Arc::new(BuildInfoConfig);
+        let response = process_build_info(&config);
+
+        let doc = response
+            .as_json()
+            .expect("buildInfo response should deserialize to BSON document");
+
+        assert_eq!(doc.get_str("version").unwrap(), Version::Seven.as_str());
+        assert!(doc.get_array("versionArray").is_ok());
+
+        let internal = doc
+            .get_document("internal")
+            .expect("buildInfo response should contain internal document");
+        let versions = internal
+            .get_array("documentdb_versions")
+            .expect("internal document should contain documentdb_versions");
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].as_str(), Some("0.110-0"));
+        assert_eq!(versions[1].as_str(), Some("0.110.0"));
+        assert_eq!(internal.get_str("kind").unwrap(), "documentdb");
+
+        assert_eq!(doc.get_f64("ok").unwrap(), 1.0);
+    }
+}
 
 pub fn list_commands() -> Response {
     let mut commands_doc = RawDocumentBuf::new();

--- a/pg_documentdb_gw/documentdb_tests/src/commands/constant.rs
+++ b/pg_documentdb_gw/documentdb_tests/src/commands/constant.rs
@@ -27,7 +27,7 @@
     reason = "Test assertions compare exact float values returned from database"
 )]
 
-use bson::doc;
+use bson::{doc, Document};
 use mongodb::{error::Error, Client, Database};
 
 pub async fn validate_rw_concern(client: &Client) -> Result<(), Error> {
@@ -112,6 +112,29 @@ pub async fn validate_connectivity(client: &Client) -> Result<(), Error> {
     Ok(())
 }
 
+fn validate_documentdb_versions(result: &Document, response_name: &str) {
+    let internal = result
+        .get_document("internal")
+        .unwrap_or_else(|_| panic!("{response_name} must contain 'internal' document"));
+    let versions = internal
+        .get_array("documentdb_versions")
+        .unwrap_or_else(|_| panic!("{response_name} must contain 'documentdb_versions' array"));
+    assert!(
+        !versions.is_empty(),
+        "{response_name} documentdb_versions array must not be empty"
+    );
+    for (i, v) in versions.iter().enumerate() {
+        assert!(
+            v.as_str().is_some(),
+            "{response_name} documentdb_versions[{i}] must be a string"
+        );
+    }
+    assert!(
+        internal.get_str("kind").is_ok(),
+        "{response_name} must contain 'kind' string"
+    );
+}
+
 pub async fn validate_is_master_unauthenticated(client: &Client) -> Result<(), Error> {
     let result = client
         .database("admin")
@@ -121,29 +144,21 @@ pub async fn validate_is_master_unauthenticated(client: &Client) -> Result<(), E
     assert_eq!(result.get_f64("ok").unwrap(), 1.0);
     assert_eq!(result.get_str("msg").unwrap(), "isdbgrid");
 
-    // Validate the internal.documentdb_versions structure
-    let internal = result
-        .get_document("internal")
-        .expect("hello response must contain 'internal' document");
-    let versions = internal
-        .get_array("documentdb_versions")
-        .expect("internal must contain 'documentdb_versions' array");
-    assert!(
-        !versions.is_empty(),
-        "documentdb_versions array must not be empty"
-    );
-    for (i, v) in versions.iter().enumerate() {
-        assert!(
-            v.as_str().is_some(),
-            "documentdb_versions[{i}] must be a string"
-        );
-    }
+    validate_documentdb_versions(&result, "isMaster response");
 
-    // Validate kind field is present as a string
-    assert!(
-        internal.get_str("kind").is_ok(),
-        "internal must contain 'kind' string"
-    );
+    Ok(())
+}
+
+pub async fn validate_build_info_unauthenticated(client: &Client) -> Result<(), Error> {
+    let result = client
+        .database("admin")
+        .run_command(doc! {"buildInfo":1})
+        .await?;
+
+    assert_eq!(result.get_f64("ok").unwrap(), 1.0);
+    assert!(result.get_str("version").is_ok());
+    assert!(result.get_array("versionArray").is_ok());
+    validate_documentdb_versions(&result, "buildInfo response");
 
     Ok(())
 }

--- a/pg_documentdb_gw/documentdb_tests/tests/unauthenticated_tests.rs
+++ b/pg_documentdb_gw/documentdb_tests/tests/unauthenticated_tests.rs
@@ -20,3 +20,12 @@ async fn is_master() -> Result<(), Error> {
 
     constant::validate_is_master_unauthenticated(&client).await
 }
+
+#[tokio::test]
+async fn build_info() -> Result<(), Error> {
+    let _ = initialize::initialize().await?;
+
+    let client = clients::get_client_unauthenticated()?;
+
+    constant::validate_build_info_unauthenticated(&client).await
+}


### PR DESCRIPTION
## Summary
- expose `internal.documentdb_versions` in `buildInfo` using the existing gateway topology metadata
- add unit and unauthenticated gateway coverage for the new `buildInfo` response shape
- smoke-test built `documentdb-local` images for both `hello` and `buildInfo` version reporting

## Validation
- `cargo fmt --all --manifest-path pg_documentdb_gw/Cargo.toml`
- `cargo test --manifest-path pg_documentdb_gw/Cargo.toml -p documentdb_gateway_core build_info_includes_documentdb_topology`
- `cargo test --manifest-path pg_documentdb_gw/Cargo.toml -p documentdb_tests --test unauthenticated_tests --no-run`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build_gateway.yml'); puts 'workflow yaml ok'"`

Fixes #547