### PR TITLE
Add system for get_required_privileges

### DIFF
--- a/pg_documentdb/Makefile
+++ b/pg_documentdb/Makefile
@@ -40,7 +40,7 @@ ALLOW_DEFAULT_VISIBILITY=yes
 
 USE_DOCUMENTDB_CORE = 1
 include $(OSS_SRC_DIR)/Makefile.cflags
-SOURCES = $(wildcard src/*.c) $(wildcard src/**/*.c)
+SOURCES = $(wildcard src/*.c) $(wildcard src/**/*.c) $(wildcard src/**/**/*.c)
 
 OBJS = $(patsubst %.c,%.o,$(SOURCES))
 

--- a/pg_documentdb/documentdb.control
+++ b/pg_documentdb/documentdb.control
@@ -1,5 +1,5 @@
 comment = 'API surface for DocumentDB for PostgreSQL'
-default_version = '0.113-0'
+default_version = '0.114-0'
 module_pathname = '$libdir/pg_documentdb'
 relocatable = false
 superuser = true

--- a/pg_documentdb/sql/documentdb--0.113-0--0.114-0.sql
+++ b/pg_documentdb/sql/documentdb--0.113-0--0.114-0.sql
@@ -1,0 +1,2 @@
+-- Authorization privilege extraction for MongoDB commands
+#include "udfs/auth/auth_authorization--0.114-0.sql"

--- a/pg_documentdb/sql/udfs/auth/auth_authorization--0.114-0.sql
+++ b/pg_documentdb/sql/udfs/auth/auth_authorization--0.114-0.sql
@@ -1,0 +1,9 @@
+/* Get required privileges for a command */
+CREATE OR REPLACE FUNCTION __API_SCHEMA_INTERNAL_V2__.get_required_privileges(
+    p_command __CORE_SCHEMA_V2__.bson)
+ RETURNS __CORE_SCHEMA_V2__.bson
+ LANGUAGE C
+PARALLEL SAFE STABLE
+AS 'MODULE_PATHNAME', $$command_get_required_privileges$$;
+COMMENT ON FUNCTION __API_SCHEMA_INTERNAL_V2__.get_required_privileges(__CORE_SCHEMA_V2__.bson)
+    IS 'Extracts required resource privileges from a MongoDB command specification';

--- a/pg_documentdb/sql/udfs/auth/auth_authorization--latest.sql
+++ b/pg_documentdb/sql/udfs/auth/auth_authorization--latest.sql
@@ -1,0 +1,9 @@
+/* Get required privileges for a command */
+CREATE OR REPLACE FUNCTION __API_SCHEMA_INTERNAL_V2__.get_required_privileges(
+    p_command __CORE_SCHEMA_V2__.bson)
+ RETURNS __CORE_SCHEMA_V2__.bson
+ LANGUAGE C
+PARALLEL SAFE STABLE
+AS 'MODULE_PATHNAME', $$command_get_required_privileges$$;
+COMMENT ON FUNCTION __API_SCHEMA_INTERNAL_V2__.get_required_privileges(__CORE_SCHEMA_V2__.bson)
+    IS 'Extracts required resource privileges from a MongoDB command specification';

--- a/pg_documentdb/src/auth/authorization/authorization.c
+++ b/pg_documentdb/src/auth/authorization/authorization.c
@@ -1,0 +1,565 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/auth/authorization/authorization.c
+ *
+ * Implementation of authorization structures and privilege management
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "authorization.h"
+#include "io/bson_core.h"
+#include "utils/documentdb_errors.h"
+
+#include <string.h>
+
+/* Exported functions */
+PG_FUNCTION_INFO_V1(command_get_required_privileges);
+
+/*
+ * Mapping table for PrivilegeAction to string conversion
+ */
+typedef struct PrivilegeActionMapping
+{
+	PrivilegeAction action;
+	const char *name;
+} PrivilegeActionMapping;
+
+static const PrivilegeActionMapping PrivilegeActionMappings[] = {
+	/* Query and Write Actions */
+	{ PRIV_FIND, "find" },
+	{ PRIV_INSERT, "insert" },
+	{ PRIV_UPDATE, "update" },
+	{ PRIV_REMOVE, "remove" },
+
+	/* Database Management Actions */
+	{ PRIV_CREATE_COLLECTION, "createCollection" },
+	{ PRIV_CREATE_INDEX, "createIndex" },
+	{ PRIV_DROP_COLLECTION, "dropCollection" },
+	{ PRIV_DROP_INDEX, "dropIndex" },
+
+	/* Deployment Management Actions */
+	{ PRIV_LIST_DATABASES, "listDatabases" },
+	{ PRIV_LIST_COLLECTIONS, "listCollections" },
+	{ PRIV_LIST_INDEXES, "listIndexes" },
+
+	/* Replication Actions */
+	{ PRIV_APPEND_OPLOG_NOTE, "appendOplogNote" },
+
+	/* Sharding Actions */
+	{ PRIV_ENABLE_SHARDING, "enableSharding" },
+	{ PRIV_FLUSH_ROUTER_CONFIG, "flushRouterConfig" },
+	{ PRIV_ADD_SHARD, "addShard" },
+	{ PRIV_REMOVE_SHARD, "removeShard" },
+
+	/* Server Administration Actions */
+	{ PRIV_APPLICATION_MESSAGE, "applicationMessage" },
+	{ PRIV_CLOSE_ALL_DATABASES, "closeAllDatabases" },
+	{ PRIV_COMPACT, "compact" },
+	{ PRIV_CONN_POOL_SYNC, "connPoolSync" },
+	{ PRIV_DROP_DATABASE, "dropDatabase" },
+	{ PRIV_FS_SYNC, "fsync" },
+	{ PRIV_GET_PARAMETER, "getParameter" },
+	{ PRIV_HOST_INFO, "hostInfo" },
+	{ PRIV_LOG_ROTATE, "logRotate" },
+	{ PRIV_REINDEX, "reIndex" },
+	{ PRIV_RENAME_COLLECTION_SAME_DB, "renameCollectionSameDB" },
+	{ PRIV_SET_PARAMETER, "setParameter" },
+	{ PRIV_SHUTDOWN, "shutdown" },
+	{ PRIV_TOUCH, "touch" },
+
+	/* Diagnostic Actions */
+	{ PRIV_COLL_STATS, "collStats" },
+	{ PRIV_CONN_POOL_STATS, "connPoolStats" },
+	{ PRIV_CURSOR_INFO, "cursorInfo" },
+	{ PRIV_DB_HASH, "dbHash" },
+	{ PRIV_DB_STATS, "dbStats" },
+	{ PRIV_GET_CMD_LINE_OPTS, "getCmdLineOpts" },
+	{ PRIV_GET_LOG, "getLog" },
+	{ PRIV_INDEX_STATS, "indexStats" },
+	{ PRIV_LIST_SHARDS, "listShards" },
+	{ PRIV_NET_STAT, "netstat" },
+	{ PRIV_SERVER_STATUS, "serverStatus" },
+	{ PRIV_TOP, "top" },
+	{ PRIV_VALIDATE, "validate" },
+
+	/* Internal Actions */
+	{ PRIV_ANY_ACTION, "anyAction" },
+	{ PRIV_INTERNAL, "internal" },
+
+	/* User and Role Management Actions */
+	{ PRIV_CHANGE_CUSTOM_DATA, "changeCustomData" },
+	{ PRIV_CHANGE_PASSWORD, "changePassword" },
+	{ PRIV_CREATE_ROLE, "createRole" },
+	{ PRIV_CREATE_USER, "createUser" },
+	{ PRIV_DROP_ROLE, "dropRole" },
+	{ PRIV_DROP_USER, "dropUser" },
+	{ PRIV_GRANT_ROLE, "grantRole" },
+	{ PRIV_REVOKE_ROLE, "revokeRole" },
+	{ PRIV_VIEW_ROLE, "viewRole" },
+	{ PRIV_VIEW_USER, "viewUser" }
+};
+
+static const int NumPrivilegeActionMappings =
+	sizeof(PrivilegeActionMappings) / sizeof(PrivilegeActionMapping);
+
+
+/*
+ * privilege_action_from_string
+ *
+ * Converts a string to a PrivilegeAction enum value.
+ * Returns PRIV_MAX if the string is not recognized.
+ */
+PrivilegeAction
+privilege_action_from_string(const char *str)
+{
+	int i;
+
+	if (str == NULL)
+	{
+		return PRIV_MAX;
+	}
+
+	for (i = 0; i < NumPrivilegeActionMappings; i++)
+	{
+		if (strcmp(str, PrivilegeActionMappings[i].name) == 0)
+		{
+			return PrivilegeActionMappings[i].action;
+		}
+	}
+
+	return PRIV_MAX;
+}
+
+
+/*
+ * privilege_action_to_string
+ *
+ * Converts a PrivilegeAction enum value to its string representation.
+ * Returns NULL if the action is invalid.
+ */
+const char *
+privilege_action_to_string(PrivilegeAction action)
+{
+	int i;
+
+	if (action < 0 || action >= PRIV_MAX)
+	{
+		return NULL;
+	}
+
+	for (i = 0; i < NumPrivilegeActionMappings; i++)
+	{
+		if (PrivilegeActionMappings[i].action == action)
+		{
+			return PrivilegeActionMappings[i].name;
+		}
+	}
+
+	return NULL;
+}
+
+
+/*
+ * privilege_set_init
+ *
+ * Initialize an empty privilege set (all bits cleared).
+ */
+void
+privilege_set_init(PrivilegeSet *set)
+{
+	int i;
+
+	if (set == NULL)
+	{
+		return;
+	}
+
+	for (i = 0; i < PRIVILEGE_SET_SIZE; i++)
+	{
+		set->bits[i] = 0;
+	}
+}
+
+
+/*
+ * privilege_set_add
+ *
+ * Add a privilege to the set.
+ */
+void
+privilege_set_add(PrivilegeSet *set, PrivilegeAction action)
+{
+	int index;
+	int bit;
+
+	if (set == NULL || action < 0 || action >= PRIV_MAX)
+	{
+		return;
+	}
+
+	index = action / 32;
+	bit = action % 32;
+	set->bits[index] |= (1U << bit);
+}
+
+
+/*
+ * privilege_set_has
+ *
+ * Check if a privilege is in the set.
+ */
+bool
+privilege_set_has(const PrivilegeSet *set, PrivilegeAction action)
+{
+	int index;
+	int bit;
+
+	if (set == NULL || action < 0 || action >= PRIV_MAX)
+	{
+		return false;
+	}
+
+	index = action / 32;
+	bit = action % 32;
+	return (set->bits[index] & (1U << bit)) != 0;
+}
+
+
+/*
+ * resource_privileges_set_create
+ *
+ * Create and initialize a new ResourcePrivilegesSet with initial capacity.
+ */
+ResourcePrivilegesSet *
+resource_privileges_set_create(int initial_capacity)
+{
+	ResourcePrivilegesSet *set;
+
+	if (initial_capacity <= 0)
+	{
+		initial_capacity = 8;
+	}
+
+	set = (ResourcePrivilegesSet *) palloc(sizeof(ResourcePrivilegesSet));
+	set->items = (ResourcePrivileges **) palloc(sizeof(ResourcePrivileges *) *
+												initial_capacity);
+	set->count = 0;
+	set->capacity = initial_capacity;
+
+	return set;
+}
+
+
+/*
+ * resource_privileges_set_add
+ *
+ * Add a resource with privileges to the set.
+ */
+void
+resource_privileges_set_add(ResourcePrivilegesSet *set,
+							const char *database,
+							const char *collection,
+							const PrivilegeSet *privileges)
+{
+	ResourcePrivileges *item;
+
+	if (set == NULL || database == NULL || privileges == NULL)
+	{
+		return;
+	}
+
+	/* Expand capacity if needed */
+	if (set->count >= set->capacity)
+	{
+		int new_capacity = set->capacity * 2;
+		set->items = (ResourcePrivileges **) repalloc(set->items,
+													  sizeof(ResourcePrivileges *) *
+													  new_capacity);
+		set->capacity = new_capacity;
+	}
+
+	/* Allocate and initialize the new item */
+	item = (ResourcePrivileges *) palloc(sizeof(ResourcePrivileges));
+
+	/* Copy database name */
+	strncpy(item->resource.database, database, MAX_DATABASE_NAME_LEN - 1);
+	item->resource.database[MAX_DATABASE_NAME_LEN - 1] = '\0';
+
+	/* Copy collection name if provided */
+	if (collection != NULL)
+	{
+		strncpy(item->resource.collection, collection, MAX_COLLECTION_NAME_LEN - 1);
+		item->resource.collection[MAX_COLLECTION_NAME_LEN - 1] = '\0';
+	}
+	else
+	{
+		item->resource.collection[0] = '\0';
+	}
+
+	/* Copy privileges */
+	memcpy(&item->privileges, privileges, sizeof(PrivilegeSet));
+
+	/* Add to set */
+	set->items[set->count++] = item;
+}
+
+
+/*
+ * resource_privileges_set_free
+ *
+ * Free a ResourcePrivilegesSet and all its contents.
+ */
+void
+resource_privileges_set_free(ResourcePrivilegesSet *set)
+{
+	int i;
+
+	if (set == NULL)
+	{
+		return;
+	}
+
+	/* Free all items */
+	for (i = 0; i < set->count; i++)
+	{
+		if (set->items[i] != NULL)
+		{
+			pfree(set->items[i]);
+		}
+	}
+
+	/* Free the array */
+	if (set->items != NULL)
+	{
+		pfree(set->items);
+	}
+
+	/* Free the set itself */
+	pfree(set);
+}
+
+
+/*
+ * extract_privileges_for_find_command
+ *
+ * Extract privileges for a "find" command.
+ * Returns true on success, false if the command cannot be parsed.
+ */
+static bool
+extract_privileges_for_find_command(pgbson *command_spec,
+									const char *database_name,
+									ResourcePrivilegesSet *result_set)
+{
+	bson_iter_t iter;
+	const char *collection_name = NULL;
+	PrivilegeSet privileges;
+
+	/* Find the "find" field which contains the collection name */
+	if (!PgbsonInitIteratorAtPath(command_spec, "find", &iter))
+	{
+		/* Not a find command */
+		return false;
+	}
+
+	/* The value should be a string (collection name) */
+	if (bson_iter_type(&iter) != BSON_TYPE_UTF8)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_DOCUMENTDB_TYPEMISMATCH),
+				 errmsg("'find' field must be a string")));
+	}
+
+	collection_name = bson_iter_utf8(&iter, NULL);
+
+	/* Create privilege set with PRIV_FIND */
+	privilege_set_init(&privileges);
+	privilege_set_add(&privileges, PRIV_FIND);
+
+	/* Add to result set */
+	resource_privileges_set_add(result_set, database_name, collection_name,
+								&privileges);
+
+	return true;
+}
+
+
+/*
+ * get_required_resource_privileges_for_cmd
+ *
+ * Extract required resource privileges from a BSON command.
+ *
+ * Returns a ResourcePrivilegesSet containing all resources and privileges
+ * needed to execute the command, or NULL if privileges cannot be determined
+ * statically.
+ */
+ResourcePrivilegesSet *
+get_required_resource_privileges_for_cmd(pgbson *bson_spec)
+{
+	ResourcePrivilegesSet *result_set;
+	bson_iter_t iter;
+	const char *database_name = NULL;
+
+	if (bson_spec == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_DOCUMENTDB_BADVALUE),
+				 errmsg("command specification cannot be NULL")));
+	}
+
+	/* Extract database name from $db field */
+	if (PgbsonInitIteratorAtPath(bson_spec, "$db", &iter))
+	{
+		if (bson_iter_type(&iter) == BSON_TYPE_UTF8)
+		{
+			database_name = bson_iter_utf8(&iter, NULL);
+		}
+	}
+
+	if (database_name == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_DOCUMENTDB_BADVALUE),
+				 errmsg("command specification must include '$db' field")));
+	}
+
+	/* Create result set */
+	result_set = resource_privileges_set_create(4);
+
+	/* Try to extract privileges for known commands */
+	if (extract_privileges_for_find_command(bson_spec, database_name, result_set))
+	{
+		return result_set;
+	}
+
+	/* Add more command handlers here as they are implemented */
+
+	/*
+	 * If we reach here, the command is not supported for static privilege
+	 * extraction. Free the result set and return NULL.
+	 */
+	resource_privileges_set_free(result_set);
+	return NULL;
+}
+
+
+/*
+ * command_get_required_privileges
+ *
+ * PostgreSQL function that wraps get_required_resource_privileges_for_cmd
+ * and returns the result as a BSON document.
+ *
+ * Input: pgbson command specification
+ * Output: pgbson with the following format:
+ * {
+ *   "ok": 1.0,
+ *   "canDeterminePrivileges": true/false,
+ *   "privileges": [
+ *     {
+ *       "resource": { "db": "database", "collection": "collection" },
+ *       "actions": ["find", "insert", ...]
+ *     }
+ *   ]
+ * }
+ */
+Datum
+command_get_required_privileges(PG_FUNCTION_ARGS)
+{
+	pgbson *command_spec;
+	ResourcePrivilegesSet *privilege_set;
+	pgbson_writer result_writer;
+	int i;
+
+	if (PG_ARGISNULL(0))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_DOCUMENTDB_BADVALUE),
+				 errmsg("command specification cannot be NULL")));
+	}
+
+	command_spec = PG_GETARG_PGBSON(0);
+
+	/* Try to extract privileges */
+	privilege_set = get_required_resource_privileges_for_cmd(command_spec);
+
+	/* Build result BSON */
+	PgbsonWriterInit(&result_writer);
+	PgbsonWriterAppendDouble(&result_writer, "ok", 2, 1.0);
+
+	if (privilege_set == NULL)
+	{
+		/* Cannot determine privileges statically */
+		PgbsonWriterAppendBool(&result_writer, "canDeterminePrivileges", -1, false);
+	}
+	else
+	{
+		pgbson_writer privileges_array_writer;
+		pgbson_array_writer array_writer;
+
+		PgbsonWriterAppendBool(&result_writer, "canDeterminePrivileges", -1, true);
+
+		/* Start privileges array */
+		PgbsonWriterStartArray(&result_writer, "privileges", -1, &array_writer);
+
+		for (i = 0; i < privilege_set->count; i++)
+		{
+			ResourcePrivileges *item = privilege_set->items[i];
+			pgbson_writer resource_writer;
+			pgbson_array_writer actions_array_writer;
+			int j;
+
+			/* Start privilege object */
+			PgbsonArrayWriterStartDocument(&array_writer, &privileges_array_writer);
+
+			/* Write resource */
+			PgbsonWriterStartDocument(&privileges_array_writer, "resource", -1,
+									  &resource_writer);
+			PgbsonWriterAppendUtf8(&resource_writer, "db", 2,
+								   item->resource.database);
+
+			if (item->resource.collection[0] != '\0')
+			{
+				PgbsonWriterAppendUtf8(&resource_writer, "collection", -1,
+									   item->resource.collection);
+			}
+			else
+			{
+				/* Empty collection means all collections in the database */
+				PgbsonWriterAppendUtf8(&resource_writer, "collection", -1, "");
+			}
+
+			PgbsonWriterEndDocument(&privileges_array_writer, &resource_writer);
+
+			/* Write actions array */
+			PgbsonWriterStartArray(&privileges_array_writer, "actions", -1,
+								   &actions_array_writer);
+
+			for (j = 0; j < PRIV_MAX; j++)
+			{
+				if (privilege_set_has(&item->privileges, j))
+				{
+					const char *priv_name = privilege_action_to_string(j);
+					if (priv_name != NULL)
+					{
+						PgbsonArrayWriterWriteUtf8(&actions_array_writer, priv_name);
+					}
+				}
+			}
+
+			PgbsonWriterEndArray(&privileges_array_writer, &actions_array_writer);
+
+			/* End privilege object */
+			PgbsonArrayWriterEndDocument(&array_writer, &privileges_array_writer);
+		}
+
+		PgbsonWriterEndArray(&result_writer, &array_writer);
+
+		/* Clean up */
+		resource_privileges_set_free(privilege_set);
+	}
+
+	PG_RETURN_POINTER(PgbsonWriterGetPgbson(&result_writer));
+}

