### PR TITLE
Fix #650: native getParameter + documentdb-local username validation

### DIFF
--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -132,6 +132,18 @@ jobs:
 
         docker exec "$CONTAINER_NAME" mongosh "localhost:10260" -u docdb_admin -p 123456 --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --quiet --eval 'const count = db.getSiblingDB("gateway_smoke").image_smoke.countDocuments({ name: "documentdb-local-smoke", ok: true }); if (count !== 1) { print(`expected 1 document, found ${count}`); quit(1); }'
 
+        # Directly exercise getParameter. mongosh treats it as an optional discovery
+        # probe and ignores its failure, so CRUD alone cannot catch a broken handler
+        # (see issue #650). Assert it succeeds and returns the requested field.
+        docker exec "$CONTAINER_NAME" mongosh "localhost:10260" -u docdb_admin -p 123456 --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --quiet --eval 'const res = db.adminCommand({ getParameter: 1, featureCompatibilityVersion: 1 }); if (res.ok !== 1) { print(`getParameter failed: ${JSON.stringify(res)}`); quit(1); } if (!res.featureCompatibilityVersion || !res.featureCompatibilityVersion.version) { print(`missing featureCompatibilityVersion: ${JSON.stringify(res)}`); quit(1); }'
+
+        # Guard against the issue #650 regression: the gateway must not call the
+        # nonexistent documentdb_api.get_parameter backend function.
+        if docker logs "$CONTAINER_NAME" 2>&1 | grep -Fq "documentdb_api.get_parameter"; then
+          echo "Gateway logged a dangling documentdb_api.get_parameter call (issue #650 regression)" >&2
+          exit 1
+        fi
+
         dump_logs=false
     - name: Push ${{ matrix.arch }} Image
       if: github.event.inputs.push_images == 'true' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Add feature-flagged single-pass RUM posting-tree vacuum that prunes emptied leaf pages inline during the bulk-delete TID cleanup walk instead of a separate pruning pass. Guarded by `enable_single_pass_posting_tree_vacuum`, disabled by default while pending stabilization. *[Perf]*
 * Fix backend crash when serializing a SQL array that contains a NULL element. *[Bugfix]*
 * Fix memory usage in tokio-postgres Framed/BytesMut crate *[Bugfix/Perf]*
