### PR TITLE
Adds scripts and sample data files to debian and rhel packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ install-documentdb:
 	$(MAKE) -C pg_documentdb_core install
 	$(MAKE) -C pg_documentdb install
 	$(MAKE) -C pg_documentdb_extended_rum install
+	$(MAKE) -C scripts install
+	$(MAKE) -C documentdb-local/scripts install
+	$(MAKE) -C documentdb-local/sample-data install
 
 .DEFAULT:
 	$(MAKE) -C pg_documentdb_core
@@ -31,3 +34,6 @@ install-documentdb:
 	$(MAKE) -C pg_documentdb $@
 	$(MAKE) -C pg_documentdb_extended_rum $@
 	$(MAKE) -C internal/pg_documentdb_distributed $@
+	$(MAKE) -C scripts $@
+	$(MAKE) -C documentdb-local/scripts $@
+	$(MAKE) -C documentdb-local/sample-data $@

--- a/documentdb-local/sample-data/Makefile
+++ b/documentdb-local/sample-data/Makefile
@@ -1,0 +1,11 @@
+.PHONY: check
+
+install:
+	/usr/bin/install -d $(DESTDIR)/usr/share/documentdb/sample-data/
+	/usr/bin/install -m 644 01-users.js $(DESTDIR)/usr/share/documentdb/sample-data/01-users.js
+	/usr/bin/install -m 644 02-products.js $(DESTDIR)/usr/share/documentdb/sample-data/02-products.js
+	/usr/bin/install -m 644 03-orders.js $(DESTDIR)/usr/share/documentdb/sample-data/03-orders.js
+	/usr/bin/install -m 644 04-analytics.js $(DESTDIR)/usr/share/documentdb/sample-data/04-analytics.js
+	/usr/bin/install -m 644 README.md $(DESTDIR)/usr/share/documentdb/sample-data/README.md
+
+check:

--- a/documentdb-local/scripts/Makefile
+++ b/documentdb-local/scripts/Makefile
@@ -1,0 +1,8 @@
+.PHONY: check
+
+install:
+	/usr/bin/install -d $(DESTDIR)/usr/share/documentdb/scripts/
+	/usr/bin/install -m 644 emulator_entrypoint.sh $(DESTDIR)/usr/share/documentdb/scripts/emulator_entrypoint.sh
+	/usr/bin/install -m 644 init_documentdb_data.sh $(DESTDIR)/usr/share/documentdb/scripts/init_documentdb_data.sh
+
+check:

--- a/packaging/build_packages.sh
+++ b/packaging/build_packages.sh
@@ -175,7 +175,6 @@ elif [[ "$PACKAGE_TYPE" == "rpm" ]]; then
         --build-arg BASE_IMAGE="$DOCKER_IMAGE" \
         --build-arg POSTGRES_VERSION="$PG" \
         --build-arg DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" "$script_dir"
-    # Run the Docker container to build the packages
     docker run --rm --env OS="$OS" --env POSTGRES_VERSION="$PG" --env DOCUMENTDB_VERSION="$DOCUMENTDB_VERSION" -v "$abs_output_dir:/output" "$TAG"
 fi
 

--- a/packaging/deb/common/control
+++ b/packaging/deb/common/control
@@ -6,5 +6,5 @@ Maintainer: Shuai Tian <shuaitian@microsoft.com>
 
 Package: postgresql-POSTGRES_VERSION-documentdb
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-POSTGRES_VERSION, postgresql-POSTGRES_VERSION-cron, postgresql-POSTGRES_VERSION-pgvector, postgresql-POSTGRES_VERSION-postgis-3, postgresql-POSTGRES_VERSION-rum
+Depends: ${shlibs:Depends}, ${misc:Depends}, postgresql-POSTGRES_VERSION, postgresql-POSTGRES_VERSION-cron, postgresql-POSTGRES_VERSION-pgvector, postgresql-POSTGRES_VERSION-postgis-3, postgresql-POSTGRES_VERSION-rum, jq
 Description: DocumentDB is the open-source engine powering vCore-based Azure Cosmos DB for MongoDB. It offers a native implementation of document-oriented NoSQL database, enabling seamless CRUD operations on BSON data types within a PostgreSQL framework.

