### PR TITLE
Mitigate #650: reject unsupported getParameter in documentdb-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add feature-flagged single-pass RUM posting-tree vacuum that prunes emptied leaf pages inline during the bulk-delete TID cleanup walk instead of a separate pruning pass. Guarded by `enable_single_pass_posting_tree_vacuum`, disabled by default while pending stabilization. *[Perf]*
 * Fix backend crash when serializing a SQL array that contains a NULL element. *[Bugfix]*
 * Fix memory usage in tokio-postgres Framed/BytesMut crate *[Bugfix/Perf]*
+* Fix documentdb-local logging PostgreSQL error 42883 on every connection when using its bundled PostgreSQL: the bundled gateway calls `documentdb_api.get_parameter(...)` for the unsupported MongoDB `getParameter` command, but that function was never shipped in the OSS extension. Until the gateway stops dispatching the command, the emulator returns `CommandNotSupported` without exposing parameter values. *[Bugfix]* (#650)
 
 ### documentdb v0.114-0 (Unreleased) ###
 * Extend `enableNewNamespaceValidation` to block create/drop/rename/createIndex on reserved collections in `admin` and `local` databases, and complete the `config` reserved-collection list (added sharding-runtime names: `changelog`, `mongos`, `placementHistory`, `tags`, `transactions`, `locks`, `lockpings`, `migrations`, `migrationCoordinators`, `rangeDeletions`, `reshardingOperations`, `cache.collections`, `cache.databases`). *[Feature]*

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -144,6 +144,82 @@ json.dump(data, sys.stdout)
         ) as file:
             return json.load(file)
 
+    def _configure_postgres_stubs(self, psql_exit_code=0):
+        sql_capture = self.root / "psql-input.sql"
+        self._write_exec(
+            self.gateway_scripts / "start_oss_server.sh",
+            f"""#!/bin/sh
+touch "{self.data_dir / 'postmaster.pid'}" "{self.data_dir / 'pglog.log'}"
+echo oss-server-stub-started
+""",
+        )
+        self._write_exec(
+            self.bin_dir / "psql",
+            f"""#!/bin/sh
+cat > "{sql_capture}"
+exit {psql_exit_code}
+""",
+        )
+        return sql_capture
+
+    def test_get_parameter_stub_returns_command_not_supported(self):
+        sql_capture = self._configure_postgres_stubs()
+
+        result = self._run_entrypoint(extra_env={"START_POSTGRESQL": "true"})
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        sql = sql_capture.read_text(encoding="utf-8")
+        self.assertIn(
+            "to_regprocedure('documentdb_api.get_parameter(boolean,boolean,text[])') IS NULL",
+            sql,
+        )
+        self.assertIn(
+            "CREATE FUNCTION documentdb_api.get_parameter(boolean, boolean, text[])",
+            sql,
+        )
+        self.assertIn('"code": 115', sql)
+        self.assertIn('"codeName": "CommandNotSupported"', sql)
+        self.assertIn('"ok": 0.0', sql)
+        self.assertIn(
+            "documentdb-local temporary CommandNotSupported stub for issue #650",
+            sql,
+        )
+        self.assertNotIn("CREATE OR REPLACE FUNCTION", sql)
+        self.assertNotIn("featureCompatibilityVersion", sql)
+        self.assertNotIn("'7.0'", sql)
+        self.assertIn(
+            "Ensuring unsupported getParameter returns CommandNotSupported",
+            result.stdout,
+        )
+
+    def test_get_parameter_stub_install_failure_aborts_startup(self):
+        self._configure_postgres_stubs(psql_exit_code=1)
+
+        result = self._run_entrypoint(extra_env={"START_POSTGRESQL": "true"})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "could not install the documentdb-local getParameter rejection stub",
+            result.stdout + result.stderr,
+        )
+        self.assertNotIn("Starting gateway in the background", result.stdout)
+
+    def test_get_parameter_stub_is_not_installed_in_external_postgres(self):
+        psql_called = self.root / "psql-called"
+        self._write_exec(
+            self.bin_dir / "psql",
+            f"""#!/bin/sh
+touch "{psql_called}"
+exit 1
+""",
+        )
+
+        result = self._run_entrypoint(extra_env={"START_POSTGRESQL": "false"})
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertFalse(psql_called.exists())
+        self.assertIn("Skipping PostgreSQL server start", result.stdout)
+
     def test_default_mode_sets_allowTLS_in_config(self):
         result = self._run_entrypoint("--password", "mypassword")
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -460,6 +460,47 @@ if [ "$START_POSTGRESQL" = "true" ]; then
         i=$((i + 1))
     done
     echo "PostgreSQL is running."
