### PR TITLE
Fix #650: reject gateway-reserved documentdb-local usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Add feature-flagged single-pass RUM posting-tree vacuum that prunes emptied leaf pages inline during the bulk-delete TID cleanup walk instead of a separate pruning pass. Guarded by `enable_single_pass_posting_tree_vacuum`, disabled by default while pending stabilization. *[Perf]*
 * Fix backend crash when serializing a SQL array that contains a NULL element. *[Bugfix]*
 * Fix memory usage in tokio-postgres Framed/BytesMut crate *[Bugfix/Perf]*
-* Reject documentdb-local usernames that begin with a gateway-reserved role prefix (e.g. `citus`, `documentdb`, `pg`, `internal_role`) at startup, instead of reporting the container ready with credentials that can never authenticate. *[Bugfix]* (#650)
+* Reject documentdb-local usernames that begin with a gateway-reserved role prefix (e.g. `citus`, `documentdb`, `pg`, `internal_role`) or collide with a registered internal DocumentDB role, instead of reporting the container ready with credentials that can never authenticate. *[Bugfix]* (#650)
 
 ### documentdb v0.114-0 (Unreleased) ###
 * Extend `enableNewNamespaceValidation` to block create/drop/rename/createIndex on reserved collections in `admin` and `local` databases, and complete the `config` reserved-collection list (added sharding-runtime names: `changelog`, `mongos`, `placementHistory`, `tags`, `transactions`, `locks`, `lockpings`, `migrations`, `migrationCoordinators`, `rangeDeletions`, `reshardingOperations`, `cache.collections`, `cache.databases`). *[Feature]*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add feature-flagged single-pass RUM posting-tree vacuum that prunes emptied leaf pages inline during the bulk-delete TID cleanup walk instead of a separate pruning pass. Guarded by `enable_single_pass_posting_tree_vacuum`, disabled by default while pending stabilization. *[Perf]*
 * Fix backend crash when serializing a SQL array that contains a NULL element. *[Bugfix]*
 * Fix memory usage in tokio-postgres Framed/BytesMut crate *[Bugfix/Perf]*
+* Reject documentdb-local usernames that begin with a gateway-reserved role prefix (e.g. `citus`, `documentdb`, `pg`, `internal_role`) at startup, instead of reporting the container ready with credentials that can never authenticate. *[Bugfix]* (#650)
 
 ### documentdb v0.114-0 (Unreleased) ###
 * Extend `enableNewNamespaceValidation` to block create/drop/rename/createIndex on reserved collections in `admin` and `local` databases, and complete the `config` reserved-collection list (added sharding-runtime names: `changelog`, `mongos`, `placementHistory`, `tags`, `transactions`, `locks`, `lockpings`, `migrations`, `migrationCoordinators`, `rangeDeletions`, `reshardingOperations`, `cache.collections`, `cache.databases`). *[Feature]*

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 import tempfile
 import textwrap
@@ -8,6 +9,14 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 ENTRYPOINT = REPO_ROOT / "documentdb-local" / "scripts" / "emulator_entrypoint.sh"
+GATEWAY_RBAC_UTILS = (
+    REPO_ROOT
+    / "pg_documentdb_gw"
+    / "documentdb_tests"
+    / "src"
+    / "utils"
+    / "rbac_utils.rs"
+)
 
 
 class EmulatorEntrypointTests(unittest.TestCase):
@@ -604,6 +613,21 @@ json.dump(data, sys.stdout)
         config["BlockedRolePrefixes"] = prefixes
         config_path.write_text(json.dumps(config), encoding="utf-8")
 
+    def _gateway_reserved_role_names(self):
+        source = GATEWAY_RBAC_UTILS.read_text(encoding="utf-8")
+        match = re.search(
+            r"pub const RESERVED_ROLE_NAMES:.*?= &\[(.*?)\];",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            match,
+            "could not find the gateway RESERVED_ROLE_NAMES registry",
+        )
+        role_names = re.findall(r'"([^"]+)"', match.group(1))
+        self.assertTrue(role_names, "gateway reserved-role registry is empty")
+        return role_names
+
     def test_blocked_username_prefix_is_rejected(self):
         # citus is the username in the issue #650 reproduction; documentdb is the
         # prefix the default test config blocks. Either must fail fast at startup
@@ -649,6 +673,21 @@ json.dump(data, sys.stdout)
                     result.stdout + result.stderr,
                 )
 
+    def test_all_gateway_reserved_role_names_are_rejected(self):
+        # Registered internal roles remain reserved even when the independent
+        # BlockedRolePrefixes policy is empty.
+        self._set_blocked_role_prefixes([])
+        for username in self._gateway_reserved_role_names():
+            with self.subTest(username=username):
+                result = self._run_entrypoint(
+                    "--password", "mypassword", extra_env={"USERNAME": username}
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "is reserved for an internal DocumentDB role",
+                    result.stdout + result.stderr,
+                )
+
     def test_empty_blocked_prefix_entry_fails_fast(self):
         # The gateway's starts_with("") matches every username, so an empty
         # BlockedRolePrefixes entry blocks all authentication. The entrypoint
@@ -671,6 +710,18 @@ json.dump(data, sys.stdout)
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("not found", result.stdout + result.stderr)
+
+    def test_unparseable_gateway_config_fails_fast(self):
+        config_path = self.gateway_config_dir / "SetupConfiguration.json"
+        config_path.write_text("{not valid json", encoding="utf-8")
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "failed to parse gateway configuration",
+            result.stdout + result.stderr,
+        )
 
     def test_non_array_blocked_role_prefixes_fails_fast(self):
         # A syntactically valid config whose BlockedRolePrefixes is not an array
@@ -726,9 +777,10 @@ json.dump(data, sys.stdout)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must contain only strings", result.stdout + result.stderr)
 
-    def test_empty_blocked_role_prefixes_allows_any_username(self):
-        # An empty array is a valid config meaning "no reserved prefixes", so a
-        # username that a non-empty policy would block must pass validation.
+    def test_empty_blocked_role_prefixes_allows_non_reserved_username(self):
+        # An empty array disables prefix blocking, but exact internal role names
+        # remain reserved. A non-reserved username that the default prefix policy
+        # would block must pass validation.
         self._set_blocked_role_prefixes([])
         result = self._run_entrypoint(
             "--password", "mypassword", extra_env={"USERNAME": "documentdb_service"}

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -62,14 +62,44 @@ exec "$@"
 import json
 import sys
 args = sys.argv[1:]
+raw = False
 vars = {}
-while args and args[0] in ('--arg', '--argjson'):
-    flag, name, value, *args = args
-    vars[name] = json.loads(value) if flag == '--argjson' else value
+while args and args[0].startswith('-'):
+    if args[0] in ('--arg', '--argjson'):
+        flag, name, value, *args = args
+        vars[name] = json.loads(value) if flag == '--argjson' else value
+    elif args[0] in ('-r', '--raw-output'):
+        raw = True
+        args = args[1:]
+    else:
+        args = args[1:]
 expr, file_path = args
 with open(file_path, 'r', encoding='utf-8') as f:
     data = json.load(f)
 expr = expr.strip()
+if expr == '.BlockedRolePrefixes | type':
+    v = data.get('BlockedRolePrefixes')
+    if v is None:
+        print('null')
+    elif isinstance(v, bool):
+        print('boolean')
+    elif isinstance(v, list):
+        print('array')
+    elif isinstance(v, str):
+        print('string')
+    elif isinstance(v, (int, float)):
+        print('number')
+    else:
+        print('object')
+    raise SystemExit(0)
+if expr == 'all(.BlockedRolePrefixes[]; type == "string")':
+    arr = data.get('BlockedRolePrefixes') or []
+    ok = isinstance(arr, list) and all(isinstance(x, str) for x in arr)
+    raise SystemExit(0 if ok else 1)
+if expr in ('.BlockedRolePrefixes[]', '.BlockedRolePrefixes[]?'):
+    for item in data.get('BlockedRolePrefixes', []):
+        print(item)
+    raise SystemExit(0)
 if expr.startswith('.GatewayListenPort = '):
     data['GatewayListenPort'] = int(expr.split('=', 1)[1].strip())
 elif expr.startswith('.PostgresPort = '):
@@ -224,12 +254,48 @@ json.dump(data, sys.stdout)
 import json
 import sys
 args = sys.argv[1:]
+raw = False
 vars = {}
-while args and args[0] in ('--arg', '--argjson'):
-    flag, name, value, *args = args
-    vars[name] = json.loads(value) if flag == '--argjson' else value
+while args and args[0].startswith('-'):
+    if args[0] in ('--arg', '--argjson'):
+        flag, name, value, *args = args
+        vars[name] = json.loads(value) if flag == '--argjson' else value
+    elif args[0] in ('-r', '--raw-output'):
+        raw = True
+        args = args[1:]
+    else:
+        args = args[1:]
 expr, file_path = args
 expr = expr.strip()
+if expr == '.BlockedRolePrefixes | type':
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    v = data.get('BlockedRolePrefixes')
+    if v is None:
+        print('null')
+    elif isinstance(v, bool):
+        print('boolean')
+    elif isinstance(v, list):
+        print('array')
+    elif isinstance(v, str):
+        print('string')
+    elif isinstance(v, (int, float)):
+        print('number')
+    else:
+        print('object')
+    raise SystemExit(0)
+if expr == 'all(.BlockedRolePrefixes[]; type == "string")':
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    arr = data.get('BlockedRolePrefixes') or []
+    ok = isinstance(arr, list) and all(isinstance(x, str) for x in arr)
+    raise SystemExit(0 if ok else 1)
+if expr in ('.BlockedRolePrefixes[]', '.BlockedRolePrefixes[]?'):
+    with open(file_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    for item in data.get('BlockedRolePrefixes', []):
+        print(item)
+    raise SystemExit(0)
 if expr.startswith('.EnforceTls = '):
     sys.stderr.write('jq: simulated failure\\n')
     sys.exit(1)
@@ -531,6 +597,144 @@ json.dump(data, sys.stdout)
                 text,
                 msg=f"{js.name} should guard inserts with an existence check (#612)",
             )
+
+    def _set_blocked_role_prefixes(self, prefixes):
+        config_path = self.gateway_config_dir / "SetupConfiguration.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        config["BlockedRolePrefixes"] = prefixes
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    def test_blocked_username_prefix_is_rejected(self):
+        # citus is the username in the issue #650 reproduction; documentdb is the
+        # prefix the default test config blocks. Either must fail fast at startup
+        # rather than letting the container report ready with an unusable user.
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "documentdb_user"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "username 'documentdb_user' uses reserved prefix 'documentdb'",
+            result.stdout + result.stderr,
+        )
+
+    def test_blocked_username_prefix_is_case_insensitive(self):
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "DocumentDBAdmin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "uses reserved prefix 'documentdb'",
+            result.stdout + result.stderr,
+        )
+
+    def test_allowed_username_passes_validation(self):
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertNotIn("reserved prefix", result.stdout + result.stderr)
+
+    def test_all_configured_blocked_prefixes_are_rejected(self):
+        prefixes = ["documentdb", "citus", "pg", "internal_role"]
+        self._set_blocked_role_prefixes(prefixes)
+        for prefix in prefixes:
+            username = f"{prefix}_service"
+            with self.subTest(username=username):
+                result = self._run_entrypoint(
+                    "--password", "mypassword", extra_env={"USERNAME": username}
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"uses reserved prefix '{prefix}'",
+                    result.stdout + result.stderr,
+                )
+
+    def test_empty_blocked_prefix_entry_fails_fast(self):
+        # The gateway's starts_with("") matches every username, so an empty
+        # BlockedRolePrefixes entry blocks all authentication. The entrypoint
+        # must fail fast rather than start a container whose user can never
+        # authenticate -- even for an otherwise-allowed username.
+        self._set_blocked_role_prefixes([""])
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains an empty entry", result.stdout + result.stderr)
+
+    def test_missing_gateway_config_fails_fast(self):
+        # Validation reads the gateway's own SetupConfiguration.json; if it is
+        # missing the check must not silently pass (which would re-open the
+        # false-success-startup bug), it must fail fast.
+        (self.gateway_config_dir / "SetupConfiguration.json").unlink()
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not found", result.stdout + result.stderr)
+
+    def test_non_array_blocked_role_prefixes_fails_fast(self):
+        # A syntactically valid config whose BlockedRolePrefixes is not an array
+        # (the gateway requires an array of strings) must fail fast rather than
+        # be silently treated as "no prefixes", which would re-open the
+        # false-success-startup bug.
+        config_path = self.gateway_config_dir / "SetupConfiguration.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        config["BlockedRolePrefixes"] = "documentdb"
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be a JSON array", result.stdout + result.stderr)
+
+    def _write_raw_config(self, mutate):
+        config_path = self.gateway_config_dir / "SetupConfiguration.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        mutate(config)
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    def test_missing_blocked_role_prefixes_key_fails_fast(self):
+        # The gateway requires BlockedRolePrefixes (non-defaulted Vec<String>), so
+        # an absent key is invalid; validate the same contract instead of silently
+        # skipping and letting the gateway fail later.
+        self._write_raw_config(lambda c: c.pop("BlockedRolePrefixes", None))
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be a JSON array", result.stdout + result.stderr)
+
+    def test_null_blocked_role_prefixes_fails_fast(self):
+        self._write_raw_config(
+            lambda c: c.__setitem__("BlockedRolePrefixes", None)
+        )
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be a JSON array", result.stdout + result.stderr)
+
+    def test_non_string_blocked_role_prefixes_element_fails_fast(self):
+        # An array with a non-string element is not a Vec<String> and the gateway
+        # would reject it; fail fast with a clear message.
+        self._write_raw_config(
+            lambda c: c.__setitem__("BlockedRolePrefixes", ["documentdb", 123])
+        )
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "docdb_admin"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must contain only strings", result.stdout + result.stderr)
+
+    def test_empty_blocked_role_prefixes_allows_any_username(self):
+        # An empty array is a valid config meaning "no reserved prefixes", so a
+        # username that a non-empty policy would block must pass validation.
+        self._set_blocked_role_prefixes([])
+        result = self._run_entrypoint(
+            "--password", "mypassword", extra_env={"USERNAME": "documentdb_service"}
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertNotIn("reserved prefix", result.stdout + result.stderr)
 
 
 class InitDataAttemptMarkerTests(unittest.TestCase):

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -290,6 +290,64 @@ echo "Using username: $USERNAME"
 echo "Using owner: $OWNER"
 echo "Using data path: $DATA_PATH"
 
+# Reject usernames that use a gateway-reserved role prefix. The gateway blocks
+# these prefixes at authentication time (BlockedRolePrefixes in
+# SetupConfiguration.json) using a case-insensitive prefix match, so creating
+# such a user would produce a container that reports ready but can never
+# authenticate. Validate against the same configuration the gateway reads.
+GATEWAY_SETUP_CONFIG="$GATEWAY_HOME/pg_documentdb_gw/SetupConfiguration.json"
+if [ ! -f "$GATEWAY_SETUP_CONFIG" ]; then
+    echo "Error: gateway configuration '$GATEWAY_SETUP_CONFIG' not found; cannot validate the username against reserved role prefixes." >&2
+    exit 1
+fi
+# The gateway deserializes BlockedRolePrefixes as a required array of strings
+# (a non-defaulted Vec<String> in setup.rs), so fail closed on a parse error or
+# any other shape instead of silently skipping validation (which would re-open
+# the false-success-startup bug) or letting the gateway fail later with a cryptic
+# deserialization error. An empty array is valid and means "no blocked prefixes".
+if ! blocked_prefixes_type=$(jq -r '.BlockedRolePrefixes | type' "$GATEWAY_SETUP_CONFIG" 2>/dev/null); then
+    echo "Error: failed to parse gateway configuration '$GATEWAY_SETUP_CONFIG'; cannot validate the username against reserved role prefixes." >&2
+    exit 1
+fi
+if [ "$blocked_prefixes_type" != "array" ]; then
+    echo "Error: BlockedRolePrefixes in '$GATEWAY_SETUP_CONFIG' must be a JSON array of strings." >&2
+    exit 1
+fi
+if ! jq -e 'all(.BlockedRolePrefixes[]; type == "string")' "$GATEWAY_SETUP_CONFIG" >/dev/null 2>&1; then
+    echo "Error: BlockedRolePrefixes in '$GATEWAY_SETUP_CONFIG' must contain only strings." >&2
+    exit 1
+fi
+# Read every entry via process substitution so a stray empty prefix is preserved
+# (command substitution would strip it away with the trailing newline).
+mapfile -t blocked_role_prefixes < <(jq -r '.BlockedRolePrefixes[]?' "$GATEWAY_SETUP_CONFIG")
+if [ "${#blocked_role_prefixes[@]}" -gt 0 ]; then
+    # Lowercase via bash parameter expansion (locale-aware in the image's UTF-8
+    # locale). This is exact for the shipped ASCII reserved prefixes; for
+    # non-ASCII prefixes bash's one-to-one case folding may differ from the
+    # gateway's Rust to_lowercase() (full Unicode folding), so exact parity is
+    # only guaranteed for ASCII prefixes.
+    username_lower=${USERNAME,,}
+    blocked_list=$(printf '%s, ' "${blocked_role_prefixes[@]}")
+    blocked_list=${blocked_list%, }
+    for blocked_prefix in "${blocked_role_prefixes[@]}"; do
+        prefix_lower=${blocked_prefix,,}
+        if [ -z "$prefix_lower" ]; then
+            # The gateway's starts_with("") matches every username, so an empty
+            # entry blocks all authentication. Fail fast rather than start a
+            # container whose configured user can never authenticate.
+            echo "Error: BlockedRolePrefixes in '$GATEWAY_SETUP_CONFIG' contains an empty entry, which the gateway treats as blocking every username. Fix the gateway configuration." >&2
+            exit 1
+        fi
+        case "$username_lower" in
+            "$prefix_lower"*)
+                echo "Error: username '$USERNAME' uses reserved prefix '$blocked_prefix'." >&2
+                echo "Choose a username that does not begin with any of: ${blocked_list}." >&2
+                exit 1
+                ;;
+        esac
+    done
+fi
+
 if { [ -n "${CERT_PATH:-}" ] && [ -z "${KEY_FILE:-}" ]; } || \
    { [ -z "${CERT_PATH:-}" ] && [ -n "${KEY_FILE:-}" ]; }; then
     echo "Error: Both CERT_PATH and KEY_FILE must be set together, or neither should be set."

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -317,6 +317,31 @@ if ! jq -e 'all(.BlockedRolePrefixes[]; type == "string")' "$GATEWAY_SETUP_CONFI
     echo "Error: BlockedRolePrefixes in '$GATEWAY_SETUP_CONFIG' must contain only strings." >&2
     exit 1
 fi
