### PR TITLE
Fix ALLOW_EXTERNAL_CONNECTIONS check in emulator_entrypoint.sh

### DIFF
--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -371,7 +371,7 @@ if [ "$START_POSTGRESQL" = "true" ]; then
     echo "Setting permissions on $DATA_PATH"
     sudo chmod -R 750 "$DATA_PATH"
     
-    if ALLOW_EXTERNAL_CONNECTIONS="true"; then
+    if [ "${ALLOW_EXTERNAL_CONNECTIONS:-}" = "true" ]; then
         echo "Allowing external connections to PostgreSQL..."
         export PGOPTIONS="-e"
     fi


### PR DESCRIPTION
## Summary

The line
```bash
if ALLOW_EXTERNAL_CONNECTIONS="true"; then
```
in `documentdb-local/scripts/emulator_entrypoint.sh` is **not** a string comparison — it is a variable assignment. Bash treats variable assignments as commands that succeed (`$?` = 0), so the `if` branch is always taken regardless of the actual value (or absence) of `ALLOW_EXTERNAL_CONNECTIONS`. The block unconditionally `export PGOPTIONS="-e"`, which `start_oss_server.sh` translates into `listen_addresses = '*'` plus a permissive `pg_hba.conf` (`host all all 0.0.0.0/0 scram-sha-256`).

## Why this matters

The script's own `--help` text documents `--allow-external-connections` as **defaulting to `false`** (line 96–99). The CLI parser correctly exports the variable from `--allow-external-connections <value>` (line 201–204). The intent is clearly opt-in.

The bug means:

1. **Security regression**: Users who only `docker run -p 10260:10260 ghcr.io/documentdb/documentdb/documentdb-local` (publishing just the gateway port) still end up running a PostgreSQL coordinator bound to every interface inside the container with a wide-open `pg_hba.conf`. While the host port is not published, the broader attack surface inside the container is unintended.
2. **Footgun for downstream integrations**: Any tooling that publishes the PG port (`9712`) explicitly relies on this accidental default. Fixing the typo without a coordinated downstream update would silently break those consumers — see for example [microsoft/azure-databases-aspire#69](https://github.com/microsoft/azure-databases-aspire/pull/69), which now explicitly sets `ALLOW_EXTERNAL_CONNECTIONS=true` precisely to be resilient to this fix.

## Fix

Replace the assignment with the standard bash string-equality test, using `${VAR:-}` to safely handle the unset case:

```bash
if [ "${ALLOW_EXTERNAL_CONNECTIONS:-}" = "true" ]; then
```

This matches the pattern already used elsewhere in the same script (for example `DISABLE_EXTENDED_RUM` on line 380, `CREATE_USER` on line 391).

## Behavior change

| Before | After |
|---|---|
| `PGOPTIONS=-e` is always exported. PG always listens on `*`. | `PGOPTIONS=-e` is exported only when `ALLOW_EXTERNAL_CONNECTIONS=true` is explicitly set (env var or `--allow-external-connections true`). |

This restores the documented default. Users that need external PG connectivity must opt in explicitly, which is the documented behavior.

## Testing

```bash
# Simulate the script logic in isolation:

# Unset (should NOT enable external):
$ unset ALLOW_EXTERNAL_CONNECTIONS
$ if [ "${ALLOW_EXTERNAL_CONNECTIONS:-}" = "true" ]; then echo on; else echo off; fi
off

# Set to "false" (should NOT enable):
$ ALLOW_EXTERNAL_CONNECTIONS=false bash -c 'if [ "${ALLOW_EXTERNAL_CONNECTIONS:-}" = "true" ]; then echo on; else echo off; fi'
off

# Set to "true" (SHOULD enable):
$ ALLOW_EXTERNAL_CONNECTIONS=true bash -c 'if [ "${ALLOW_EXTERNAL_CONNECTIONS:-}" = "true" ]; then echo on; else echo off; fi'
on
```

vs. the buggy form, which prints `on` in all three cases.