+
+    # getParameter is intentionally unsupported in OSS, but the bundled gateway
+    # still dispatches it to documentdb_api.get_parameter(...), which has never
+    # shipped in the OSS extension. Install an emulator-only rejection stub in the
+    # bundled database (start_oss_server.sh pins documentdb_gateway.database to
+    # postgres) so clients receive the gateway's normal unsupported-command response
+    # instead of PostgreSQL 42883. Preserve a real implementation if one is added
+    # later; this temporary bridge can then be removed with the gateway fix.
+    #
+    # START_POSTGRESQL=false targets a caller-managed backend and is intentionally
+    # excluded: this temporary emulator workaround must not install its private
+    # rejection function in an external PostgreSQL instance.
+    echo "Ensuring unsupported getParameter returns CommandNotSupported (issue #650)..."
+    if ! psql -p "$POSTGRESQL_PORT" -d postgres -X -v ON_ERROR_STOP=1 <<'GET_PARAMETER_SQL'
+DO $install_get_parameter_stub$
+BEGIN
+    IF to_regprocedure('documentdb_api.get_parameter(boolean,boolean,text[])') IS NULL THEN
+        EXECUTE $ddl$
+            CREATE FUNCTION documentdb_api.get_parameter(boolean, boolean, text[])
+            RETURNS documentdb_core.bson
+            LANGUAGE sql
+            STABLE
+            SET search_path = pg_catalog
+            AS $body$
+                SELECT documentdb_core.bson_in(
+                    '{ "ok": 0.0, "errmsg": "Command ''getParameter'' not supported.", "code": 115, "codeName": "CommandNotSupported" }'::cstring
+                )
+            $body$
+        $ddl$;
+        EXECUTE $comment$
+            COMMENT ON FUNCTION documentdb_api.get_parameter(boolean, boolean, text[])
+            IS 'documentdb-local temporary CommandNotSupported stub for issue #650'
+        $comment$;
+    END IF;
+END;
+$install_get_parameter_stub$;
+GET_PARAMETER_SQL
+    then
+        echo "Error: could not install the documentdb-local getParameter rejection stub; refusing to start with the known PostgreSQL 42883 failure (issue #650)." >&2
+        exit 1
+    fi
 else
     echo "Skipping PostgreSQL server start."
 fi


### PR DESCRIPTION
## Summary

Temporary documentdb-local mitigation for #650. The OSS gateway recognizes `getParameter` but dispatches it to `documentdb_api.get_parameter(boolean, boolean, text[])`, which is intentionally absent from the OSS extension. That produces PostgreSQL 42883 during the discovery probe that mongosh issues on each connection.

`getParameter` remains unsupported. This PR does not fabricate FCV or parameter values.

## Behavior

When documentdb-local starts its owned bundled PostgreSQL, the entrypoint installs a temporary rejection stub only if the exact function signature is absent. The stub returns the gateway-standard MongoDB error:

```json
{ "ok": 0.0, "errmsg": "Command 'getParameter' not supported.", "code": 115, "codeName": "CommandNotSupported" }
```

The installation:

- Preserves any future real implementation (`CREATE FUNCTION`, never `CREATE OR REPLACE`).
- Fails startup if the rejection contract cannot be installed, rather than reporting ready with the known 42883 failure.
- Is explicitly marked with a function comment for cleanup when the gateway stops dispatching this command.
- Does not install the temporary function when `START_POSTGRESQL=false`, because that mode targets a caller-managed backend.

## Scope

This is an emulator-only bridge for the published image, not an OSS `getParameter` implementation. The gateway-side root fix remains to stop advertising/dispatching the unsupported command. Once that lands, the bridge and its marked function should be removed from documentdb-local, including cleanup on persistent volumes.

Companion work:

- #659 owns the image-level undefined-function log gate.
- #660 owns reserved-username startup validation.

## Tests

The entrypoint suite covers successful stub generation, fail-fast installation failure, and exclusion of external PostgreSQL mode. All 25 entrypoint tests pass.

Files: `emulator_entrypoint.sh`, `test_emulator_entrypoint.py`, `CHANGELOG.md`.