--- a/pg_documentdb/src/auth/authorization/authorization.h
+++ b/pg_documentdb/src/auth/authorization/authorization.h
@@ -1,0 +1,238 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/auth/authorization/authorization.h
+ *
+ * Authorization structures and privilege management for MongoDB compatibility
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef AUTHORIZATION_H
+#define AUTHORIZATION_H
+
+#include "postgres.h"
+#include "io/bson_core.h"
+
+/*
+ * PrivilegeAction Enum
+ *
+ * Lists all MongoDB privilege actions as defined in:
+ * https://www.mongodb.com/docs/manual/reference/privilege-actions/
+ */
+typedef enum PrivilegeAction
+{
+	/* Query and Write Actions */
+	PRIV_FIND = 0,
+	PRIV_INSERT,
+	PRIV_UPDATE,
+	PRIV_REMOVE,
+
+	/* Database Management Actions */
+	PRIV_CREATE_COLLECTION,
+	PRIV_CREATE_INDEX,
+	PRIV_DROP_COLLECTION,
+	PRIV_DROP_INDEX,
+
+	/* Deployment Management Actions */
+	PRIV_LIST_DATABASES,
+	PRIV_LIST_COLLECTIONS,
+	PRIV_LIST_INDEXES,
+
+	/* Replication Actions */
+	PRIV_APPEND_OPLOG_NOTE,
+
+	/* Sharding Actions */
+	PRIV_ENABLE_SHARDING,
+	PRIV_FLUSH_ROUTER_CONFIG,
+	PRIV_ADD_SHARD,
+	PRIV_REMOVE_SHARD,
+
+	/* Server Administration Actions */
+	PRIV_APPLICATION_MESSAGE,
+	PRIV_CLOSE_ALL_DATABASES,
+	PRIV_COMPACT,
+	PRIV_CONN_POOL_SYNC,
+	PRIV_DROP_DATABASE,
+	PRIV_FS_SYNC,
+	PRIV_GET_PARAMETER,
+	PRIV_HOST_INFO,
+	PRIV_LOG_ROTATE,
+	PRIV_REINDEX,
+	PRIV_RENAME_COLLECTION_SAME_DB,
+	PRIV_SET_PARAMETER,
+	PRIV_SHUTDOWN,
+	PRIV_TOUCH,
+
+	/* Diagnostic Actions */
+	PRIV_COLL_STATS,
+	PRIV_CONN_POOL_STATS,
+	PRIV_CURSOR_INFO,
+	PRIV_DB_HASH,
+	PRIV_DB_STATS,
+	PRIV_GET_CMD_LINE_OPTS,
+	PRIV_GET_LOG,
+	PRIV_INDEX_STATS,
+	PRIV_LIST_SHARDS,
+	PRIV_NET_STAT,
+	PRIV_SERVER_STATUS,
+	PRIV_TOP,
+	PRIV_VALIDATE,
+
+	/* Internal Actions */
+	PRIV_ANY_ACTION,
+	PRIV_INTERNAL,
+
+	/* User and Role Management Actions */
+	PRIV_CHANGE_CUSTOM_DATA,
+	PRIV_CHANGE_PASSWORD,
+	PRIV_CREATE_ROLE,
+	PRIV_CREATE_USER,
+	PRIV_DROP_ROLE,
+	PRIV_DROP_USER,
+	PRIV_GRANT_ROLE,
+	PRIV_REVOKE_ROLE,
+	PRIV_VIEW_ROLE,
+	PRIV_VIEW_USER,
+
+	/* Keep this last for bitmap sizing */
+	PRIV_MAX
+} PrivilegeAction;
+
+
+/*
+ * Privileges (Bitmap)
+ *
+ * Bitmap for storing and comparing privileges on any action.
+ * Each bit represents a PrivilegeAction.
+ */
+#define PRIVILEGE_SET_SIZE ((PRIV_MAX + 31) / 32)
+
+typedef struct Privileges
+{
+	uint32 bits[PRIVILEGE_SET_SIZE];
+} PrivilegeSet;
+
+
+/*
+ * Role
+ *
+ * Represents a role within a specific database.
+ */
+#define MAX_DATABASE_NAME_LEN 64
+#define MAX_ROLE_NAME_LEN 64
+
+typedef struct Role
+{
+	char database[MAX_DATABASE_NAME_LEN];
+	char role[MAX_ROLE_NAME_LEN];
+} Role;
+
+
+/*
+ * Resource
+ *
+ * Represents a database resource (database and/or collection).
+ */
+#define MAX_COLLECTION_NAME_LEN 255
+
+typedef struct Resource
+{
+	char database[MAX_DATABASE_NAME_LEN];
+	char collection[MAX_COLLECTION_NAME_LEN];
+} Resource;
+
+
+/*
+ * ResourcePrivileges
+ *
+ * Associates a set of privileges with a specific resource.
+ */
+typedef struct ResourcePrivileges
+{
+	Resource resource;
+	PrivilegeSet privileges;
+} ResourcePrivileges;
+
+
+/*
+ * ResourcePrivilegesSet
+ *
+ * Dynamic array of resource privileges.
+ */
+typedef struct ResourcePrivilegesSet
+{
+	ResourcePrivileges **items;
+	int count;
+	int capacity;
+} ResourcePrivilegesSet;
+
+
+/* Function declarations */
+
+/*
+ * Convert a string to a PrivilegeAction enum value.
+ * Returns PRIV_MAX if the string is not recognized.
+ */
+extern PrivilegeAction privilege_action_from_string(const char *str);
+
+/*
+ * Convert a PrivilegeAction enum value to its string representation.
+ * Returns NULL if the action is invalid.
+ */
+extern const char *privilege_action_to_string(PrivilegeAction action);
+
+/* PrivilegeSet manipulation functions */
+
+/*
+ * Initialize an empty privilege set (all bits cleared).
+ */
+extern void privilege_set_init(PrivilegeSet *set);
+
+/*
+ * Add a privilege to the set.
+ */
+extern void privilege_set_add(PrivilegeSet *set, PrivilegeAction action);
+
+/*
+ * Check if a privilege is in the set.
+ */
+extern bool privilege_set_has(const PrivilegeSet *set, PrivilegeAction action);
+
+/* ResourcePrivilegesSet manipulation functions */
+
+/*
+ * Create and initialize a new ResourcePrivilegesSet with initial capacity.
+ */
+extern ResourcePrivilegesSet *resource_privileges_set_create(int initial_capacity);
+
+/*
+ * Add a resource with privileges to the set.
+ */
+extern void resource_privileges_set_add(ResourcePrivilegesSet *set,
+										const char *database,
+										const char *collection,
+										const PrivilegeSet *privileges);
+
+/*
+ * Free a ResourcePrivilegesSet and all its contents.
+ */
+extern void resource_privileges_set_free(ResourcePrivilegesSet *set);
+
+/* Command privilege extraction */
+
+/*
+ * Extract required resource privileges from a BSON command.
+ *
+ * Returns a ResourcePrivilegesSet containing all resources and privileges
+ * needed to execute the command, or NULL if privileges cannot be determined
+ * statically (e.g., killOp where privileges depend on runtime context).
+ *
+ * The caller is responsible for freeing the returned set using
+ * resource_privileges_set_free().
+ *
+ * On error (invalid command format), throws an ereport ERROR.
+ */
+extern ResourcePrivilegesSet *get_required_resource_privileges_for_cmd(pgbson *bson_spec);
+
+#endif   /* AUTHORIZATION_H */

