### PR TITLE
Add PostgreSQL 19 support to build pipelines (internal + GitHub)

### DIFF
--- a/.github/workflows/build_deb_packages.yml
+++ b/.github/workflows/build_deb_packages.yml
@@ -43,8 +43,8 @@ jobs:
       matrix:
         ${{ fromJson(
           (github.event_name == 'pull_request' && !inputs.use_full_matrix) &&
-          '{"include":[{"os":"deb12","arch":"amd64","runner":"ubuntu-24.04","pg_version":"17"},{"os":"ubuntu22.04","arch":"arm64","runner":"ubuntu-24.04-arm","pg_version":"18"}]}' ||
-          '{"os":["deb11","deb12","deb13","ubuntu22.04","ubuntu24.04"],"arch":["amd64","arm64"],"include":[{"arch":"amd64","runner":"ubuntu-24.04"},{"arch":"arm64","runner":"ubuntu-24.04-arm"}],"pg_version":["16","17","18"]}'
+          '{"include":[{"os":"deb12","arch":"amd64","runner":"ubuntu-24.04","pg_version":"17"},{"os":"ubuntu22.04","arch":"arm64","runner":"ubuntu-24.04-arm","pg_version":"19"}]}' ||
+          '{"os":["deb11","deb12","deb13","ubuntu22.04","ubuntu24.04"],"arch":["amd64","arm64"],"include":[{"arch":"amd64","runner":"ubuntu-24.04"},{"arch":"arm64","runner":"ubuntu-24.04-arm"}],"pg_version":["16","17","18","19"]}'
         ) }}
 
     steps:

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -52,6 +52,7 @@ jobs:
           - 16
           - 17
           - 18
+          - 19
     runs-on: ${{ matrix.runner }}
     outputs:
       documentdb_version: ${{ steps.extract_version.outputs.documentdb_version }}
@@ -150,6 +151,7 @@ jobs:
           - 16
           - 17
           - 18
+          - 19
     runs-on: ubuntu-22.04
     needs: build-and-push
     steps:

--- a/.github/workflows/build_rpm_packages.yml
+++ b/.github/workflows/build_rpm_packages.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       # Use reduced matrix for PRs, full matrix for pushes/releases
-      matrix: ${{ fromJson((github.event_name == 'pull_request' && !inputs.use_full_matrix) && '{"include":[{"os":"rhel9","arch":"amd64","runner":"ubuntu-24.04","pg_version":"17"},{"os":"rhel9","arch":"arm64","runner":"ubuntu-24.04-arm","pg_version":"18"}]}' || '{"os":["rhel8","rhel9"],"arch":["amd64","arm64"],"include":[{"arch":"amd64","runner":"ubuntu-24.04"},{"arch":"arm64","runner":"ubuntu-24.04-arm"}],"pg_version":["16","17","18"]}') }}
+      matrix: ${{ fromJson((github.event_name == 'pull_request' && !inputs.use_full_matrix) && '{"include":[{"os":"rhel9","arch":"amd64","runner":"ubuntu-24.04","pg_version":"17"},{"os":"rhel9","arch":"arm64","runner":"ubuntu-24.04-arm","pg_version":"19"}]}' || '{"os":["rhel8","rhel9"],"arch":["amd64","arm64"],"include":[{"arch":"amd64","runner":"ubuntu-24.04"},{"arch":"arm64","runner":"ubuntu-24.04-arm"}],"pg_version":["16","17","18","19"]}') }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/gateway_tests.yml
+++ b/.github/workflows/gateway_tests.yml
@@ -37,6 +37,9 @@ jobs:
           - pg_version: 18
             arch: arm64
             runner: ubuntu-22.04-arm
+          - pg_version: 19
+            arch: amd64
+            runner: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/regress_tests.yml
+++ b/.github/workflows/regress_tests.yml
@@ -38,6 +38,9 @@ jobs:
           - pg_version: 18
             arch: arm64
             runner: ubuntu-22.04-arm
+          - pg_version: 19
+            arch: amd64
+            runner: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v5
@@ -58,7 +61,7 @@ jobs:
         export LANGUAGE=en_US
         export LC_COLLATE=en_US.UTF-8
         export LC_CTYPE=en_US.UTF-8
-        if [ "${{ matrix.pg_version }}" -eq 18 ]; then
+        if [ "${{ matrix.pg_version }}" -ge 18 ]; then
           make check-no-distributed
         else
           make check

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -16,7 +16,7 @@ Supported DEB/Ubuntu distributions:
 - ubuntu22.04 — Ubuntu 22.04 (jammy)
 - ubuntu24.04 — Ubuntu 24.04 (noble)
 
-Supported PG versions: 15, 16, 17, 18
+Supported PG versions: 15, 16, 17, 18, 19
 
 ## Building RPM Packages
 
@@ -30,7 +30,7 @@ Supported RPM distributions:
 - rhel8 (Red Hat Enterprise Linux 8 compatible)
 - rhel9 (Red Hat Enterprise Linux 9 compatible)
 
-Supported PG versions: 15, 16, 17, 18
+Supported PG versions: 15, 16, 17, 18, 19
 
 ### RPM Build Prerequisites
 
@@ -79,6 +79,6 @@ Supported DEB/Ubuntu distributions:
 - ubuntu22.04 — Ubuntu 22.04 (jammy)
 - ubuntu24.04 — Ubuntu 24.04 (noble)
 
-Supported PG versions: 15, 16, 17, 18
+Supported PG versions: 15, 16, 17, 18, 19
 
 The resulting gateway packages will be placed in the output directory (default: `packaging`). You can change the output location with the `--output-dir` option.

--- a/packaging/build_packages.sh
+++ b/packaging/build_packages.sh
@@ -14,7 +14,7 @@ function show_help {
     echo ""
     echo "Mandatory Arguments:"
     echo "  --os                 OS to build packages for. Possible values: [deb11, deb12, ubuntu22.04, ubuntu24.04, rhel8, rhel9]"
-    echo "  --pg                 PG version to build packages for. Possible values: [15, 16, 17, 18]"
+    echo "  --pg                 PG version to build packages for. Possible values: [15, 16, 17, 18, 19]"
     echo ""
     echo "Optional Arguments:"
     echo "  --version            The version of documentdb to build. Examples: [0.100.0, 0.101.0]"
@@ -55,11 +55,11 @@ while [[ $# -gt 0 ]]; do
         --pg)
             shift
             case $1 in
-                15|16|17|18)
+                15|16|17|18|19)
                     PG=$1
                     ;;
                 *)
