### PR TITLE
Fix explain executionStats InternalError on PostgreSQL 18

### DIFF
--- a/pg_documentdb_gw/documentdb_gateway_core/src/explain/mod.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/explain/mod.rs
@@ -2313,4 +2313,43 @@ mod tests {
 
         assert_eq!(error.error_code(), crate::error::ErrorCode::BadValue);
     }
+
+    #[test]
+    fn parses_pg18_fractional_actual_rows() {
+        let pg18_explain = serde_json::json!([
+            {
+                "Plan": {
+                    "Node Type": "Nested Loop",
+                    "Actual Rows": 7.0,
+                    "Actual Loops": 1,
+                    "Plans": [
+                        {
+                            "Node Type": "Index Only Scan",
+                            "Index Name": "in2_k_idx",
+                            "Actual Rows": 2.33,
+                            "Actual Loops": 3,
+                            "Rows Removed by Filter": 1.67,
+                            "Heap Fetches": 0.5,
+                            "Shared Hit Blocks": 4.5
+                        }
+                    ]
+                },
+                "Planning Time": 0.1,
+                "Execution Time": 0.2
+            }
+        ]);
+
+        let parsed: Result<Vec<super::model::PostgresExplain>, _> =
+            serde_json::from_value(pg18_explain);
+
+        let plans = parsed.expect("PG18 fractional row counts must deserialize");
+        let root = &plans[0].plan;
+        assert_eq!(root.actual_rows, Some(7));
+        let inner = &root.inner_plans.as_ref().expect("inner plan")[0];
+        // 2.33 rounds to 2, 1.67 rounds to 2.
+        assert_eq!(inner.actual_rows, Some(2));
+        assert_eq!(inner.rows_removed_by_filter, Some(2));
+        assert_eq!(inner.heap_fetches, Some(1));
+        assert_eq!(inner.shared_hit_blocks, Some(5));
+    }
 }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/explain/mod.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/explain/mod.rs
@@ -2339,7 +2339,7 @@ mod tests {
             }
         ]);
 
-        let parsed: Result<Vec<super::model::PostgresExplain>, _> =
+        let parsed: serde_json::Result<Vec<super::model::PostgresExplain>> =
             serde_json::from_value(pg18_explain);
 
         let plans = parsed.expect("PG18 fractional row counts must deserialize");

--- a/pg_documentdb_gw/documentdb_gateway_core/src/explain/model.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/explain/model.rs
@@ -6,7 +6,24 @@
  *-------------------------------------------------------------------------
  */
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize an optional integer counter, tolerating fractional values.
+///
+/// `PostgreSQL` 18 prints per-node runtime counters averaged over `Actual
+/// Loops`, so they can arrive as floats (e.g. `2.33`) when loops > 1. We round
+/// back to `i64` so both the PG18 and pre-18 wire formats parse.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "runtime counters are small; rounding an averaged f64 back to i64 is intentional"
+)]
+fn de_opt_round_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: Option<f64> = Option::deserialize(deserializer)?;
+    Ok(value.map(|v| v.round() as i64))
+}
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
@@ -66,7 +83,7 @@ pub struct PostgresExplain {
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct ExplainPlan {
-    #[serde(rename = "Actual Rows")]
+    #[serde(rename = "Actual Rows", default, deserialize_with = "de_opt_round_i64")]
     pub actual_rows: Option<i64>,
 
     #[serde(rename = "Actual Total Time")]
@@ -89,7 +106,7 @@ pub struct ExplainPlan {
     #[serde(rename = "Group Key")]
     pub group_key: Option<Vec<String>>,
 
-    #[serde(rename = "Heap Fetches")]
+    #[serde(rename = "Heap Fetches", default, deserialize_with = "de_opt_round_i64")]
     pub heap_fetches: Option<i64>,
 
     #[serde(rename = "Index Cond")]
@@ -139,10 +156,18 @@ pub struct ExplainPlan {
     #[serde(rename = "Parent Relationship")]
     pub parent_relationship: Option<String>,
 
-    #[serde(rename = "Rows Removed by Filter")]
+    #[serde(
+        rename = "Rows Removed by Filter",
+        default,
+        deserialize_with = "de_opt_round_i64"
+    )]
     pub rows_removed_by_filter: Option<i64>,
 
-    #[serde(rename = "Rows Removed by Index Recheck")]
+    #[serde(
+        rename = "Rows Removed by Index Recheck",
+        default,
+        deserialize_with = "de_opt_round_i64"
+    )]
     pub rows_removed_by_index: Option<i64>,
 
     #[serde(rename = "Scan Direction")]