+
+# The createUser backend also reserves the internal PostgreSQL roles registered
+# by DocumentDB. Keep this exact-name check independent of BlockedRolePrefixes:
+# an empty or customized prefix list is valid gateway configuration, but it does
+# not make an internal role name available for a user.
+gateway_reserved_role_names=(
+    "documentdb_admin_role"
+    "documentdb_api_find_role"
+    "documentdb_api_insert_role"
+    "documentdb_api_remove_role"
+    "documentdb_api_update_role"
+    "documentdb_bg_worker_role"
+    "documentdb_cluster_admin_role"
+    "documentdb_readonly_role"
+    "documentdb_readwrite_role"
+    "documentdb_root_role"
+    "documentdb_user_admin_role"
+)
+for reserved_role_name in "${gateway_reserved_role_names[@]}"; do
+    if [ "$USERNAME" = "$reserved_role_name" ]; then
+        echo "Error: username '$USERNAME' is reserved for an internal DocumentDB role." >&2
+        exit 1
+    fi
+done
+
 # Read every entry via process substitution so a stray empty prefix is preserved
 # (command substitution would strip it away with the trailing newline).
 mapfile -t blocked_role_prefixes < <(jq -r '.BlockedRolePrefixes[]?' "$GATEWAY_SETUP_CONFIG")