+* Implement `getParameter` natively in the gateway instead of dispatching it to a nonexistent `documentdb_api.get_parameter` backend function, which made every `getParameter` request fail with PostgreSQL error 42883. *[Bugfix]* (#650)
+* Reject documentdb-local usernames that begin with a gateway-reserved role prefix (e.g. `citus`, `documentdb`) at startup, instead of reporting the container ready with credentials that can never authenticate. *[Bugfix]* (#650)
 
 ### documentdb v0.114-0 (Unreleased) ###
 * Extend `enableNewNamespaceValidation` to block create/drop/rename/createIndex on reserved collections in `admin` and `local` databases, and complete the `config` reserved-collection list (added sharding-runtime names: `changelog`, `mongos`, `placementHistory`, `tags`, `transactions`, `locks`, `lockpings`, `migrations`, `migrationCoordinators`, `rangeDeletions`, `reshardingOperations`, `cache.collections`, `cache.databases`). *[Feature]*

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -62,14 +62,25 @@ exec "$@"
 import json
 import sys
 args = sys.argv[1:]
+raw = False
 vars = {}
-while args and args[0] in ('--arg', '--argjson'):
-    flag, name, value, *args = args
-    vars[name] = json.loads(value) if flag == '--argjson' else value
+while args and args[0].startswith('-'):
+    if args[0] in ('--arg', '--argjson'):
+        flag, name, value, *args = args
+        vars[name] = json.loads(value) if flag == '--argjson' else value
+    elif args[0] in ('-r', '--raw-output'):
+        raw = True
+        args = args[1:]
+    else:
+        args = args[1:]
 expr, file_path = args
 with open(file_path, 'r', encoding='utf-8') as f:
     data = json.load(f)
 expr = expr.strip()
+if expr in ('.BlockedRolePrefixes[]', '.BlockedRolePrefixes[]?'):
+    for item in data.get('BlockedRolePrefixes', []):
+        print(item)
+    raise SystemExit(0)
 if expr.startswith('.GatewayListenPort = '):
     data['GatewayListenPort'] = int(expr.split('=', 1)[1].strip())
 elif expr.startswith('.PostgresPort = '):
@@ -224,12 +235,25 @@ json.dump(data, sys.stdout)
 import json
 import sys
 args = sys.argv[1:]
+raw = False
 vars = {}
-while args and args[0] in ('--arg', '--argjson'):
-    flag, name, value, *args = args
-    vars[name] = json.loads(value) if flag == '--argjson' else value
+while args and args[0].startswith('-'):
+    if args[0] in ('--arg', '--argjson'):
+        flag, name, value, *args = args
+        vars[name] = json.loads(value) if flag == '--argjson' else value
+    elif args[0] in ('-r', '--raw-output'):
+        raw = True
+        args = args[1:]
+    else:
+        args = args[1:]
 expr, file_path = args
 expr = expr.strip()
+if expr in ('.BlockedRolePrefixes[]', '.BlockedRolePrefixes[]?'):
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    for item in data.get('BlockedRolePrefixes', []):
+        print(item)
+    raise SystemExit(0)
 if expr.startswith('.EnforceTls = '):
     sys.stderr.write('jq: simulated failure\\n')
     sys.exit(1)
@@ -531,6 +555,57 @@ json.dump(data, sys.stdout)
                 text,
                 msg=f"{js.name} should guard inserts with an existence check (#612)",
             )
+
+    def _set_blocked_role_prefixes(self, prefixes):
+        config_path = self.gateway_config_dir / "SetupConfiguration.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        config["BlockedRolePrefixes"] = prefixes
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    def test_blocked_username_prefix_is_rejected(self):
+        # citus is the username in the issue #650 reproduction; documentdb is the
+        # prefix the default test config blocks. Either must fail fast at startup
+        # rather than letting the container report ready with an unusable user.
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "documentdb_user"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "username 'documentdb_user' uses reserved prefix 'documentdb'",
+            result.stdout + result.stderr,
+        )
+
+    def test_blocked_username_prefix_is_case_insensitive(self):
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "DocumentDBAdmin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "uses reserved prefix 'documentdb'",
+            result.stdout + result.stderr,
+        )
+
+    def test_allowed_username_passes_validation(self):
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertNotIn("reserved prefix", result.stdout + result.stderr)
+
+    def test_all_configured_blocked_prefixes_are_rejected(self):
+        prefixes = ["documentdb", "citus", "pg", "internal_role"]
+        self._set_blocked_role_prefixes(prefixes)
+        for prefix in prefixes:
+            username = f"{prefix}_service"
+            with self.subTest(username=username):
+                result = self._run_entrypoint(
+                    "--password", "mypassword", extra_env={"USERNAME": username}
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"uses reserved prefix '{prefix}'",
+                    result.stdout + result.stderr,
+                )
 
 
 class InitDataAttemptMarkerTests(unittest.TestCase):

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -290,6 +290,31 @@ echo "Using username: $USERNAME"
 echo "Using owner: $OWNER"
 echo "Using data path: $DATA_PATH"
 
+# Reject usernames that use a gateway-reserved role prefix. The gateway blocks
+# these prefixes at authentication time (BlockedRolePrefixes in
+# SetupConfiguration.json), so creating such a user would produce a container
+# that reports ready but can never authenticate.
+GATEWAY_SETUP_CONFIG="$GATEWAY_HOME/pg_documentdb_gw/SetupConfiguration.json"
+if [ -f "$GATEWAY_SETUP_CONFIG" ]; then
+    mapfile -t blocked_role_prefixes < <(jq -r '.BlockedRolePrefixes[]?' "$GATEWAY_SETUP_CONFIG")
+    if [ "${#blocked_role_prefixes[@]}" -gt 0 ]; then
+        username_lower=$(printf '%s' "$USERNAME" | tr '[:upper:]' '[:lower:]')
+        for blocked_prefix in "${blocked_role_prefixes[@]}"; do
+            [ -z "$blocked_prefix" ] && continue
+            prefix_lower=$(printf '%s' "$blocked_prefix" | tr '[:upper:]' '[:lower:]')
+            case "$username_lower" in
+                "$prefix_lower"*)
+                    blocked_list=$(printf '%s, ' "${blocked_role_prefixes[@]}")
+                    blocked_list=${blocked_list%, }
+                    echo "Error: username '$USERNAME' uses reserved prefix '$blocked_prefix'." >&2
+                    echo "Choose a username that does not begin with any of: ${blocked_list}." >&2
+                    exit 1
+                    ;;
+            esac
+        done
+    fi
+fi
+
 if { [ -n "${CERT_PATH:-}" ] && [ -z "${KEY_FILE:-}" ]; } || \
    { [ -z "${CERT_PATH:-}" ] && [ -n "${KEY_FILE:-}" ]; }; then
     echo "Error: Both CERT_PATH and KEY_FILE must be set together, or neither should be set."