--- a/packaging/gateway/docker/Dockerfile_documentdb_local
+++ b/packaging/gateway/docker/Dockerfile_documentdb_local
@@ -45,6 +45,7 @@ RUN install -d -m 0755 /etc/apt/keyrings; \
         postgresql-${POSTGRES_VERSION}-cron \
         postgresql-${POSTGRES_VERSION}-pgvector \
         postgresql-${POSTGRES_VERSION}-postgis-3 \
+        jq \
         $RUM_PKG \
     ; \
     rm -rf /usr/lib/postgresql/${POSTGRES_VERSION}/lib/bitcode; \

--- a/packaging/gateway/test/Dockerfile_deb_gateway_test
+++ b/packaging/gateway/test/Dockerfile_deb_gateway_test
@@ -40,6 +40,7 @@ RUN install -d -m 0755 /etc/apt/keyrings; \
         postgresql-${POSTGRES_VERSION}-cron \
         postgresql-${POSTGRES_VERSION}-pgvector \
         postgresql-${POSTGRES_VERSION}-postgis-3 \
+        jq \
         $RUM_PKG \
     ; \
     rm -rf /var/lib/apt/lists/*

--- a/packaging/rpm/spec/documentdb.spec
+++ b/packaging/rpm/spec/documentdb.spec
@@ -31,6 +31,7 @@ Requires:       (pgvector_%{pg_version} or percona-pgvector_%{pg_version})
 Requires:       pg_cron_%{pg_version}
 Requires:       postgis36_%{pg_version}
 Requires:       rum_%{pg_version}
+Requires:       jq
 # Libbson is now bundled, so no runtime Requires for it.
 # pcre2 is statically linked.
 # libbid.a is bundled.
@@ -75,6 +76,20 @@ cp -P /usr/%{_lib}/libbson-1.0.so %{buildroot}%{_libdir}/
 cp -P /usr/%{_lib}/libbson-1.0.so.0 %{buildroot}%{_libdir}/
 # static library
 cp /usr/%{_lib}/pkgconfig/libbson-static-1.0.pc %{buildroot}%{_libdir}/pkgconfig/
+# install scripts
+cp -P /usr/share/documentdb/scripts/utils.sh %{buildroot}%{_datadir}/documentdb/scripts/utils.sh
+cp -P /usr/share/documentdb/scripts/start_oss_server.sh %{buildroot}%{_datadir}/documentdb/scripts/start_oss_server.sh
+cp -P /usr/share/documentdb/scripts/build_and_start_gateway.sh %{buildroot}%{_datadir}/documentdb/scripts/build_and_start_gateway.sh
+cp -P /usr/share/documentdb/scripts/emulator_entrypoint.sh %{buildroot}%{_datadir}/documentdb/scripts/emulator_entrypoint.sh
+cp -P /usr/share/documentdb/scripts/init_documentdb_data.sh %{buildroot}%{_datadir}/documentdb/scripts/init_documentdb_data.sh
+cp -P /usr/share/documentdb/scripts/setup_psqlrc.sh %{buildroot}%{_datadir}/documentdb/scripts/setup_psqlrc.sh
+cp -P /usr/share/documentdb/scripts/documentdb-setup.sh %{buildroot}%{_datadir}/documentdb/scripts/documentdb-setup.sh
+# install sample data
+cp -P /usr/share/documentdb/sample-data/01-users.js %{buildroot}%{_datadir}/documentdb/sample-data/01-users.js
+cp -P /usr/share/documentdb/sample-data/02-products.js %{_datadir}/documentdb/sample-data/02-products.js
+cp -P /usr/share/documentdb/sample-data/03-orders.js %{_datadir}/documentdb/sample-data/03-orders.js
+cp -P /usr/share/documentdb/sample-data/04-analytics.js %{_datadir}/documentdb/sample-data/04-analytics.js
+cp -P /usr/share/documentdb/sample-data/README.md %{_datadir}/documentdb/sample-data/README.md
 
 # Install source code and test files for make check
 mkdir -p %{buildroot}/usr/src/documentdb
@@ -98,8 +113,27 @@ rm -rf %{buildroot}/usr/src/documentdb/build
 %{_libdir}/libbson-1.0.so.0
 %{_libdir}/libbson-1.0.so.0.0.0
 %{_libdir}/pkgconfig/libbson-static-1.0.pc
+# scripts needed for docker container and cli
+%{_datadir}/documentdb/scripts/utils.sh
+%{_datadir}/documentdb/scripts/start_oss_server.sh
+%{_datadir}/documentdb/scripts/build_and_start_gateway.sh
+%{_datadir}/documentdb/scripts/emulator_entrypoint.sh
+%{_datadir}/documentdb/scripts/init_documentdb_data.sh
+%{_datadir}/documentdb/scripts/setup_psqlrc.sh
+%{_datadir}/documentdb/scripts/documentdb-setup.sh
+# sample data needed for docker container and cli
+%{_datadir}/documentdb/sample-data/01-users.js
+%{_datadir}/documentdb/sample-data/02-products.js
+%{_datadir}/documentdb/sample-data/03-orders.js
+%{_datadir}/documentdb/sample-data/04-analytics.js
+%{_datadir}/documentdb/sample-data/README.md
+
+
 
 %changelog
+* Mon Jun 8 2026 Suchandra Thapa <suchandra@gmail.com> - 0.115
+- Add scripts and sample data to rpm packaging
+
 * Fri Aug 29 2025 Shuai Tian <shuaitian@microsoft.com> - 0.106-0
 - Add internal extension that provides extensions to the `rum` index. *[Feature]*
 - Enable let support for update queries *[Feature]*. Requires `EnableVariablesSupportForWriteCommands` to be `on`.

--- a/packaging/rpm/spec/documentdb.spec
+++ b/packaging/rpm/spec/documentdb.spec
@@ -76,20 +76,6 @@ cp -P /usr/%{_lib}/libbson-1.0.so %{buildroot}%{_libdir}/
 cp -P /usr/%{_lib}/libbson-1.0.so.0 %{buildroot}%{_libdir}/
 # static library
 cp /usr/%{_lib}/pkgconfig/libbson-static-1.0.pc %{buildroot}%{_libdir}/pkgconfig/
-# install scripts
-cp -P /usr/share/documentdb/scripts/utils.sh %{buildroot}%{_datadir}/documentdb/scripts/utils.sh
-cp -P /usr/share/documentdb/scripts/start_oss_server.sh %{buildroot}%{_datadir}/documentdb/scripts/start_oss_server.sh
-cp -P /usr/share/documentdb/scripts/build_and_start_gateway.sh %{buildroot}%{_datadir}/documentdb/scripts/build_and_start_gateway.sh
-cp -P /usr/share/documentdb/scripts/emulator_entrypoint.sh %{buildroot}%{_datadir}/documentdb/scripts/emulator_entrypoint.sh
-cp -P /usr/share/documentdb/scripts/init_documentdb_data.sh %{buildroot}%{_datadir}/documentdb/scripts/init_documentdb_data.sh
-cp -P /usr/share/documentdb/scripts/setup_psqlrc.sh %{buildroot}%{_datadir}/documentdb/scripts/setup_psqlrc.sh
-cp -P /usr/share/documentdb/scripts/documentdb-setup.sh %{buildroot}%{_datadir}/documentdb/scripts/documentdb-setup.sh
-# install sample data
-cp -P /usr/share/documentdb/sample-data/01-users.js %{buildroot}%{_datadir}/documentdb/sample-data/01-users.js
-cp -P /usr/share/documentdb/sample-data/02-products.js %{_datadir}/documentdb/sample-data/02-products.js
-cp -P /usr/share/documentdb/sample-data/03-orders.js %{_datadir}/documentdb/sample-data/03-orders.js
-cp -P /usr/share/documentdb/sample-data/04-analytics.js %{_datadir}/documentdb/sample-data/04-analytics.js
-cp -P /usr/share/documentdb/sample-data/README.md %{_datadir}/documentdb/sample-data/README.md
 
 # Install source code and test files for make check
 mkdir -p %{buildroot}/usr/src/documentdb
@@ -120,7 +106,7 @@ rm -rf %{buildroot}/usr/src/documentdb/build
 %{_datadir}/documentdb/scripts/emulator_entrypoint.sh
 %{_datadir}/documentdb/scripts/init_documentdb_data.sh
 %{_datadir}/documentdb/scripts/setup_psqlrc.sh
-%{_datadir}/documentdb/scripts/documentdb-setup.sh
+# %{_datadir}/documentdb/scripts/documentdb-setup.sh
 # sample data needed for docker container and cli
 %{_datadir}/documentdb/sample-data/01-users.js
 %{_datadir}/documentdb/sample-data/02-products.js
@@ -131,9 +117,6 @@ rm -rf %{buildroot}/usr/src/documentdb/build
 
 
 %changelog
-* Mon Jun 8 2026 Suchandra Thapa <suchandra@gmail.com> - 0.115
-- Add scripts and sample data to rpm packaging
-
 * Fri Aug 29 2025 Shuai Tian <shuaitian@microsoft.com> - 0.106-0
 - Add internal extension that provides extensions to the `rum` index. *[Feature]*
 - Enable let support for update queries *[Feature]*. Requires `EnableVariablesSupportForWriteCommands` to be `on`.

--- a/packaging/test_packages/deb/Dockerfile-deb-test
+++ b/packaging/test_packages/deb/Dockerfile-deb-test
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-${POSTGRES_VERSION}-cron \
     postgresql-${POSTGRES_VERSION}-pgvector \
     postgresql-${POSTGRES_VERSION}-postgis-3 \
+    jq \
     $(if [ "${POSTGRES_VERSION}" -lt 18 ]; then echo "postgresql-${POSTGRES_VERSION}-rum"; else echo ""; fi)
 
 WORKDIR /test-install

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -6,7 +6,6 @@ install:
 	/usr/bin/install -m 644 start_oss_server.sh $(DESTDIR)/usr/share/documentdb/scripts/start_oss_server.sh
 	/usr/bin/install -m 644 build_and_start_gateway.sh $(DESTDIR)/usr/share/documentdb/scripts/build_and_start_gateway.sh
 	/usr/bin/install -m 644 setup_psqlrc.sh $(DESTDIR)/usr/share/documentdb/scripts/setup_psqlrc.sh
-#	/usr/bin/install -m 644 documentdb-setup.sh $(DESTDIR)/usr/share/documentdb/scripts/documentdb-setup.sh
 
 check:
 

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,0 +1,12 @@
+.PHONY: check
+
+install:
+	/usr/bin/install -d $(DESTDIR)/usr/share/documentdb/scripts/
+	/usr/bin/install -m 644 utils.sh $(DESTDIR)/usr/share/documentdb/scripts/utils.sh
+	/usr/bin/install -m 644 start_oss_server.sh $(DESTDIR)/usr/share/documentdb/scripts/start_oss_server.sh
+	/usr/bin/install -m 644 build_and_start_gateway.sh $(DESTDIR)/usr/share/documentdb/scripts/build_and_start_gateway.sh
+	/usr/bin/install -m 644 setup_psqlrc.sh $(DESTDIR)/usr/share/documentdb/scripts/setup_psqlrc.sh
+#	/usr/bin/install -m 644 documentdb-setup.sh $(DESTDIR)/usr/share/documentdb/scripts/documentdb-setup.sh
+
+check:
+


### PR DESCRIPTION
Addresses issue #563  - tested this with rhel8, rhel9, deb12, and ubuntu24.04 and pg18 so I'm pretty sure the other items on the test matrix will work 