### PR TITLE
Update CHANGELOG.md release date for v0.111-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Migrate `DrainStreamingQuery` from SPI cursor-based execution to direct executor invocation via `DestReceiver`, eliminating Portal/SPI overhead for streaming queries *[Perf]*
 * Add `enableSortPushToAccumulator` GUC to control pushing sort order into accumulator in `$sortGroup`; disabled by default while pending stabilization. *[Bugfix]*
 
-### documentdb v0.111-0 (Unreleased) ###
+### documentdb v0.111-0 (May 11, 2026) ###
 * Support index pushdown for `$group` stage when `_id` is a single-field document expression (e.g., `{ _id: { "field": "$path" } }`) *[Perf]*
 * Add init background job infrastructure for running one time C callback initialization tasks before the periodic job loop. Guarded by `enableBackgroundWorkerInitJobs` feature flag *[Feature]*
 * Add feature flag `enableCollationWithIndexes` to `enableCollationWithNonUniqueOrderedIndexes` to gate collation support specifically for non-unique ordered/composite indexes. Collation is rejected for other index types/options *[Feature]*


### PR DESCRIPTION
Update v0.111-0 from `(Unreleased)` to `(May 11, 2026)`.

Related: https://github.com/documentdb/documentdb/releases/tag/v0.111-0