### PR TITLE
Add identity labels to DocumentDB Local image for discovery

### DIFF
--- a/packaging/gateway/docker/Dockerfile_documentdb_local
+++ b/packaging/gateway/docker/Dockerfile_documentdb_local
@@ -152,6 +152,12 @@ ENV LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 FROM runtime-base AS final
 ARG POSTGRES_VERSION
 
+# Identity labels baked into the image so tooling (e.g. the VS Code DocumentDB
+# extension) can discover a running DocumentDB Local container by label alone —
+# no container-name, port, log, or env inspection required. Every container
+# inherits these regardless of the --name / -p / --label chosen at `docker run`.
+LABEL org.opencontainers.image.title="DocumentDB Local" \
+      com.documentdb.documentdb.local="true"
 
 ENV LANGUAGE=en_US.UTF-8 \
     TERM=xterm-256color


### PR DESCRIPTION
## What

Bake identity labels into the `final` stage of the DocumentDB Local image (`packaging/gateway/docker/Dockerfile_documentdb_local`):

```dockerfile
LABEL org.opencontainers.image.title="DocumentDB Local" \
      com.documentdb.documentdb.local="true"
```

## Why

Today the DocumentDB Local runtime image carries **no** label, and the documented `docker run` flow uses a user-chosen `--name` and port with no `--label`. That leaves tooling (e.g. the VS Code DocumentDB extension) with no privacy-safe way to discover a running DocumentDB Local container it did not itself create:

- **Name/port are not reliable** — users pick their own.
- **Logs/env are off-limits** — the container env carries the user's `USERNAME`/`PASSWORD`, so inspecting it (or reading logs) is a privacy problem.

A baked-in image label is inherited by **every** container from the image regardless of the `--name`, `-p`, or `--label` chosen at `docker run`, and is filterable via `docker ps --filter label=com.documentdb.documentdb.local=true` — no name, port, log, or env inspection required.

## Labels

- `org.opencontainers.image.title="DocumentDB Local"` — OCI standard image title.
- `com.documentdb.documentdb.local="true"` — stable discovery key for tooling.

## Notes

- Discovery only works for images built/pulled **after** this ships; existing pulled images stay unlabeled until re-pulled.
- Validated with `docker build --check` (no warnings).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