@@ -160,7 +185,7 @@ pub struct ExplainPlan {
     #[serde(rename = "Sort Space Type")]
     pub sort_space_type: Option<String>,
 
-    #[serde(rename = "Sort Space Used")]
+    #[serde(rename = "Sort Space Used", default, deserialize_with = "de_opt_round_i64")]
     pub sort_space_used: Option<i64>,
 
     #[serde(rename = "Startup Cost")]
@@ -172,19 +197,19 @@ pub struct ExplainPlan {
     #[serde(rename = "Function Name")]
     pub function_name: Option<String>,
 
-    #[serde(rename = "Exact Heap Blocks")]
+    #[serde(rename = "Exact Heap Blocks", default, deserialize_with = "de_opt_round_i64")]
     pub exact_heap_blocks: Option<i64>,
 
-    #[serde(rename = "Lossy Heap Blocks")]
+    #[serde(rename = "Lossy Heap Blocks", default, deserialize_with = "de_opt_round_i64")]
     pub lossy_heap_blocks: Option<i64>,
 
-    #[serde(rename = "Shared Hit Blocks")]
+    #[serde(rename = "Shared Hit Blocks", default, deserialize_with = "de_opt_round_i64")]
     pub shared_hit_blocks: Option<i64>,
 
-    #[serde(rename = "Shared Read Blocks")]
+    #[serde(rename = "Shared Read Blocks", default, deserialize_with = "de_opt_round_i64")]
     pub shared_read_blocks: Option<i64>,
 
-    #[serde(rename = "I/O Read Time")]
+    #[serde(rename = "I/O Read Time", default, deserialize_with = "de_opt_round_i64")]
     pub io_read_time: Option<i64>,
 
     #[serde(rename = "Workers Launched")]

--- a/pg_documentdb_gw/documentdb_gateway_core/src/explain/model.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/explain/model.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Deserializer};
     clippy::cast_possible_truncation,
     reason = "runtime counters are small; rounding an averaged f64 back to i64 is intentional"
 )]
-fn de_opt_round_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+fn deserialize_opt_round_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -83,7 +83,11 @@ pub struct PostgresExplain {
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct ExplainPlan {
-    #[serde(rename = "Actual Rows", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "Actual Rows",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub actual_rows: Option<i64>,
 
     #[serde(rename = "Actual Total Time")]
@@ -106,7 +110,11 @@ pub struct ExplainPlan {
     #[serde(rename = "Group Key")]
     pub group_key: Option<Vec<String>>,
 
-    #[serde(rename = "Heap Fetches", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "Heap Fetches",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub heap_fetches: Option<i64>,
 
     #[serde(rename = "Index Cond")]
@@ -159,14 +167,14 @@ pub struct ExplainPlan {
     #[serde(
         rename = "Rows Removed by Filter",
         default,
-        deserialize_with = "de_opt_round_i64"
+        deserialize_with = "deserialize_opt_round_i64"
     )]
     pub rows_removed_by_filter: Option<i64>,
 
     #[serde(
         rename = "Rows Removed by Index Recheck",
         default,
-        deserialize_with = "de_opt_round_i64"
+        deserialize_with = "deserialize_opt_round_i64"
     )]
     pub rows_removed_by_index: Option<i64>,
 
@@ -185,7 +193,11 @@ pub struct ExplainPlan {
     #[serde(rename = "Sort Space Type")]
     pub sort_space_type: Option<String>,
 
-    #[serde(rename = "Sort Space Used", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "Sort Space Used",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub sort_space_used: Option<i64>,
 
     #[serde(rename = "Startup Cost")]
@@ -197,19 +209,39 @@ pub struct ExplainPlan {
     #[serde(rename = "Function Name")]
     pub function_name: Option<String>,
 
-    #[serde(rename = "Exact Heap Blocks", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "Exact Heap Blocks",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub exact_heap_blocks: Option<i64>,
 
-    #[serde(rename = "Lossy Heap Blocks", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "Lossy Heap Blocks",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub lossy_heap_blocks: Option<i64>,
 
-    #[serde(rename = "Shared Hit Blocks", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "Shared Hit Blocks",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub shared_hit_blocks: Option<i64>,
 
-    #[serde(rename = "Shared Read Blocks", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "Shared Read Blocks",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub shared_read_blocks: Option<i64>,
 
-    #[serde(rename = "I/O Read Time", default, deserialize_with = "de_opt_round_i64")]
+    #[serde(
+        rename = "I/O Read Time",
+        default,
+        deserialize_with = "deserialize_opt_round_i64"
+    )]
     pub io_read_time: Option<i64>,
 
     #[serde(rename = "Workers Launched")]