--- a/pg_documentdb_gw/documentdb_gateway_core/src/configuration/version.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/configuration/version.rs
@@ -41,6 +41,19 @@ impl Version {
         }
     }
 
+    /// Returns the `featureCompatibilityVersion` string (major.minor form),
+    /// as reported by `getParameter { featureCompatibilityVersion: 1 }`.
+    #[must_use]
+    pub const fn feature_compatibility_version(&self) -> &str {
+        match self {
+            Self::FourTwo => "4.2",
+            Self::Five => "5.0",
+            Self::Six => "6.0",
+            Self::Seven => "7.0",
+            Self::Eight => "8.0",
+        }
+    }
+
     #[must_use]
     pub const fn as_array(&self) -> [i32; 4] {
         match self {
@@ -70,6 +83,28 @@ impl Version {
             Self::Six => 17,
             Self::Seven => 21,
             Self::Eight => 25,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Version;
+
+    #[test]
+    fn feature_compatibility_version_is_major_minor() {
+        assert_eq!(Version::FourTwo.feature_compatibility_version(), "4.2");
+        assert_eq!(Version::Five.feature_compatibility_version(), "5.0");
+        assert_eq!(Version::Six.feature_compatibility_version(), "6.0");
+        assert_eq!(Version::Seven.feature_compatibility_version(), "7.0");
+        assert_eq!(Version::Eight.feature_compatibility_version(), "8.0");
+    }
+
+    #[test]
+    fn parse_round_trips_to_feature_compatibility_version() {
+        for fcv in ["4.2", "5.0", "6.0", "7.0", "8.0"] {
+            let version = Version::parse(fcv).expect("known version should parse");
+            assert_eq!(version.feature_compatibility_version(), fcv);
         }
     }
 }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/data_client.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/data_client.rs
@@ -278,15 +278,6 @@ pub trait PgDataClient: Send + Sync {
         connection_context: &ConnectionContext,
     ) -> Result<Response>;
 
-    async fn execute_get_parameter(
-        &self,
-        request_context: &RequestContext<'_>,
-        all: bool,
-        show_details: bool,
-        params: Vec<String>,
-        connection_context: &ConnectionContext,
-    ) -> Result<Response>;
-
     async fn execute_db_stats(
         &self,
         request_context: &RequestContext<'_>,

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/documentdb_data_client.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/documentdb_data_client.rs
@@ -1024,41 +1024,6 @@ impl PgDataClient for DocumentDBDataClient {
         .await
     }
 
-    async fn execute_get_parameter(
-        &self,
-        request_context: &RequestContext<'_>,
-        all: bool,
-        show_details: bool,
-        params: Vec<String>,
-        connection_context: &ConnectionContext,
-    ) -> Result<Response> {
-        let run_get_param = |conn: Arc<Connection>| {
-            let params = params.clone();
-            async move {
-                let rows = conn
-                    .query(
-                        self.service_context.query_catalog().get_parameter(),
-                        &[Type::BOOL, Type::BOOL, Type::TEXT_ARRAY],
-                        &[&all, &show_details, &params],
-                    )
-                    .await?;
-
-                Ok(Response::Pg(PgResponse::new(rows)))
-            }
-        };
-
-        self.run_query(
-            request_context,
-            connection_context,
-            PullConnection::PoolOrTransaction,
-            QueryOptions::builder()
-                .supports_backend_timeout(false)
-                .build(),
-            run_get_param,
-        )
-        .await
-    }
-
     async fn execute_db_stats(
         &self,
         request_context: &RequestContext<'_>,

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs
@@ -86,7 +86,6 @@ pub struct QueryCatalog {
     pub coll_stats: String,
     pub db_stats: String,
     pub current_op: String,
-    pub get_parameter: String,
     pub compact: String,
     pub kill_op: String,
     pub balancer_start: String,
@@ -438,11 +437,6 @@ impl QueryCatalog {
     }
 
     #[must_use]
-    pub fn get_parameter(&self) -> &str {
-        &self.get_parameter
-    }
-
-    #[must_use]
     pub fn move_collection(&self) -> &str {
         &self.move_collection
     }
@@ -628,7 +622,6 @@ pub fn create_query_catalog() -> QueryCatalog {
             coll_stats: "SELECT documentdb_api.coll_stats($1, $2, $3)".to_owned(),
             db_stats: "SELECT documentdb_api.db_stats($1, $2, $3)".to_owned(),
             current_op: "SELECT documentdb_api.current_op_command($1)".to_owned(),
-            get_parameter: "SELECT documentdb_api.get_parameter($1, $2, $3)".to_owned(),
             compact: "SELECT documentdb_api.compact($1)".to_owned(),
             kill_op: "SELECT documentdb_api.kill_op($1)".to_owned(),
 

--- a/pg_documentdb_gw/documentdb_gateway_core/src/processor/constant.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/processor/constant.rs
@@ -11,9 +11,10 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use bson::{rawdoc, RawArrayBuf, RawDocumentBuf};
+use bson::{rawdoc, RawArrayBuf, RawBson, RawDocumentBuf};
 
 use crate::{
+    bson::convert_to_bool,
     configuration::DynamicConfiguration,
     context::{ConnectionContext, RequestContext},
     error::{DocumentDBError, ErrorCode, Result},
@@ -90,6 +91,180 @@ pub fn process_get_rw_concern(request_context: &RequestContext<'_>) -> Result<Re
         "defaultWriteConcernSource": "implicit",
         "ok":OK_SUCCEEDED,
     })))
+}
+
+/// Command-envelope fields that drivers/mongosh attach to every request. These
+/// are not `getParameter` parameter names and must be ignored when collecting
+/// the requested parameters.
+fn is_generic_command_field(key: &str) -> bool {
+    key.starts_with('$')
+        || matches!(
+            key,
+            "lsid"
+                | "comment"
+                | "maxTimeMS"
+                | "apiVersion"
+                | "apiStrict"
+                | "apiDeprecationErrors"
+                | "readConcern"
+                | "writeConcern"
+                | "txnNumber"
+                | "autocommit"
+                | "startTransaction"
+                | "stmtId"
+                | "clusterTime"
+                | "signature"
+        )
+}
+
+/// Returns the value and mutability metadata for a parameter the gateway
+/// exposes via `getParameter`, or `None` if the parameter is not supported.
+///
+/// The returned tuple is `(value, settableAtRuntime, settableAtStartup)`.
+fn known_parameter(
+    name: &str,
+    dynamic_config: &Arc<dyn DynamicConfiguration>,
+) -> Option<(RawBson, bool, bool)> {
+    match name {
+        "featureCompatibilityVersion" => {
+            let version = dynamic_config.server_version();
+            let fcv = version.feature_compatibility_version();
+            Some((
+                RawBson::Document(rawdoc! { "version": fcv }),
+                false,
+                false,
+            ))
+        }
+        _ => None,
+    }
+}
+
+/// Every parameter name the gateway can report, used for the `*` /
+/// `allParameters` forms.
+const KNOWN_PARAMETER_NAMES: &[&str] = &["featureCompatibilityVersion"];
+
+fn append_parameter(
+    result: &mut RawDocumentBuf,
+    name: &str,
+    value: RawBson,
+    settable_at_runtime: bool,
+    settable_at_startup: bool,
+    show_details: bool,
+) {
+    if show_details {
+        result.append(
+            name,
+            rawdoc! {
+                "value": value,
+                "settableAtRuntime": settable_at_runtime,
+                "settableAtStartup": settable_at_startup,
+            },
+        );
+    } else {
+        result.append(name, value);
+    }
+}
+
+/// Handles the `getParameter` command natively in the gateway, without a
+/// database round-trip. Only the `admin` database may run it.
+pub fn process_get_parameter(
+    request_context: &RequestContext<'_>,
+    dynamic_config: &Arc<dyn DynamicConfiguration>,
+) -> Result<Response> {
+    let request = request_context.request();
+
+    let mut all_parameters = false;
+    let mut show_details = false;
+    let mut star = false;
+    let mut requested = Vec::new();
+
+    request.extract_fields(|k, v| {
+        match k {
+            "getParameter" => {
+                if v.as_str().is_some_and(|s| s == "*") {
+                    star = true;
+                } else if let Some(doc) = v.as_document() {
+                    for pair in doc {
+                        let (dk, dv) = pair?;
+                        match dk {
+                            "allParameters" => {
+                                all_parameters =
+                                    convert_to_bool(dv).ok_or_else(|| {
+                                        DocumentDBError::type_mismatch(
+                                            "allParameters should be a bool".to_owned(),
+                                        )
+                                    })?;
+                            }
+                            "showDetails" => {
+                                show_details =
+                                    convert_to_bool(dv).ok_or_else(|| {
+                                        DocumentDBError::type_mismatch(
+                                            "showDetails should be convertible to a bool"
+                                                .to_owned(),
+                                        )
+                                    })?;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            "allParameters" => {
+                all_parameters = convert_to_bool(v).ok_or_else(|| {
+                    DocumentDBError::type_mismatch("allParameters should be a bool".to_owned())
+                })?;
+            }
+            "showDetails" => {
+                show_details = convert_to_bool(v).ok_or_else(|| {
+                    DocumentDBError::type_mismatch(
+                        "showDetails should be convertible to a bool".to_owned(),
+                    )
+                })?;
+            }
+            other if is_generic_command_field(other) => {}
+            other => requested.push(other.to_owned()),
+        }
+        Ok(())
+    })?;
+
+    if request.db() != "admin" {
+        return Err(DocumentDBError::documentdb_error(
+            ErrorCode::Unauthorized,
+            "getParameter may only be run against the admin database.".to_owned(),
+        ));
+    }
+
+    let mut result = RawDocumentBuf::new();
+
+    if star || all_parameters {
+        for name in KNOWN_PARAMETER_NAMES {
+            if let Some((value, runtime, startup)) = known_parameter(name, dynamic_config) {
+                append_parameter(&mut result, name, value, runtime, startup, show_details);
+            }
+        }
+    } else if requested.is_empty() {
+        return Err(DocumentDBError::documentdb_error(
+            ErrorCode::FailedToParse,
+            "no parameters specified".to_owned(),
+        ));
+    } else {
+        for name in &requested {
+            match known_parameter(name, dynamic_config) {
+                Some((value, runtime, startup)) => {
+                    append_parameter(&mut result, name, value, runtime, startup, show_details);
+                }
+                None => {
+                    return Err(DocumentDBError::documentdb_error(
+                        ErrorCode::InvalidOptions,
+                        format!("no option found to get: {name}"),
+                    ));
+                }
+            }
+        }
+    }
+
+    result.append("ok", OK_SUCCEEDED);
+    Ok(Response::Raw(RawResponse::new(result)))
 }
 
 pub fn process_get_log() -> Response {

--- a/pg_documentdb_gw/documentdb_gateway_core/src/processor/data_management.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/processor/data_management.rs
@@ -10,7 +10,6 @@ use bson::{spec::ElementType, RawBsonRef};
 use std::sync::Arc;
 
 use crate::{
-    bson::convert_to_bool,
     configuration::DynamicConfiguration,
     context::{ConnectionContext, RequestContext},
     error::{DocumentDBError, ErrorCode, Result},
@@ -269,96 +268,6 @@ pub async fn process_kill_op(
     pg_data_client
         .execute_kill_op(request_context, &op_id, connection_context)
         .await
-}
-
-async fn get_parameter(
-    connection_context: &ConnectionContext,
-    request_context: &RequestContext<'_>,
-    all: bool,
-    show_details: bool,
-    params: Vec<String>,
-    pg_data_client: &impl PgDataClient,
-) -> Result<Response> {
-    pg_data_client
-        .execute_get_parameter(
-            request_context,
-            all,
-            show_details,
-            params,
-            connection_context,
-        )
-        .await
-}
-
-pub async fn process_get_parameter(
-    request_context: &RequestContext<'_>,
-    connection_context: &ConnectionContext,
-    pg_data_client: &impl PgDataClient,
-) -> Result<Response> {
-    let request = request_context.request();
-
-    let mut all_parameters = false;
-    let mut show_details = false;
-    let mut star = false;
-    let mut params = Vec::new();
-    request.extract_fields(|k, v| {
-        match k {
-            "getParameter" => {
-                if v.as_str().is_some_and(|s| s == "*") {
-                    star = true;
-                } else if let Some(doc) = v.as_document() {
-                    for pair in doc {
-                        let (k, v) = pair?;
-                        match k {
-                            "allParameters" => {
-                                all_parameters =
-                                    convert_to_bool(v).ok_or(DocumentDBError::type_mismatch(
-                                        "allParameters should be a bool".to_owned(),
-                                    ))?;
-                            }
-                            "showDetails" => {
-                                show_details =
-                                    convert_to_bool(v).ok_or(DocumentDBError::type_mismatch(
-                                        "showDetails should be convertible to a bool".to_owned(),
-                                    ))?;
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-            _ => params.push(k.to_owned()),
-        }
-        Ok(())
-    })?;
-    if request.db() != "admin" {
-        return Err(DocumentDBError::documentdb_error(
-            ErrorCode::Unauthorized,
-            "getParameter may only be run against the admin database.".to_owned(),
-        ));
-    }
-
-    if star {
-        return get_parameter(
-            connection_context,
-            request_context,
-            true,
-            false,
-            vec![],
-            pg_data_client,
-        )
-        .await;
-    }
-
-    get_parameter(
-        connection_context,
-        request_context,
-        all_parameters,
-        show_details,
-        params,
-        pg_data_client,
-    )
-    .await
 }
 
 pub async fn process_compact(

--- a/pg_documentdb_gw/documentdb_gateway_core/src/processor/process.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/processor/process.rs
@@ -236,12 +236,7 @@ pub async fn process_request(
                 .await
         }
         RequestType::GetParameter => {
-            data_management::process_get_parameter(
-                request_context,
-                connection_context,
-                pg_data_client,
-            )
-            .await
+            constant::process_get_parameter(request_context, &dynamic_config)
         }
         RequestType::KillCursors => {
             cursor::process_kill_cursors(request_context, connection_context, pg_data_client).await

--- a/pg_documentdb_gw/documentdb_tests/src/commands/get_parameter.rs
+++ b/pg_documentdb_gw/documentdb_tests/src/commands/get_parameter.rs
@@ -1,0 +1,146 @@
+/*-------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All rights reserved.
+ *
+ * documentdb_tests/src/commands/get_parameter.rs
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#![expect(
+    clippy::missing_panics_doc,
+    reason = "Test helper functions - panics are expected test failures"
+)]
+#![expect(
+    clippy::missing_errors_doc,
+    reason = "Test helper functions - error conditions are self-explanatory"
+)]
+#![expect(
+    clippy::unwrap_used,
+    reason = "Test helper functions - unwrap failures indicate test failures"
+)]
+#![expect(
+    clippy::expect_used,
+    reason = "Test helper functions - expect failures indicate test failures"
+)]
+#![expect(
+    clippy::float_cmp,
+    reason = "Test assertions compare exact float values returned from database"
+)]
+
+use bson::doc;
+use mongodb::{error::Error, Client};
+
+use crate::utils::commands;
+
+/// The `featureCompatibilityVersion` the gateway reports mirrors its configured
+/// server version, so accept any of the versions the gateway knows about.
+const KNOWN_FCV_VERSIONS: &[&str] = &["4.2", "5.0", "6.0", "7.0", "8.0"];
+
+pub async fn validate_get_parameter_fcv(client: &Client) -> Result<(), Error> {
+    let db = client.database("admin");
+    let result = db
+        .run_command(doc! { "getParameter": 1, "featureCompatibilityVersion": 1 })
+        .await?;
+
+    assert_eq!(result.get_f64("ok").unwrap(), 1.0);
+    let fcv = result
+        .get_document("featureCompatibilityVersion")
+        .expect("response must contain featureCompatibilityVersion");
+    let version = fcv.get_str("version").unwrap();
+    assert!(
+        KNOWN_FCV_VERSIONS.contains(&version),
+        "unexpected featureCompatibilityVersion.version: {version}"
+    );
+
+    Ok(())
+}
+
+pub async fn validate_get_parameter_star(client: &Client) -> Result<(), Error> {
+    let db = client.database("admin");
+    let result = db.run_command(doc! { "getParameter": "*" }).await?;
+
+    assert_eq!(result.get_f64("ok").unwrap(), 1.0);
+    assert!(
+        result.get_document("featureCompatibilityVersion").is_ok(),
+        "the '*' form must include featureCompatibilityVersion"
+    );
+
+    Ok(())
+}
+
+pub async fn validate_get_parameter_all_parameters(client: &Client) -> Result<(), Error> {
+    let db = client.database("admin");
+    let result = db
+        .run_command(doc! { "getParameter": 1, "allParameters": true })
+        .await?;
+
+    assert_eq!(result.get_f64("ok").unwrap(), 1.0);
+    assert!(
+        result.get_document("featureCompatibilityVersion").is_ok(),
+        "the allParameters form must include featureCompatibilityVersion"
+    );
+
+    Ok(())
+}
+
+pub async fn validate_get_parameter_show_details(client: &Client) -> Result<(), Error> {
+    let db = client.database("admin");
+    let result = db
+        .run_command(doc! {
+            "getParameter": doc! { "showDetails": true },
+            "featureCompatibilityVersion": 1,
+        })
+        .await?;
+
+    assert_eq!(result.get_f64("ok").unwrap(), 1.0);
+    let details = result
+        .get_document("featureCompatibilityVersion")
+        .expect("response must contain featureCompatibilityVersion");
+    // With showDetails the value is wrapped alongside mutability metadata.
+    let value = details.get_document("value").unwrap();
+    let version = value.get_str("version").unwrap();
+    assert!(
+        KNOWN_FCV_VERSIONS.contains(&version),
+        "unexpected featureCompatibilityVersion.version: {version}"
+    );
+    assert!(!details.get_bool("settableAtRuntime").unwrap());
+    assert!(!details.get_bool("settableAtStartup").unwrap());
+
+    Ok(())
+}
+
+pub async fn validate_get_parameter_unknown(client: &Client) {
+    let db = client.database("admin");
+    commands::execute_command_and_validate_error(
+        &db,
+        doc! { "getParameter": 1, "someUnknownParameter": 1 },
+        72,
+        "no option found to get: someUnknownParameter",
+        "InvalidOptions",
+    )
+    .await;
+}
+
+pub async fn validate_get_parameter_no_params(client: &Client) {
+    let db = client.database("admin");
+    commands::execute_command_and_validate_error(
+        &db,
+        doc! { "getParameter": 1 },
+        9,
+        "no parameters specified",
+        "FailedToParse",
+    )
+    .await;
+}
+
+pub async fn validate_get_parameter_non_admin(client: &Client) {
+    let db = client.database("get_parameter_non_admin");
+    commands::execute_command_and_validate_error(
+        &db,
+        doc! { "getParameter": 1, "featureCompatibilityVersion": 1 },
+        13,
+        "admin database",
+        "Unauthorized",
+    )
+    .await;
+}

--- a/pg_documentdb_gw/documentdb_tests/src/commands/mod.rs
+++ b/pg_documentdb_gw/documentdb_tests/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod distinct;
 pub mod explain;
 pub mod find;
 pub mod find_and_modify;
+pub mod get_parameter;
 pub mod indexing;
 pub mod insert;
 pub mod killop;

--- a/pg_documentdb_gw/documentdb_tests/tests/command_tests.rs
+++ b/pg_documentdb_gw/documentdb_tests/tests/command_tests.rs
@@ -9,7 +9,7 @@
 use documentdb_tests::{
     commands::{
         aggregate, coll_stats, collection_cmd, constant, count, delete, distinct, find,
-        find_and_modify, indexing, insert, list_collections, update, validate_cmd,
+        find_and_modify, get_parameter, indexing, insert, list_collections, update, validate_cmd,
     },
     test_setup::initialize,
 };
@@ -160,6 +160,58 @@ async fn get_cmd_line_opts() -> Result<(), Error> {
     let db = initialize::initialize_with_db("commands_tests_get_cmd_line_opts").await?;
 
     constant::validate_get_cmd_line_opts(&db).await
+}
+
+#[tokio::test]
+async fn get_parameter_feature_compatibility_version() -> Result<(), Error> {
+    let client = initialize::initialize().await?;
+
+    get_parameter::validate_get_parameter_fcv(&client).await
+}
+
+#[tokio::test]
+async fn get_parameter_star() -> Result<(), Error> {
+    let client = initialize::initialize().await?;
+
+    get_parameter::validate_get_parameter_star(&client).await
+}
+
+#[tokio::test]
+async fn get_parameter_all_parameters() -> Result<(), Error> {
+    let client = initialize::initialize().await?;
+
+    get_parameter::validate_get_parameter_all_parameters(&client).await
+}
+
+#[tokio::test]
+async fn get_parameter_show_details() -> Result<(), Error> {
+    let client = initialize::initialize().await?;
+
+    get_parameter::validate_get_parameter_show_details(&client).await
+}
+
+#[tokio::test]
+async fn get_parameter_unknown_parameter() -> Result<(), Error> {
+    let client = initialize::initialize().await?;
+
+    get_parameter::validate_get_parameter_unknown(&client).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_parameter_no_parameters() -> Result<(), Error> {
+    let client = initialize::initialize().await?;
+
+    get_parameter::validate_get_parameter_no_params(&client).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_parameter_non_admin_database() -> Result<(), Error> {
+    let client = initialize::initialize().await?;
+
+    get_parameter::validate_get_parameter_non_admin(&client).await;
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #650. The `documentdb-local` image had two independent defects; this PR fixes both.

### 1. Gateway `getParameter` called a backend function that never existed (PostgreSQL 42883)

The gateway advertised `getParameter` in `SUPPORTED_COMMANDS` and dispatched it to a hard-coded `SELECT documentdb_api.get_parameter($1, $2, $3)` in `QueryCatalog`. That function has **never** existed in the OSS extension, so every `getParameter` request failed with PostgreSQL error **42883**. (`mongosh` sends `getParameter` only as an optional discovery probe and ignores its failure, so `ping`/CRUD still worked while the gateway logged the error on every connection — which is why CRUD smoke tests never caught it.)

**Fix:** implement `getParameter` **natively in the gateway** (like `buildInfo`/`getCmdLineOpts`) and remove the dead PostgreSQL plumbing. The native handler returns `featureCompatibilityVersion` derived from the gateway's configured server version, with MongoDB-compatible semantics:

| Request | Response |
| --- | --- |
| `{getParameter:1, featureCompatibilityVersion:1}` | `{ featureCompatibilityVersion: { version: "7.0" }, ok:1 }` |
| unknown parameter | error **72** `InvalidOptions` — `no option found to get: <name>` |
| `{getParameter:1}` (no params) | error **9** `FailedToParse` — `no parameters specified` |
| `"*"` / `allParameters:true` | all known parameters |
| `showDetails:true` | value wrapped with `settableAtRuntime`/`settableAtStartup` |
| non-`admin` database | `Unauthorized` (preserved) |

Removed: the `QueryCatalog::get_parameter` entry, the `PgDataClient::execute_get_parameter` trait method and its impl, and the old `data_management` handler.

### 2. documentdb-local accepted usernames that could never authenticate

The issue reproduction used `USERNAME=citus`. `citus` is a gateway-reserved `BlockedRolePrefixes` entry, so the gateway rejects it at authentication time (error 18 `Username is invalid.`), but the entrypoint never validated it — the container reported ready with credentials that could never authenticate.

**Fix:** `emulator_entrypoint.sh` now reads the gateway's own `BlockedRolePrefixes` from `SetupConfiguration.json` and rejects reserved-prefix usernames (case-insensitive, mirroring the Rust auth check) at startup with an actionable message.

## Tests

- **Gateway integration tests** (`documentdb_tests`): `getParameter` happy paths (fcv, `*`, `allParameters`, `showDetails`) and error paths (unknown → 72, empty → 9, non-admin → Unauthorized).
- **Entrypoint tests**: blocked prefixes (incl. mixed-case) rejected; allowed username passes.
- **Image smoke test** (`build_gateway.yml`): a direct `getParameter` assertion **plus a log scan** for `documentdb_api.get_parameter` — CRUD alone can't catch this because `mongosh` ignores failed probes.

## Verification

- 461 `documentdb_gateway_core` unit tests pass; `cargo check` + `clippy` clean.
- `documentdb_tests` compiles; clippy clean. (Integration tests require a live gateway+PG and run in CI.)
- 26 entrypoint tests pass.

## Notes

- `atlasVersion` "Command not found" (error 59) is **expected** MongoDB-compatible behavior, not a bug.
- A follow-up PR will harden the **test system / pipeline** so this class of bug (a gateway command referencing a nonexistent backend function; cross-layer policy drift) is caught at build time — e.g. a `QueryCatalog` ↔ extension contract test and a broader log-error smoke gate.