-                    echo "Invalid --pg value. Allowed values are [15, 16, 17, 18]"
+                    echo "Invalid --pg value. Allowed values are [15, 16, 17, 18, 19]"
                     exit 1
                     ;;
             esac

--- a/scripts/build_documentdb_with_scripts.sh
+++ b/scripts/build_documentdb_with_scripts.sh
@@ -6,7 +6,7 @@ set -e
 
 usage() {
     echo "Usage: $0 --pg-version <version> [--citus-version <version>]"
-    echo "  --pg-version: PostgreSQL version (required, e.g., 15, 16, 17, 18)"
+    echo "  --pg-version: PostgreSQL version (required, e.g., 15, 16, 17, 18, 19)"
     echo "  --citus-version: Citus version (optional, defaults to 12)"
     exit 1
 }

--- a/scripts/setup_versions.sh
+++ b/scripts/setup_versions.sh
@@ -8,6 +8,10 @@ set -e
 # declare all the versions of dependencies
 LIBBSON_VERSION=1.28.0
 
+# PostgreSQL 19 is not GA yet; track the latest pre-release tag.
+# TODO: bump to REL_19_0 once PostgreSQL 19 is released.
+POSTGRES_19_REF="REL_19_BETA1"
+
 # This maps to REL_18_0:3d6a828938a5fa0444275d3d2f67b64ec3199eb7
 POSTGRES_18_REF="REL_18_0"
 
@@ -39,7 +43,9 @@ UNCRUSTIFY_VERSION=uncrustify-0.68.1
 function GetPostgresSourceRef()
 {
   local pgVersion=$1
-  if [ "$pgVersion" == "18" ]; then
+  if [ "$pgVersion" == "19" ]; then
+    echo $POSTGRES_19_REF
+  elif [ "$pgVersion" == "18" ]; then
     echo $POSTGRES_18_REF
   elif [ "$pgVersion" == "17" ]; then
     echo $POSTGRES_17_REF
@@ -56,7 +62,9 @@ function GetPostgresSourceRef()
 function GetCitusVersion()
 {
   local citusVersion=$1
-  if [ "$PGVERSION" == "18" ]; then
+  if [ "$PGVERSION" == "19" ]; then
+    echo $CITUS_14_VERSION
+  elif [ "$PGVERSION" == "18" ]; then
     echo $CITUS_14_VERSION
   elif [ "$PGVERSION" == "17" ]; then
     echo $CITUS_14_VERSION


### PR DESCRIPTION
Closes #603.

Extends the build/test pipelines to cover **PostgreSQL 19** alongside the existing 15/16/17/18 matrix, mirroring the prior pg18 enablement work (#351).

## Changes

- **`scripts/setup_versions.sh`** — added `POSTGRES_19_REF` plus `19` branches in `GetPostgresSourceRef` and `GetCitusVersion`.
- **`.github/workflows/regress_tests.yml`** — added pg19 matrix entry; widened the distributed-test skip guard from `-eq 18` to `-ge 18` (Citus not supported yet on 18+).
- **`.github/workflows/gateway_tests.yml`** — added pg19 matrix entry.
- **`.github/workflows/build_deb_packages.yml`** / **`build_rpm_packages.yml`** — added `19` to the full matrix; promoted the newest-version PR-matrix slot from 18 to 19.
- **`.github/workflows/build_gateway.yml`** (documentdb-local image) — added `18` and `19` to both matrices (previously only 15/16/17).
- **`packaging/build_packages.sh`** — accept `19` for `--pg`.
- **`scripts/build_documentdb_with_scripts.sh`**, **`packaging/README.md`** — docs/usage updated.

The RUM/PostGIS version gates in the deb/rpm Dockerfiles and install scripts already key off `>= 18` / `-lt 18`, so they cover pg19 automatically.

## Notes / follow-ups

- **`POSTGRES_19_REF` is set to a pre-release tag (`REL_19_BETA1`)** since pg19 isn't GA. It carries a `TODO` to bump to `REL_19_0` on release (mirroring the pg18 GA bump).
- **Citus on pg19** is the primary build risk: pg19 maps to the same Citus ref as pg18 (`CITUS_14_VERSION`). If that ref doesn't compile against pg19, the Citus install step will need to be gated off for pg19 (the way public RUM already is for 18+).
- `build_gateway.yml` had no pg18 entry before; it was added here so the documentdb-local image matrix is consistent across 15–19.