--- a/pg_documentdb_gw/documentdb_tests/src/commands/explain.rs
+++ b/pg_documentdb_gw/documentdb_tests/src/commands/explain.rs
@@ -7,12 +7,32 @@
  */
 
 #![expect(
+    clippy::missing_panics_doc,
+    reason = "Test helper functions - panics are expected test failures"
+)]
+#![expect(
     clippy::missing_errors_doc,
     reason = "Test helper functions - error conditions are self-explanatory"
 )]
+#![expect(
+    clippy::expect_used,
+    reason = "Test helper functions - expect failures indicate test failures"
+)]
 
-use bson::doc;
+use bson::{doc, Bson};
 use mongodb::{error::Error, Database};
+
+/// Extract an integer stat regardless of whether it was encoded as Int32,
+/// Int64, or Double (the gateway picks the smallest representation).
+fn stat_i64(stats: &bson::Document, key: &str) -> Option<i64> {
+    match stats.get(key) {
+        Some(Bson::Int32(v)) => Some(i64::from(*v)),
+        Some(Bson::Int64(v)) => Some(*v),
+        #[expect(clippy::cast_possible_truncation, reason = "counter is a whole number")]
+        Some(Bson::Double(v)) => Some(*v as i64),
+        _ => None,
+    }
+}
 
 pub async fn validate_explain(db: &Database) -> Result<(), Error> {
     let coll = db.collection("test");
@@ -41,6 +61,53 @@ pub async fn validate_explain(db: &Database) -> Result<(), Error> {
                 "sum": {"$sum":"$a"}
             }}]
         }
+    })
+    .await?;
+
+    // Validate that executionStats counters come back as correct integers (not
+    // just that the command succeeds). `test` holds 3 documents, so a scan
+    // returns all 3. On PG18 these counters arrive as fractional numbers (e.g.
+    // 3.00) and must round to whole integers. `nReturned` is plan-independent;
+    // `totalDocsExamined` depends on the plan, so we only require it to be a
+    // sane count (>= nReturned) rather than an exact value.
+    let find_stats = db
+        .run_command(doc! {
+            "explain": { "find": "test", "filter": { "a": { "$gte": 1 } } },
+            "verbosity": "executionStats"
+        })
+        .await?;
+
+    let execution_stats = find_stats
+        .get_document("executionStats")
+        .expect("executionStats present in find explain");
+    let returned = stat_i64(execution_stats, "nReturned").expect("nReturned present");
+    let examined =
+        stat_i64(execution_stats, "totalDocsExamined").expect("totalDocsExamined present");
+    assert_eq!(returned, 3, "nReturned should count all 3 documents");
+    assert!(
+        examined >= returned,
+        "totalDocsExamined ({examined}) should be at least nReturned ({returned})"
+    );
+
+    let lookup_from = db.collection("test_lookup_from");
+    for i in 0..20 {
+        lookup_from.insert_one(doc! {"k": i % 3, "v": i}).await?;
+    }
+
+    db.run_command(doc! {
+        "explain": {
+            "aggregate": "test",
+            "cursor": {},
+            "pipeline": [{
+                "$lookup": {
+                    "from": "test_lookup_from",
+                    "localField": "a",
+                    "foreignField": "k",
+                    "as": "matched"
+                }
+            }]
+        },
+        "verbosity": "executionStats"
     })
     .await?;
 


### PR DESCRIPTION
PG18 prints fractional per-loop row counts in EXPLAIN ANALYZE (e.g. "Actual Rows": 2.33), which failed to deserialize into the gateway's Option<i64> counters, surfacing as InternalError. Parse these fields via a float-tolerant deserializer that rounds back to i64, and add unit + functional coverage for the executionStats path.

Fixes #653