--- a/pg_documentdb/src/auth/authorization/test_authorization.c
+++ b/pg_documentdb/src/auth/authorization/test_authorization.c
@@ -1,0 +1,89 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * src/auth/authorization/test_authorization.c
+ *
+ * Example/test code for authorization privilege extraction
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+#include "fmgr.h"
+#include "authorization.h"
+#include "io/bson_core.h"
+
+/*
+ * Example test function that demonstrates how to use the privilege extraction
+ *
+ * Usage:
+ *   SELECT documentdb_test_privilege_extraction('{ "find": "users", "$db": "test" }');
+ */
+PG_FUNCTION_INFO_V1(documentdb_test_privilege_extraction);
+
+Datum
+documentdb_test_privilege_extraction(PG_FUNCTION_ARGS)
+{
+	pgbson *command_spec;
+	ResourcePrivilegesSet *privilege_set;
+	StringInfoData result;
+	int i;
+
+	if (PG_ARGISNULL(0))
+	{
+		PG_RETURN_NULL();
+	}
+
+	command_spec = PG_GETARG_PGBSON(0);
+
+	/* Extract privileges */
+	privilege_set = get_required_resource_privileges_for_cmd(command_spec);
+
+	if (privilege_set == NULL)
+	{
+		PG_RETURN_TEXT_P(cstring_to_text(
+							 "Cannot determine privileges statically for this command"));
+	}
+
+	/* Build result string */
+	initStringInfo(&result);
+	appendStringInfo(&result, "Required privileges:\n");
+
+	for (i = 0; i < privilege_set->count; i++)
+	{
+		ResourcePrivileges *item = privilege_set->items[i];
+		int j;
+
+		appendStringInfo(&result, "  Resource: db=%s, collection=%s\n",
+						 item->resource.database,
+						 item->resource.collection[0] ? item->resource.collection : "*");
+
+		appendStringInfo(&result, "  Privileges: ");
+
+		/* List all privileges in the set */
+		bool first = true;
+		for (j = 0; j < PRIV_MAX; j++)
+		{
+			if (privilege_set_has(&item->privileges, j))
+			{
+				const char *priv_name = privilege_action_to_string(j);
+				if (priv_name != NULL)
+				{
+					if (!first)
+					{
+						appendStringInfo(&result, ", ");
+					}
+					appendStringInfo(&result, "%s", priv_name);
+					first = false;
+				}
+			}
+		}
+
+		appendStringInfo(&result, "\n");
+	}
+
+	/* Clean up */
+	resource_privileges_set_free(privilege_set);
+
+	PG_RETURN_TEXT_P(cstring_to_text(result.data));
+}

