### PR TITLE
Update CHANGELOG.md release dates for v0.112-0 and v0.113-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fix `$sample` TABLESAMPLE optimization not being applied on sharded collections when preceded by an empty filter. Guarded by `enableSampleScanFixOnSharded` feature flag *[Bugfix]*
 * Schema Validation: enabled by default.
 
-### documentdb v0.113-0 (Unreleased) ###
+### documentdb v0.113-0 (June 22, 2026) ###
 * Add `EnableSortPushToAccumulator` GUC to control pushing sort order into accumulator in `$sortGroup` stage *[Perf]*
 * Support collation with non-unique ordered indexes with $elemMatch. Requires `EnableCollationWithNonUniqueOrderedIndexes` flag to be `on`.  *[Feature]*
 * Use in-place tuple overwrite instead of delete-and-reinsert when vacuuming RUM entry page posting lists *[Perf]*
@@ -20,7 +20,7 @@
 * Support `$elemMatch`, `$slice`, and `$` positional projection operators in `findAndModify` by routing through the find-specific projection path *[Feature]*
 * Enable index-only scan for `$group` accumulators when all referenced fields are covered by the composite index *[Perf]*
 
-### documentdb v0.112-0 (Unreleased) ###
+### documentdb v0.112-0 (May 26, 2026) ###
 * Removed feature flag `documentdb.enableUpdateBsonDocument` and dropped legacy composite-returning `bson_update_document` UDF — all callers now use the scalar `update_bson_document` UDF
 * Eliminate subquery migration in $group for unsharded and sharded with constant _id aggregation queries. Guarded with `EnableGroupSubqueryElimination` *[Perf]*
 * Support collation with non-unique ordered indexes with $lt, $lte. Requires `EnableCollationWithNonUniqueOrderedIndexes` flag to be `on`.  *[Feature]*


### PR DESCRIPTION
Marks the `v0.112-0` and `v0.113-0` CHANGELOG sections as released, matching their published GitHub release dates and the existing dating convention (e.g. `v0.111-0 (May 11, 2026)`).

- `v0.112-0 (Unreleased)` → `v0.112-0 (May 26, 2026)` (published 2026-05-26; date was previously missed)
- `v0.113-0 (Unreleased)` → `v0.113-0 (June 22, 2026)` (published 2026-06-22)

Documentation/changelog-only change; no code or behavior impact.