### PR TITLE
Gate the documentdb-local image smoke test on undefined backend-function errors (#650)

### DIFF
--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -138,21 +138,25 @@ jobs:
         # function the shipped extension does not define surfaces as a PostgreSQL
         # undefined_function error (SQLSTATE 42883) in the container logs -- but
         # clients silently tolerate failed discovery probes, so the CRUD assertion
-        # above cannot catch it (this is exactly how issue #650 shipped). Fail the
-        # build if such an error is present. The 42883 match is anchored to the
-        # gateway/PostgreSQL "code="/"sub_status=" form so it cannot collide with a
-        # timestamp fraction or activity-id digit run; benign "database/relation ...
+        # above cannot catch it (this is exactly how issue #650 shipped).
+        #
+        # The scan is delegated to the shared, unit-tested detector
+        # (documentdb_local_tests/backend_contract.py) so the pre-merge image
+        # test and this release smoke enforce the identical contract. The
+        # detector strips ANSI before matching: the gateway logs via
+        # tracing_subscriber's fmt layer with colour ON by default, so a real
+        # field is emitted as "<esc>sub_status<esc>=<esc>42883" and a raw grep
+        # for "sub_status=42883" would miss it. Benign "database/relation ...
         # does not exist" lines (different SQLSTATEs) do not match "function ...".
-        echo "Checking gateway logs for undefined backend-function errors..."
+        echo "Checking gateway logs for undefined backend-function errors (issue #650)..."
         if ! smoke_logs=$(docker logs "$CONTAINER_NAME" 2>&1); then
           echo "Failed to read container logs for the backend-contract gate." >&2
           exit 1
         fi
-        if printf '%s\n' "$smoke_logs" | grep -E "(code|sub_status)=42883|function .* does not exist"; then
-          echo "Found a PostgreSQL undefined_function error in the gateway logs (see matches above): a gateway command calls a backend function the shipped extension does not define (cf. issue #650)." >&2
+        if ! printf '%s\n' "$smoke_logs" \
+            | python3 documentdb-local/scripts/documentdb_local_tests/backend_contract.py -; then
           exit 1
         fi
-        echo "Backend-contract gate passed: no undefined-function errors in container logs."
 
         dump_logs=false
     - name: Push ${{ matrix.arch }} Image

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -132,6 +132,28 @@ jobs:
 
         docker exec "$CONTAINER_NAME" mongosh "localhost:10260" -u docdb_admin -p 123456 --authenticationMechanism SCRAM-SHA-256 --tls --tlsAllowInvalidCertificates --quiet --eval 'const count = db.getSiblingDB("gateway_smoke").image_smoke.countDocuments({ name: "documentdb-local-smoke", ok: true }); if (count !== 1) { print(`expected 1 document, found ${count}`); quit(1); }'
 
+        # Backend-contract gate (issue #650). The smoke run above drives the
+        # gateway end to end, including the getParameter discovery probe mongosh
+        # issues on every connection. A gateway command whose backend SQL calls a
+        # function the shipped extension does not define surfaces as a PostgreSQL
+        # undefined_function error (SQLSTATE 42883) in the container logs -- but
+        # clients silently tolerate failed discovery probes, so the CRUD assertion
+        # above cannot catch it (this is exactly how issue #650 shipped). Fail the
+        # build if such an error is present. The 42883 match is anchored to the
+        # gateway/PostgreSQL "code="/"sub_status=" form so it cannot collide with a
+        # timestamp fraction or activity-id digit run; benign "database/relation ...
+        # does not exist" lines (different SQLSTATEs) do not match "function ...".
+        echo "Checking gateway logs for undefined backend-function errors..."
+        if ! smoke_logs=$(docker logs "$CONTAINER_NAME" 2>&1); then
+          echo "Failed to read container logs for the backend-contract gate." >&2
+          exit 1
+        fi
+        if printf '%s\n' "$smoke_logs" | grep -E "(code|sub_status)=42883|function .* does not exist"; then
+          echo "Found a PostgreSQL undefined_function error in the gateway logs (see matches above): a gateway command calls a backend function the shipped extension does not define (cf. issue #650)." >&2
+          exit 1
+        fi
+        echo "Backend-contract gate passed: no undefined-function errors in container logs."
+
         dump_logs=false
     - name: Push ${{ matrix.arch }} Image
       if: github.event.inputs.push_images == 'true' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/documentdb_local_tests.yml
+++ b/.github/workflows/documentdb_local_tests.yml
@@ -26,3 +26,9 @@ jobs:
 
       - name: Run documentdb-local Python unit tests
         run: python3 -m unittest discover -s documentdb-local/scripts/documentdb_local_tests -p 'test_emulator_entrypoint.py'
+
+      - name: Run backend-contract detector unit tests
+        run: python3 -m unittest discover -s documentdb-local/scripts/documentdb_local_tests -p 'test_backend_contract.py'
+
+      - name: Run backend-catalog contract unit tests
+        run: python3 -m unittest discover -s documentdb-local/scripts/documentdb_local_tests -p 'test_catalog_contract.py'

--- a/documentdb-local/scripts/documentdb_local_tests/backend_contract.py
+++ b/documentdb-local/scripts/documentdb_local_tests/backend_contract.py
@@ -1,0 +1,161 @@
+"""
+Backend-contract detector for documentdb-local (issue #650).
+
+A gateway command whose backend SQL calls a function the shipped extension
+does not define surfaces as a PostgreSQL ``undefined_function`` error
+(SQLSTATE ``42883``) in the container logs. Clients silently tolerate failed
+discovery probes -- e.g. the ``getParameter`` probe mongosh issues on every
+connection -- so a green CRUD smoke test cannot catch it. That is exactly how
+issue #650 shipped despite passing CI.
+
+This module scans container logs for that class of error so a single shared,
+unit-tested detector can be reused by:
+
+  * the pre-merge image test (``test_image.py``),
+  * the release-build smoke test (``.github/workflows/build_gateway.yml``).
+
+ANSI awareness (why this is not a plain ``grep``)
+-------------------------------------------------
+The gateway logs through ``tracing_subscriber``'s ``fmt`` layer, which emits
+ANSI SGR escape sequences around structured field *names* and the ``=`` by
+default (it does not auto-detect a TTY and nothing disables colour). So a real
+log line for the #650 error is not the literal ``sub_status=42883`` but rather::
+
+    \\x1b[3msub_status\\x1b[0m\\x1b[2m=\\x1b[0m42883
+
+which means a naive ``grep 'sub_status=42883'`` matches *nothing* -- only the
+language-specific English ``function ... does not exist`` fallback would fire,
+defeating the point of a language-independent SQLSTATE gate. We therefore strip
+ANSI before matching. Stripping is a no-op when colour is absent, so the same
+detector works on both coloured and uncoloured logs.
+
+CLI
+---
+Used by ``build_gateway.yml``'s release smoke test::
+
+    docker logs "$CONTAINER" 2>&1 | \\
+        python3 backend_contract.py -
+
+    python3 backend_contract.py path/to/container.log
+
+Exit status is ``1`` if any undefined backend-function error is found (the
+offending lines are printed to stderr) and ``0`` otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable
+
+# CSI/SGR escape sequence, e.g. ESC[3m (italic), ESC[0m (reset), ESC[2m (dim).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# After ANSI is stripped, an undefined backend-function error is detected in two
+# ways:
+#
+#   * the PostgreSQL undefined_function SQLSTATE (42883) surfaced on the
+#     gateway's structured error fields -- ``sub_status=42883`` and
+#     ``sub_status_code=42883``. This is language-independent and is the signal
+#     we actually want. The pattern is anchored to those exact field names (with
+#     a leading word boundary) so it does not collide with an unrelated ``42883``
+#     digit run in a timestamp/activity id, nor with a different field that merely
+#     ends in ``code`` such as the gateway's ``error_code`` (a MongoDB error code,
+#     never a SQLSTATE). A benign psql NOTICE never carries these fields, so this
+#     branch needs no extra guard.
+#
+#   * the English ``function ... does not exist`` message (defense in depth, and
+#     the form PostgreSQL itself logs). Benign ``database/relation ... does not
+#     exist`` lines carry a different noun, so they never match. But PostgreSQL
+#     also logs ``NOTICE: function ... does not exist, skipping`` for a
+#     ``DROP ... IF EXISTS`` on an absent function (e.g. while ``CREATE EXTENSION``
+#     runs the versioned upgrade chain), and that NOTICE *does* reach
+#     ``docker logs`` -- so we exclude the ``, skipping`` form, which is emitted
+#     only by ``IF EXISTS`` and never by a genuine undefined_function ERROR.
+_SQLSTATE_42883_RE = re.compile(r"\bsub_status(?:_code)?=42883")
+_FUNCTION_MISSING_RE = re.compile(r"function .* does not exist")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI SGR/CSI escape sequences from ``text``."""
+    return _ANSI_RE.sub("", text)
+
+
+def _is_benign_missing_object_notice(line: str) -> bool:
+    """Return ``True`` for PostgreSQL's benign ``... does not exist, skipping``
+    NOTICE, emitted by ``DROP ... IF EXISTS`` on an absent object. Such NOTICEs
+    reach ``docker logs`` (psql stderr) during ``CREATE EXTENSION`` but are not
+    backend-contract violations. The ``, skipping`` suffix is unique to the
+    ``IF EXISTS`` path and never appears on a genuine undefined_function ERROR."""
+    return "does not exist, skipping" in line
+
+
+def find_undefined_function_errors(logs: str) -> list[str]:
+    """Return the (ANSI-stripped) log lines that indicate an undefined
+    backend-function error -- the issue #650 class.
+
+    Matching is line-oriented so the ``function ... does not exist`` pattern
+    cannot straddle unrelated lines and so the benign-NOTICE guard applies per
+    line.
+    """
+    matches: list[str] = []
+    for raw_line in logs.splitlines():
+        line = strip_ansi(raw_line)
+        if _SQLSTATE_42883_RE.search(line):
+            matches.append(line)
+            continue
+        if _FUNCTION_MISSING_RE.search(line) and not _is_benign_missing_object_notice(
+            line
+        ):
+            matches.append(line)
+    return matches
+
+
+def _read_sources(paths: Iterable[str]) -> str:
+    chunks: list[str] = []
+    for path in paths:
+        if path == "-":
+            chunks.append(sys.stdin.read())
+        else:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                chunks.append(handle.read())
+    return "\n".join(chunks)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail (exit 1) if container logs contain a PostgreSQL "
+            "undefined_function error (SQLSTATE 42883) -- the issue #650 "
+            "class where a gateway command calls a backend function the "
+            "shipped extension does not define."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["-"],
+        help="Log file paths, or '-' for stdin (default: stdin).",
+    )
+    args = parser.parse_args(argv)
+    paths = args.paths or ["-"]
+
+    logs = _read_sources(paths)
+    matches = find_undefined_function_errors(logs)
+    if matches:
+        print(
+            "Backend-contract gate FAILED: found PostgreSQL undefined_function "
+            "error(s) in the gateway logs -- a gateway command calls a backend "
+            "function the shipped extension does not define (cf. issue #650):",
+            file=sys.stderr,
+        )
+        for line in matches:
+            print(f"  {line}", file=sys.stderr)
+        return 1
+    print("Backend-contract gate passed: no undefined-function errors in logs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/documentdb-local/scripts/documentdb_local_tests/catalog_contract.py
+++ b/documentdb-local/scripts/documentdb_local_tests/catalog_contract.py
@@ -1,0 +1,89 @@
+"""
+Backend-catalog contract for documentdb-local (issue #650, coverage hardening).
+
+The log-scan gate (``backend_contract.py``) is *passive*: it only sees an
+undefined-function error for a command the smoke workload actually exercises. A
+backend routine the gateway advertises but that no smoke command triggers -- one
+used only by ``compact``, ``collStats``, ``dbStats``, ``validate``, etc. -- would
+go missing silently, which is precisely the #650 failure mode generalised.
+
+This module makes the check *active*: enumerate every backend routine the
+gateway's ``QueryCatalog`` calls, so an installed-image test can assert each one
+exists in the shipped extension regardless of which commands the smoke runs.
+
+Authoritative source
+--------------------
+The gateway builds its catalog in ``create_query_catalog()`` at
+``pg_documentdb_gw/documentdb_gateway_core/src/postgres/query_catalog.rs``. The
+image is built from the same commit, so parsing that source is a faithful proxy
+for what the shipped gateway calls -- and it auto-updates as new commands are
+added, so the contract cannot silently drift.
+
+We extract calls into the ``documentdb_api``, ``documentdb_api_internal``,
+``documentdb_api_catalog`` and ``documentdb_core`` schemas -- i.e. every
+documentdb schema the gateway executes against, so a missing routine in any of
+them is caught (the ``documentdb_core.bson_build_document`` /
+``documentdb_core.row_get_bson`` / ``documentdb_api_catalog.bson_array_agg``
+dependencies of ``explain`` / ``listDatabases`` are in scope, not just the
+``documentdb_api`` command handlers).
+
+Requiring a trailing ``(`` keeps the match to real function *calls* and excludes
+the many name fragments and regex/diagnostic string fields (e.g.
+``find_bson_text_meta_qual``, the ``bson_dollar_...`` regexes, the
+``documentdb_api_catalog.`` name prefix), none of which are executable calls.
+
+The one routine the static parser cannot resolve is the ``explain`` template
+``documentdb_api_catalog.bson_aggregation_{query_base}(...)``: the function name
+is built at runtime from ``{query_base}``, so the literal never contains a
+complete callable name and is skipped by the trailing-``(`` rule. Because
+``{query_base}`` is drawn from a small fixed set (``run_explain`` is called with
+``pipeline``/``find``/``count``/``distinct`` in ``explain/mod.rs``), those
+concrete names are enumerated in ``EXPLAIN_AGGREGATION_FUNCTIONS`` and folded
+back in by ``required_backend_functions()`` -- so the active contract test still
+covers them. Everything else the gateway calls is a static name the parser
+captures directly.
+"""
+
+from __future__ import annotations
+
+import re
+
+# A call to a documentdb backend routine: ``<schema>.<fn>(``. The schema
+# alternation lists the longer names first so ``documentdb_api_internal`` /
+# ``documentdb_api_catalog`` win over the ``documentdb_api`` prefix. Group 1 is
+# the schema, group 2 the function name. The trailing ``\(`` requires an actual
+# call, excluding name fragments, regex fields and the dynamically-named
+# ``bson_aggregation_{query_base}`` explain template (whose ``{`` breaks the
+# ``[a-z0-9_]+\s*\(`` tail).
+_CALL_RE = re.compile(
+    r"\b(documentdb_api_internal|documentdb_api_catalog|documentdb_api|documentdb_core)"
+    r"\.([a-z0-9_]+)\s*\("
+)
+
+# Concrete routine names behind the dynamic explain template
+# ``documentdb_api_catalog.bson_aggregation_{query_base}``. ``{query_base}`` is
+# supplied by ``run_explain`` in
+# ``pg_documentdb_gw/documentdb_gateway_core/src/explain/mod.rs`` as one of these
+# four literals (RequestType::Aggregate -> "pipeline", Find -> "find",
+# Count -> "count", Distinct -> "distinct"). Keep in sync with those call sites.
+EXPLAIN_AGGREGATION_FUNCTIONS = frozenset(
+    f"documentdb_api_catalog.bson_aggregation_{query_base}"
+    for query_base in ("find", "pipeline", "count", "distinct")
+)
+
+
+def extract_referenced_functions(rust_source: str) -> set[str]:
+    """Return the set of ``schema.function`` names the gateway ``QueryCatalog``
+    calls by a *static* name in the documentdb backend schemas (i.e. excluding
+    the runtime-templated explain aggregation family)."""
+    return {
+        f"{match.group(1)}.{match.group(2)}"
+        for match in _CALL_RE.finditer(rust_source)
+    }
+
+
+def required_backend_functions(rust_source: str) -> set[str]:
+    """Return every backend routine the gateway calls that must exist in the
+    shipped extension: the statically-parsed calls plus the enumerated explain
+    aggregation family (which the static parser cannot resolve on its own)."""
+    return extract_referenced_functions(rust_source) | EXPLAIN_AGGREGATION_FUNCTIONS

--- a/documentdb-local/scripts/documentdb_local_tests/test_backend_contract.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_backend_contract.py
@@ -1,0 +1,271 @@
+"""
+Unit tests for the shared backend-contract detector (``backend_contract``).
+
+These tests are pure standard library -- they do not build or run any image --
+so they execute anywhere, including the ``documentdb-local-tests`` PR job.
+
+The critical coverage here is that the detector works on *ANSI-coloured* logs.
+The gateway logs through ``tracing_subscriber``'s ``fmt`` layer with colour on
+by default, so a real ``sub_status=42883`` field is emitted with SGR escapes
+around the name and the ``=``. A naive ``grep`` misses it; the detector must
+not.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import backend_contract as bc  # noqa: E402  (path set up above)
+
+
+# --- ANSI SGR codes tracing_subscriber's fmt layer uses for fields ----------
+_ITALIC = "\x1b[3m"
+_DIM = "\x1b[2m"
+_RESET = "\x1b[0m"
+
+
+def _field(name: str, value: str) -> str:
+    """Render a structured tracing field the way the coloured ``fmt`` layer
+    does: italic(name) + dim('=') + value."""
+    return f"{_ITALIC}{name}{_RESET}{_DIM}={_RESET}{value}"
+
+
+# A realistic (coloured) gateway error line for the #650 getParameter failure.
+_REAL_GETPARAMETER_LINE = (
+    "2026-07-15T10:21:17.351234Z \x1b[31mERROR\x1b[0m gateway: "
+    + _field("activity_id", "abc-123")
+    + " "
+    + _field(
+        "error",
+        "db error: ERROR: function documentdb_api.get_parameter(bson) "
+        "does not exist",
+    )
+    + " "
+    + _field("error_code", "59")
+    + " "
+    + _field("sub_status", "42883")
+    + " "
+    + _field("sub_status_code", "42883")
+    + " DbError during request."
+)
+
+
+class StripAnsiTests(unittest.TestCase):
+    def test_strips_field_escapes(self):
+        self.assertEqual(
+            bc.strip_ansi(_field("sub_status", "42883")), "sub_status=42883"
+        )
+
+    def test_noop_on_plain_text(self):
+        self.assertEqual(bc.strip_ansi("sub_status=42883"), "sub_status=42883")
+
+    def test_strips_standalone_level_colour(self):
+        self.assertEqual(bc.strip_ansi("\x1b[31mERROR\x1b[0m done"), "ERROR done")
+
+
+class DetectColouredTests(unittest.TestCase):
+    """The regression that motivated this module: coloured logs must match."""
+
+    def test_coloured_sub_status_is_detected(self):
+        line = "ERROR gw: " + _field("sub_status", "42883") + " failed."
+        self.assertEqual(bc.find_undefined_function_errors(line), ["ERROR gw: sub_status=42883 failed."])
+
+    def test_coloured_sub_status_code_is_detected(self):
+        line = "ERROR gw: " + _field("sub_status_code", "42883")
+        # Matches via the sub_status_code field (the `(?:_code)?` branch).
+        self.assertEqual(len(bc.find_undefined_function_errors(line)), 1)
+
+    def test_coloured_function_message_is_detected(self):
+        line = "ERROR gw: " + _field(
+            "error", "function documentdb_api.get_parameter(bson) does not exist"
+        )
+        self.assertEqual(len(bc.find_undefined_function_errors(line)), 1)
+
+    def test_real_getparameter_line_is_detected_once(self):
+        # A single offending line must be reported once, not per-alternative.
+        self.assertEqual(
+            len(bc.find_undefined_function_errors(_REAL_GETPARAMETER_LINE)), 1
+        )
+
+    def test_raw_coloured_sub_status_would_evade_plain_grep(self):
+        # Guard the premise: the un-stripped line does NOT contain the literal
+        # `sub_status=42883`, which is why a naive grep failed on real logs.
+        raw = "ERROR gw: " + _field("sub_status", "42883")
+        self.assertNotIn("sub_status=42883", raw)
+        self.assertEqual(len(bc.find_undefined_function_errors(raw)), 1)
+
+
+class DetectPlainTests(unittest.TestCase):
+    """Uncoloured logs (colour disabled) must match too."""
+
+    def test_plain_sub_status_is_detected(self):
+        self.assertEqual(
+            bc.find_undefined_function_errors("ts ERROR sub_status=42883 x"),
+            ["ts ERROR sub_status=42883 x"],
+        )
+
+    def test_plain_sub_status_code_is_detected(self):
+        # sub_status_code is the other real SQLSTATE-bearing field.
+        self.assertEqual(
+            len(bc.find_undefined_function_errors("gw ERROR sub_status_code=42883")),
+            1,
+        )
+
+    def test_plain_function_message_is_detected(self):
+        self.assertEqual(
+            len(
+                bc.find_undefined_function_errors(
+                    "function documentdb_api.get_parameter(bson) does not exist"
+                )
+            ),
+            1,
+        )
+
+    def test_genuine_error_function_missing_without_skipping_is_detected(self):
+        # A real undefined_function ERROR (no ", skipping") must still fire even
+        # though the benign IF-EXISTS NOTICE is excluded.
+        self.assertEqual(
+            len(
+                bc.find_undefined_function_errors(
+                    "ERROR:  function documentdb_api.get_parameter(boolean, "
+                    "boolean, text[]) does not exist"
+                )
+            ),
+            1,
+        )
+
+
+class NoFalsePositiveTests(unittest.TestCase):
+    def test_benign_database_does_not_exist_is_ignored(self):
+        self.assertEqual(
+            bc.find_undefined_function_errors(
+                'ERROR: database "gateway_smoke" does not exist'
+            ),
+            [],
+        )
+
+    def test_benign_relation_does_not_exist_is_ignored(self):
+        self.assertEqual(
+            bc.find_undefined_function_errors(
+                'ERROR: relation "documentdb_data.documents_5" does not exist'
+            ),
+            [],
+        )
+
+    def test_benign_drop_if_exists_function_notice_is_ignored(self):
+        # `DROP FUNCTION IF EXISTS <absent>` logs this NOTICE (to psql stderr ->
+        # docker logs) while CREATE EXTENSION runs the versioned upgrade chain.
+        # It shares the "function ... does not exist" wording but is not a
+        # backend-contract breach; the ", skipping" suffix must exclude it.
+        self.assertEqual(
+            bc.find_undefined_function_errors(
+                "NOTICE:  function documentdb_api.foo(bson) does not exist, "
+                "skipping"
+            ),
+            [],
+        )
+
+    def test_coloured_drop_if_exists_notice_is_ignored(self):
+        line = "NOTICE " + _field(
+            "msg", "function documentdb_api.foo(bson) does not exist, skipping"
+        )
+        self.assertEqual(bc.find_undefined_function_errors(line), [])
+
+    def test_42883_digit_run_in_activity_id_is_ignored(self):
+        # The `=42883` anchor must not fire on an unrelated digit run that
+        # merely contains 42883 (e.g. inside an activity id or timestamp).
+        self.assertEqual(
+            bc.find_undefined_function_errors(
+                _field("activity_id", "conn-1742883000") + " ready"
+            ),
+            [],
+        )
+
+    def test_error_code_field_is_not_matched(self):
+        # The anchored SQLSTATE pattern must not fire on `error_code=42883`
+        # (a MongoDB error code field, never a SQLSTATE); this is the collision
+        # the old unanchored `code=42883` substring branch would have hit.
+        self.assertEqual(
+            bc.find_undefined_function_errors("gw ERROR error_code=42883 done"),
+            [],
+        )
+
+    def test_clean_logs_yield_no_matches(self):
+        logs = "\n".join(
+            [
+                "INFO gateway: === DocumentDB is ready ===",
+                "INFO gateway: " + _field("request", "ping") + " ok",
+                "INFO gateway: Custom data initialization completed.",
+            ]
+        )
+        self.assertEqual(bc.find_undefined_function_errors(logs), [])
+
+
+class MultiLineTests(unittest.TestCase):
+    def test_returns_only_offending_lines(self):
+        logs = "\n".join(
+            [
+                "INFO ok",
+                "ERROR gw: " + _field("sub_status", "42883"),
+                "INFO still ok",
+                'ERROR: database "x" does not exist',
+                "ERROR gw: function foo.bar() does not exist",
+            ]
+        )
+        matches = bc.find_undefined_function_errors(logs)
+        self.assertEqual(len(matches), 2)
+        self.assertTrue(all("does not exist" in m or "42883" in m for m in matches))
+
+
+class CliTests(unittest.TestCase):
+    def _run_main(self, argv: list[str]) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = bc.main(argv)
+        return code, out.getvalue(), err.getvalue()
+
+    def test_file_with_match_exits_1(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = pathlib.Path(tmp) / "c.log"
+            log.write_text(_REAL_GETPARAMETER_LINE, encoding="utf-8")
+            code, _, err = self._run_main([str(log)])
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED", err)
+
+    def test_clean_file_exits_0(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = pathlib.Path(tmp) / "c.log"
+            log.write_text("INFO ready\nINFO done\n", encoding="utf-8")
+            code, out, _ = self._run_main([str(log)])
+        self.assertEqual(code, 0)
+        self.assertIn("passed", out)
+
+    def test_stdin_with_match_exits_1(self):
+        stdin = sys.stdin
+        sys.stdin = io.StringIO("ERROR " + _field("sub_status", "42883"))
+        try:
+            code, _, _ = self._run_main(["-"])
+        finally:
+            sys.stdin = stdin
+        self.assertEqual(code, 1)
+
+    def test_default_reads_stdin(self):
+        stdin = sys.stdin
+        sys.stdin = io.StringIO("all good here")
+        try:
+            code, _, _ = self._run_main([])
+        finally:
+            sys.stdin = stdin
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/documentdb-local/scripts/documentdb_local_tests/test_catalog_contract.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_catalog_contract.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for the backend-catalog contract parser (``catalog_contract``).
+
+Pure standard library -- no image, no docker -- so these run in the
+``documentdb-local-tests`` PR job. They pin the extraction rules and, against
+the real ``query_catalog.rs``, prove the reviewer's unexercised routines
+(``compact``/``collStats``/``dbStats``/...) are covered.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import catalog_contract as cc  # noqa: E402  (path set up above)
+
+# Repo root: .../documentdb-local/scripts/documentdb_local_tests/<this file>.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_QUERY_CATALOG_RS = (
+    _REPO_ROOT
+    / "pg_documentdb_gw"
+    / "documentdb_gateway_core"
+    / "src"
+    / "postgres"
+    / "query_catalog.rs"
+)
+
+# A synthetic catalog fragment covering every extraction rule.
+_SYNTHETIC = """
+    QueryCatalog {
+        a: "SELECT documentdb_api.drop_database($1)".to_owned(),
+        b: "SELECT * FROM documentdb_api.insert($1, $2, $3, NULL)".to_owned(),
+        c: "SELECT documentdb_api_internal.authenticate_token($1, $2)".to_owned(),
+        d: "CALL documentdb_api.insert_txn_proc($1, $2, $3, NULL)".to_owned(),
+        e: "SELECT documentdb_api.get_parameter ($1, $2, $3)".to_owned(),
+        f: "COALESCE(documentdb_api_catalog.bson_array_agg(r.doc, ''))".to_owned(),
+        g: "SELECT documentdb_core.bson_build_document('a', 1)".to_owned(),
+        h: "documentdb_api_catalog.bson_text_meta_qual".to_owned(),
+        i: "(documentdb_api_catalog.)?bson_dollar_project".to_owned(),
+        j: "SELECT documentdb_api.drop_database($1)".to_owned(),
+        k: "... documentdb_api_catalog.bson_aggregation_{query_base}($1, $2)".to_owned(),
+    }
+"""
+
+
+class ExtractTests(unittest.TestCase):
+    def test_extracts_calls_across_all_documentdb_schemas(self):
+        self.assertEqual(
+            cc.extract_referenced_functions(_SYNTHETIC),
+            {
+                "documentdb_api.drop_database",
+                "documentdb_api.insert",
+                "documentdb_api_internal.authenticate_token",
+                "documentdb_api.insert_txn_proc",
+                "documentdb_api.get_parameter",
+                # Static executable calls in the catalog/core schemas are in
+                # scope too (explain / listDatabases dependencies).
+                "documentdb_api_catalog.bson_array_agg",
+                "documentdb_core.bson_build_document",
+            },
+        )
+
+    def test_excludes_fragments_regex_and_dynamic_template(self):
+        got = cc.extract_referenced_functions(_SYNTHETIC)
+        # h: a bare name fragment (no `(`); i: a regex field; k: the
+        # runtime-templated bson_aggregation_{query_base} explain name.
+        self.assertNotIn("documentdb_api_catalog.bson_text_meta_qual", got)
+        self.assertFalse(any("bson_dollar" in f for f in got))
+        self.assertFalse(any("bson_aggregation" in f for f in got))
+
+    def test_deduplicates_repeated_calls(self):
+        got = cc.extract_referenced_functions(_SYNTHETIC)
+        self.assertEqual(
+            [f for f in got if f == "documentdb_api.drop_database"],
+            ["documentdb_api.drop_database"],
+        )
+
+    def test_requires_call_parenthesis(self):
+        # A bare name reference (no `(`) is a string fragment, not a call.
+        self.assertEqual(
+            cc.extract_referenced_functions('"documentdb_api.binary_version"'),
+            set(),
+        )
+        self.assertEqual(
+            cc.extract_referenced_functions('"documentdb_api.binary_version()"'),
+            {"documentdb_api.binary_version"},
+        )
+
+    def test_schema_names_disambiguated(self):
+        # Each schema is captured whole; documentdb_api_catalog must not be read
+        # as documentdb_api + ".catalog", nor shadow documentdb_api.
+        self.assertEqual(
+            cc.extract_referenced_functions('"documentdb_api_catalog.foo(x)"'),
+            {"documentdb_api_catalog.foo"},
+        )
+        self.assertEqual(
+            cc.extract_referenced_functions('"documentdb_api_internal.bar(x)"'),
+            {"documentdb_api_internal.bar"},
+        )
+        self.assertEqual(
+            cc.extract_referenced_functions('"documentdb_api.baz(x)"'),
+            {"documentdb_api.baz"},
+        )
+
+    def test_required_is_extracted_plus_explain_family(self):
+        # required_backend_functions() folds the enumerated explain aggregation
+        # family back in on top of the statically-parsed calls.
+        self.assertEqual(len(cc.EXPLAIN_AGGREGATION_FUNCTIONS), 4)
+        extracted = cc.extract_referenced_functions(_SYNTHETIC)
+        self.assertEqual(
+            cc.required_backend_functions(_SYNTHETIC),
+            extracted | set(cc.EXPLAIN_AGGREGATION_FUNCTIONS),
+        )
+
+
+@unittest.skipUnless(
+    _QUERY_CATALOG_RS.is_file(), f"query_catalog.rs not found at {_QUERY_CATALOG_RS}"
+)
+class RealCatalogTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.functions = cc.extract_referenced_functions(
+            _QUERY_CATALOG_RS.read_text(encoding="utf-8")
+        )
+
+    def test_includes_unexercised_command_routines(self):
+        # The reviewer's examples -- routines the CRUD/handshake smoke never
+        # triggers, so only an active contract test can guard them.
+        for fn in (
+            "documentdb_api.compact",
+            "documentdb_api.coll_stats",
+            "documentdb_api.db_stats",
+            "documentdb_api.get_parameter",
+            "documentdb_api.validate",
+        ):
+            self.assertIn(fn, self.functions)
+
+    def test_includes_internal_schema_routines(self):
+        self.assertIn(
+            "documentdb_api_internal.authenticate_token", self.functions
+        )
+
+    def test_includes_core_and_catalog_static_calls(self):
+        # Real executable calls in the non-command schemas (explain /
+        # listDatabases dependencies) must be covered, not just documentdb_api.
+        for fn in (
+            "documentdb_core.bson_build_document",
+            "documentdb_core.row_get_bson",
+            "documentdb_api_catalog.bson_array_agg",
+        ):
+            self.assertIn(fn, self.functions)
+
+    def test_excludes_dynamic_aggregation_template(self):
+        # The explain template documentdb_api_catalog.bson_aggregation_{query_base}
+        # has no statically-complete name, so it must not be extracted.
+        self.assertFalse(
+            any("bson_aggregation" in f for f in self.functions)
+        )
+
+    def test_required_adds_explain_aggregation_family(self):
+        # The dynamic explain routines are excluded from the static parse but
+        # re-added by required_backend_functions(), so the active gate covers
+        # bson_aggregation_{find,pipeline,count,distinct}.
+        required = cc.required_backend_functions(
+            _QUERY_CATALOG_RS.read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            required - self.functions, set(cc.EXPLAIN_AGGREGATION_FUNCTIONS)
+        )
+        for base in ("find", "pipeline", "count", "distinct"):
+            self.assertIn(
+                f"documentdb_api_catalog.bson_aggregation_{base}", required
+            )
+
+    def test_parses_a_substantial_set(self):
+        # ~49 backend routines across the four documentdb schemas today; a floor
+        # guards against a parser or source-layout breakage that silently
+        # returns nothing or a tiny set.
+        self.assertGreaterEqual(len(self.functions), 40)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/documentdb-local/scripts/documentdb_local_tests/test_image.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_image.py
@@ -42,14 +42,35 @@ from __future__ import annotations
 
 import os
 import pathlib
+import re
 import secrets
 import shutil
 import string
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
 import uuid
+
+# The shared backend-contract detector lives alongside this file. Make it
+# importable regardless of how the suite is launched: `unittest discover -s
+# <dir>` puts <dir> on sys.path, but a dotted
+# `-m unittest documentdb_local_tests.test_image` run does not.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import backend_contract  # noqa: E402
+import catalog_contract  # noqa: E402
+
+# Gateway QueryCatalog source (same commit the image is built from). Used by the
+# active backend-contract test to enumerate the routines the gateway calls.
+QUERY_CATALOG_RS = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "pg_documentdb_gw"
+    / "documentdb_gateway_core"
+    / "src"
+    / "postgres"
+    / "query_catalog.rs"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +246,65 @@ def _last_nonempty_line(text: str) -> str:
         if line.strip():
             return line.strip()
     return ""
+
+
+def _container_pg_ports(container: str) -> list[str]:
+    """Discover the in-container PostgreSQL port(s) from the unix socket(s).
+
+    The emulator runs PostgreSQL on a non-default port (default 9712) whose
+    socket lives at `/var/run/postgresql/.s.PGSQL.<port>`. Returning every
+    socket keeps introspection robust if the default changes or a second
+    cluster is present."""
+    res = _docker(
+        "exec", container, "sh", "-c",
+        "ls /var/run/postgresql/.s.PGSQL.* 2>/dev/null",
+        check=False, timeout=15,
+    )
+    ports = sorted(set(re.findall(r"\.s\.PGSQL\.(\d+)", res.stdout)))
+    if not ports:
+        raise RuntimeError(
+            "could not find a PostgreSQL unix socket "
+            "(/var/run/postgresql/.s.PGSQL.*) in the container; "
+            f"stdout={res.stdout!r} stderr={res.stderr!r}"
+        )
+    return ports
+
+
+def _existing_documentdb_functions(container: str) -> set[str]:
+    """Return the `schema.function` names present in the documentdb backend
+    schemas (documentdb_api, documentdb_api_internal, documentdb_api_catalog,
+    documentdb_core) of the container's `postgres` database.
+
+    Connects as the container's OS user (a superuser via peer auth) over the
+    local socket -- the same path the emulator's own setup uses. The SQL is
+    passed as a single argv element (no shell), so its quoting is literal. When
+    several PostgreSQL sockets exist, we union across them so the cluster that
+    actually holds the extension is found regardless of its port."""
+    sql = (
+        "SELECT n.nspname || '.' || p.proname "
+        "FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+        "WHERE n.nspname IN ('documentdb_api', 'documentdb_api_internal', "
+        "'documentdb_api_catalog', 'documentdb_core')"
+    )
+    functions: set[str] = set()
+    errors: list[str] = []
+    for port in _container_pg_ports(container):
+        res = _docker(
+            "exec", container, "psql", "-p", port, "-d", "postgres",
+            "-tAqc", sql, check=False, timeout=30,
+        )
+        if res.returncode == 0:
+            functions |= {
+                line.strip() for line in res.stdout.splitlines() if line.strip()
+            }
+        else:
+            errors.append(f"port {port}: rc={res.returncode} stderr={res.stderr.strip()!r}")
+    if not functions:
+        raise RuntimeError(
+            "no documentdb backend functions found on any PostgreSQL socket; "
+            f"psql attempts: {errors or 'all returned empty'}"
+        )
+    return functions
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +488,70 @@ class DefaultContainerTests(_ContainerTestBase):
             result.returncode, 0,
             "mongosh unexpectedly succeeded with a wrong password\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_no_undefined_backend_function_errors_in_logs(self):
+        """Backend-contract guard for issue #650.
+
+        A gateway command whose backend SQL calls a function the shipped
+        extension does not define surfaces as a PostgreSQL undefined_function
+        error (SQLSTATE 42883) in the container logs -- but clients silently
+        tolerate failed discovery probes (e.g. mongosh's getParameter on
+        connect), so a green ping/CRUD assertion cannot catch it. That is
+        exactly how #650 shipped. Drive one connection to force the discovery
+        handshake, then scan the logs with the shared, ANSI-aware detector."""
+        ping = self._mongosh("db.runCommand({ping: 1}).ok")
+        self.assertEqual(
+            ping.returncode, 0,
+            "mongosh ping failed while priming the backend-contract check\n"
+            f"stdout:\n{ping.stdout}\nstderr:\n{ping.stderr}",
+        )
+
+        logs = _docker("logs", self.container)
+        offending = backend_contract.find_undefined_function_errors(
+            logs.stdout + logs.stderr
+        )
+        self.assertEqual(
+            offending, [],
+            "gateway logged PostgreSQL undefined_function error(s) (SQLSTATE "
+            "42883): a gateway command calls a backend function the shipped "
+            "extension does not define (cf. issue #650). Offending lines:\n"
+            + "\n".join(offending),
+        )
+
+    def test_all_backend_catalog_functions_exist_in_image(self):
+        """Active backend-contract coverage for issue #650.
+
+        The log scan above only catches undefined-function errors for commands
+        the smoke actually exercises. Assert instead that EVERY backend routine
+        the gateway's QueryCatalog calls exists in the shipped extension -- so a
+        function used only by an unexercised command (compact, collStats,
+        dbStats, ...) cannot go missing silently, the generalised #650 class.
+        The required set is the statically-parsed calls plus the enumerated
+        explain aggregation family (bson_aggregation_{find,pipeline,count,
+        distinct}), which the gateway builds by a runtime-templated name."""
+        if not QUERY_CATALOG_RS.is_file():
+            self.skipTest(f"gateway QueryCatalog source not found: {QUERY_CATALOG_RS}")
+        referenced = catalog_contract.required_backend_functions(
+            QUERY_CATALOG_RS.read_text(encoding="utf-8")
+        )
+        self.assertGreaterEqual(
+            len(referenced), 40,
+            f"parsed only {len(referenced)} catalog routines; the parser or "
+            "query_catalog.rs layout may have changed",
+        )
+        existing = _existing_documentdb_functions(self.container)
+        self.assertTrue(
+            existing,
+            "no functions found in the documentdb backend schemas -- the "
+            "extension may not be installed in the 'postgres' database, or "
+            "introspection reached the wrong cluster",
+        )
+        missing = sorted(referenced - existing)
+        self.assertEqual(
+            missing, [],
+            "backend routines the gateway QueryCatalog calls but which are "
+            f"ABSENT from the shipped image (cf. issue #650): {missing}",
         )
 
     def test_container_still_running_after_workload(self):


### PR DESCRIPTION
## Issue

Part of the #650 fix set. #650 shipped despite a **green** documentdb-local CRUD smoke test: the gateway logged PostgreSQL `42883` (undefined function `documentdb_api.get_parameter`) on every connection, but clients silently tolerate failed discovery probes (mongosh runs `getParameter` on connect), so the smoke never inspected the logs. The root cause class is a gateway command whose backend SQL calls a function the shipped extension does not define.

## How this fixes it

CI-side hardening so that class of defect cannot ship silently again:

1. **ANSI-aware backend-contract log gate** — a shared, unit-tested detector (`backend_contract.py`) scans the container logs after the smoke run and fails on an undefined-function error (SQLSTATE `42883`, or `function ... does not exist`). It strips ANSI first: the gateway logs in colour by default, so a raw grep for `sub_status=42883` matched nothing. Wired into the release smoke in `build_gateway.yml`.

2. **Pre-merge enforcement** — `build_gateway.yml` runs only post-merge, so the same scan now also runs at PR time via the image test (`test_image.py`, PG17/18 × amd64/arm64), and the detector unit tests run on PRs.

3. **Active whole-catalog contract** — the log scan only sees *exercised* commands, so a routine used only by e.g. `compact`/`collStats`/`dbStats` could still go missing silently. A new parser (`catalog_contract.py`) enumerates every backend routine the gateway's `QueryCatalog` calls — 53 across the `documentdb_api`, `documentdb_api_internal`, `documentdb_api_catalog` and `documentdb_core` schemas, including the four `bson_aggregation_*` explain routines — and a new image test asserts each exists in the shipped extension via `pg_proc` introspection.

## Merge order

Land after the getParameter compatibility fix (#658) — the pre-merge gates correctly stay red until `documentdb_api.get_parameter` ships.