### PR DESCRIPTION
## Summary

Part 1 of 3 addressing #650. This PR fixes **only** the documentdb-local username defect—the fatal error in the issue reproduction—and touches only documentdb-local files (no gateway/engine changes).

Two independent name restrictions can make a configured emulator user unusable:
- The gateway rejects any username whose lowercased form begins with a configured `BlockedRolePrefixes` entry (`documentdb`, `citus`, `pg`, `internal_role`) during authentication.
- The `createUser` backend reserves 11 exact internal PostgreSQL role names, enumerated by the gateway's `RESERVED_ROLE_NAMES` registry.

The reproduction used `USERNAME=citus`; documentdb-local previously created or reused an invalid role and reported the container **ready**, even though the configured credentials could never authenticate.

## Fix

`emulator_entrypoint.sh` now validates the username before PostgreSQL initialization and user creation:
- Rejects every exact internal role in the gateway registry, independently of prefix configuration.
- Reads `BlockedRolePrefixes` from the gateway's own `SetupConfiguration.json` and mirrors the gateway's case-insensitive prefix check.
- Runs regardless of `CREATE_USER`, because pre-existing roles remain subject to the same gateway and backend restrictions.

Robustness:
- Fails closed if the gateway config is missing, unparseable, or has an invalid `BlockedRolePrefixes` shape.
- Preserves empty prefix entries; because the gateway treats `starts_with("")` as matching every username, an empty entry is a hard configuration error.
- Allows an empty prefix array while still rejecting exact registered internal roles.
- Drives exact-role coverage from the gateway `RESERVED_ROLE_NAMES` registry so a newly registered role cannot be missed silently.

## Tests

The entrypoint suite covers all 11 registered internal roles, every configured blocked prefix, case-insensitive matching, allowed usernames, empty/custom prefix policies, malformed/missing config, invalid config shapes, and empty-prefix failure. **35/35 entrypoint tests pass.**

## Scope note

This is one of three PRs for #650:
1. **This PR** — documentdb-local username validation.
2. #658 — `getParameter` compatibility shim (emulator-only workaround for the 42883).
3. #659 — CI gate for undefined backend-function errors.

Recommended merge order: **#660 → #658 → #659**.

Files: `emulator_entrypoint.sh`, `test_emulator_entrypoint.py`, `CHANGELOG.md`.