--- a/pg_documentdb/src/test/regress/expected/authorization/authorization_get_required_privileges_find.out
+++ b/pg_documentdb/src/test/regress/expected/authorization/authorization_get_required_privileges_find.out
@@ -1,0 +1,98 @@
+SET search_path TO documentdb_core,documentdb_api_catalog,public;
+SET
+SET documentdb_core.bsonUseEJson TO true;
+SET
+SET search_path TO documentdb_api_catalog;
+SET
+SET documentdb.next_collection_id TO 2000;
+SET
+SET documentdb.next_collection_index_id TO 2000;
+SET
+-- TEST authorization get_required_privileges function for FIND command
+--   Test file to test the function:
+--     documentdb_api_internal.get_required_privileges()
+--   This test specifically validates privilege extraction for the 'find' MongoDB command
+-- Test 1: Basic find command
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test", "$db": "db"}');
+                                                                                  get_required_privileges                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "db", "collection" : "authorization_test" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 2: Find command with filter
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test", "filter": {"name": "test"}, "$db": "db"}');
+                                                                                  get_required_privileges                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "db", "collection" : "authorization_test" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 3: Find command with projection and sort
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test", "filter": {"name": "test"}, "projection": {"name": 1}, "sort": {"name": 1}, "$db": "db"}');
+                                                                                  get_required_privileges                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "db", "collection" : "authorization_test" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 4: Find command on different collection
+SELECT documentdb_api_internal.get_required_privileges('{"find": "other_collection", "$db": "db"}');
+                                                                                 get_required_privileges                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "db", "collection" : "other_collection" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 5: Find command on different database
+SELECT documentdb_api_internal.get_required_privileges('{"find": "test_collection", "$db": "other_db"}');
+                                                                                   get_required_privileges                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "other_db", "collection" : "test_collection" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 6: Error case - missing $db field
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test"}');
+ERROR:  command specification must include '$db' field
+-- Test 7: Error case - invalid find field type (not a string)
+SELECT documentdb_api_internal.get_required_privileges('{"find": 123, "$db": "db"}');
+ERROR:  'find' field must be a string
+-- Test 8: Error case - find field is a number
+SELECT documentdb_api_internal.get_required_privileges('{"find": {"$numberInt": "5"}, "$db": "db"}');
+ERROR:  'find' field must be a string
+-- Test 9: Find with special characters in collection name
+SELECT documentdb_api_internal.get_required_privileges('{"find": "my.collection.name", "$db": "db"}');
+                                                                                  get_required_privileges                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "db", "collection" : "my.collection.name" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 10: Find with empty collection name
+SELECT documentdb_api_internal.get_required_privileges('{"find": "", "$db": "db"}');
+                                                                         get_required_privileges                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "db", "collection" : "" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 11: Find with very long collection name (near MAX_COLLECTION_NAME_LEN)
+SELECT documentdb_api_internal.get_required_privileges(('{"find": "' || repeat('a', 250) || '", "$db": "db"}')::documentdb_core.bson);
+                                                                                                                                                                                                      get_required_privileges                                                                                                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "db", "collection" : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 12: Find with very long database name (near MAX_DATABASE_NAME_LEN)
+SELECT documentdb_api_internal.get_required_privileges(('{"find": "test_collection", "$db": "' || repeat('d', 60) || '"}')::documentdb_core.bson);
+                                                                                                             get_required_privileges                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "ok" : { "$numberDouble" : "1.0" }, "canDeterminePrivileges" : true, "privileges" : [ { "resource" : { "db" : "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "collection" : "test_collection" }, "actions" : [ "find" ] } ] }
+(1 row)
+
+-- Test 13: Error case - NULL command
+SELECT documentdb_api_internal.get_required_privileges(NULL);
+ERROR:  command specification cannot be NULL
+-- Test 14: Error case - empty BSON document
+SELECT documentdb_api_internal.get_required_privileges('{}');
+ERROR:  command specification must include '$db' field
+-- Test 15: Error case - $db field is not a string
+SELECT documentdb_api_internal.get_required_privileges('{"find": "test_collection", "$db": 123}');
+ERROR:  command specification must include '$db' field
+-- Test 16: Error case - $db field is null
+SELECT documentdb_api_internal.get_required_privileges('{"find": "test_collection", "$db": null}');
+ERROR:  command specification must include '$db' field

--- a/pg_documentdb/src/test/regress/sql/authorization/authorization_get_required_privileges_find.sql
+++ b/pg_documentdb/src/test/regress/sql/authorization/authorization_get_required_privileges_find.sql
@@ -1,0 +1,56 @@
+SET search_path TO documentdb_api_catalog;
+SET documentdb.next_collection_id TO 2000;
+SET documentdb.next_collection_index_id TO 2000;
+
+-- TEST authorization get_required_privileges function for FIND command
+--   Test file to test the function:
+--     documentdb_api_internal.get_required_privileges()
+--   This test specifically validates privilege extraction for the 'find' MongoDB command
+
+-- Test 1: Basic find command
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test", "$db": "db"}');
+
+-- Test 2: Find command with filter
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test", "filter": {"name": "test"}, "$db": "db"}');
+
+-- Test 3: Find command with projection and sort
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test", "filter": {"name": "test"}, "projection": {"name": 1}, "sort": {"name": 1}, "$db": "db"}');
+
+-- Test 4: Find command on different collection
+SELECT documentdb_api_internal.get_required_privileges('{"find": "other_collection", "$db": "db"}');
+
+-- Test 5: Find command on different database
+SELECT documentdb_api_internal.get_required_privileges('{"find": "test_collection", "$db": "other_db"}');
+
+-- Test 6: Error case - missing $db field
+SELECT documentdb_api_internal.get_required_privileges('{"find": "authorization_test"}');
+
+-- Test 7: Error case - invalid find field type (not a string)
+SELECT documentdb_api_internal.get_required_privileges('{"find": 123, "$db": "db"}');
+
+-- Test 8: Error case - find field is a number
+SELECT documentdb_api_internal.get_required_privileges('{"find": {"$numberInt": "5"}, "$db": "db"}');
+
+-- Test 9: Find with special characters in collection name
+SELECT documentdb_api_internal.get_required_privileges('{"find": "my.collection.name", "$db": "db"}');
+
+-- Test 10: Find with empty collection name
+SELECT documentdb_api_internal.get_required_privileges('{"find": "", "$db": "db"}');
+
+-- Test 11: Find with very long collection name (near MAX_COLLECTION_NAME_LEN)
+SELECT documentdb_api_internal.get_required_privileges(('{"find": "' || repeat('a', 250) || '", "$db": "db"}')::documentdb_core.bson);
+
+-- Test 12: Find with very long database name (near MAX_DATABASE_NAME_LEN)
+SELECT documentdb_api_internal.get_required_privileges(('{"find": "test_collection", "$db": "' || repeat('d', 60) || '"}')::documentdb_core.bson);
+
+-- Test 13: Error case - NULL command
+SELECT documentdb_api_internal.get_required_privileges(NULL);
+
+-- Test 14: Error case - empty BSON document
+SELECT documentdb_api_internal.get_required_privileges('{}');
+
+-- Test 15: Error case - $db field is not a string
+SELECT documentdb_api_internal.get_required_privileges('{"find": "test_collection", "$db": 123}');
+
+-- Test 16: Error case - $db field is null
+SELECT documentdb_api_internal.get_required_privileges('{"find": "test_collection", "$db": null}');


### PR DESCRIPTION
## Summary

This change implements the foundational authorization privilege extraction system for DocumentDB, introducing a new `get_required_privileges()` function that analyzes MongoDB commands and returns the required resource privileges needed to execute them. This is the first step in building a MongoDB-compatible Role-Based Access Control (RBAC) system.

## Overview

This CR introduces a static privilege extraction system that:
1. Parses MongoDB command BSON specifications
2. Determines which resources (database/collection) are accessed
3. Identifies what privilege actions (find, insert, update, etc.) are required
4. Internal UDF for testing privilege extraction for commands

**Current Scope**: Implements extraction for `find` commands as a proof-of-concept. Future commands will follow the same pattern.

### Test Coverage (authorization_get_required_privileges_find.sql - 16 tests)

**PostgreSQL Interface:**
- `command_get_required_privileges()` - PG_FUNCTION_INFO_V1 wrapper
  - Input: BSON command specification
  - Output: BSON with format:
    ```json
    {
      "ok": 1.0,
      "canDeterminePrivileges": true,
      "privileges": [
        {
          "resource": {"db": "test", "collection": "users"},
          "actions": ["find"]
        }
      ]
    }
    ```
  - Returns `canDeterminePrivileges: false` for unsupported commands


**Positive Test Cases:**
- Basic find command
- Find with filters, projections, sort
- Different collections and databases
- Special characters in collection names
- Boundary conditions (very long names)