### PR TITLE
Fix bson_aggregation_pipeline_tests vector test broken by pgvector 0.8.5

### DIFF
--- a/pg_documentdb/src/test/regress/expected/bson_aggregation_pipeline_tests.out
+++ b/pg_documentdb/src/test/regress/expected/bson_aggregation_pipeline_tests.out
@@ -932,22 +932,34 @@ CALL documentdb_api.drop_indexes('db', '{ "dropIndexes": "aggregation_pipeline",
  { "ok" : true, "nIndexesWas" : { "$numberLong" : "2" } }
 (1 row)
 
-SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "aggregation_pipeline", "indexes": [ { "key": { "v": "cosmosSearch" }, "name": "foo_1", "cosmosSearchOptions": { "kind": "vector-ivf", "numLists": 10000, "similarity": "COS", "dimensions": 3 } } ] }', true);
+SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "aggregation_pipeline", "indexes": [ { "key": { "v": "cosmosSearch" }, "name": "foo_1", "cosmosSearchOptions": { "kind": "vector-ivf", "numLists": 3, "similarity": "COS", "dimensions": 3 } } ] }', true);
 NOTICE:  ivfflat index created with little data
 DETAIL:  This will cause low recall.
 HINT:  Drop the index until the table has more data.
-ERROR:  memory required is 394 MB, maintenance_work_mem is 64 MB
-CONTEXT:  SQL statement "CREATE INDEX documents_rum_index_3502 ON documentdb_data.documents_3500 USING ivfflat(CAST(documentdb_api_internal.bson_extract_vector(document, 'v'::text) AS public.vector(3)) public.vector_cosine_ops) WITH (lists = 10000) WHERE documentdb_api_internal.bson_extract_vector(document, 'v'::text) IS NOT NULL"
+                                                                                                   create_indexes_non_concurrently                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "raw" : { "defaultShard" : { "numIndexesBefore" : { "$numberInt" : "1" }, "numIndexesAfter" : { "$numberInt" : "2" }, "createdCollectionAutomatically" : false, "ok" : { "$numberInt" : "1" } } }, "ok" : { "$numberInt" : "1" } }
+(1 row)
+
 ANALYZE;
 BEGIN;
 SET LOCAL enable_seqscan = off;
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "cosmosSearch": { "vector": [ 3.0, 4.9, 1.0 ], "k": 2, "path": "v", "nProbes": 10000 }  } } ], "cursor": {} }');
-ERROR:  Similarity index was not found for a vector similarity search query.
+                                                                                                                               document                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "_id" : { "$numberInt" : "6" }, "a" : "some sentence", "v" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "5.0" }, { "$numberDouble" : "1.1000000000000000888" } ], "__cosmos_meta__" : { "score" : { "$numberDouble" : "0.99986126308999445644" } } }
+ { "_id" : { "$numberInt" : "7" }, "a" : "some other sentence", "v" : [ { "$numberDouble" : "8.0" }, { "$numberDouble" : "5.0" }, { "$numberDouble" : "0.10000000000000000555" } ], "__cosmos_meta__" : { "score" : { "$numberDouble" : "0.88331075895982669177" } } }
+(2 rows)
+
 COMMIT;
 BEGIN;
 SET LOCAL enable_seqscan = off;
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "cosmosSearch": { "vector": [ 3.0, 5.0, 1.1 ], "k": 2, "path": "v", "nProbes": 1 }  } } ], "cursor": {} }');
-ERROR:  Similarity index was not found for a vector similarity search query.
+                                                                                                                  document                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "_id" : { "$numberInt" : "6" }, "a" : "some sentence", "v" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "5.0" }, { "$numberDouble" : "1.1000000000000000888" } ], "__cosmos_meta__" : { "score" : { "$numberDouble" : "1.0" } } }
+(1 row)
+
 COMMIT;
 SELECT documentdb_test_helpers.drop_primary_key('db','aggregation_pipeline');
  drop_primary_key 
@@ -958,27 +970,79 @@ SELECT documentdb_test_helpers.drop_primary_key('db','aggregation_pipeline');
 BEGIN;
 set local enable_seqscan to off;
 EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "cosmosSearch": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v", "nProbes": 1 }  } } ], "cursor": {} }');
-ERROR:  Similarity index was not found for a vector similarity search query.
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on agg_stage_0
+   Output: documentdb_api_internal.bson_document_add_score_field(agg_stage_0.document, ('1'::double precision - (public.vector(documentdb_api_internal.bson_extract_vector(agg_stage_0.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)))
+   ->  Limit
+         Output: collection.document, ((public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector))
+         ->  Custom Scan (DocumentDBApiQueryScan)
+               Output: collection.document, (public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)
+               CosmosSearch Custom Params: { "nProbes" : 1 }
+               ->  Index Scan using foo_1 on documentdb_data.documents_3500 collection
+                     Output: collection.document
+                     Order By: (public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)
+                     Filter: documentdb_api_internal.bson_search_param(collection.document, '{ "nProbes" : { "$numberInt" : "1" } }'::bson)
+(11 rows)
+
 EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "cosmosSearch": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v" }  } } ], "cursor": {} }');
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on agg_stage_0
+   Output: documentdb_api_internal.bson_document_add_score_field(agg_stage_0.document, ('1'::double precision - (public.vector(documentdb_api_internal.bson_extract_vector(agg_stage_0.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)))
+   ->  Limit
+         Output: collection.document, ((public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector))
+         ->  Custom Scan (DocumentDBApiQueryScan)
+               Output: collection.document, (public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)
+               CosmosSearch Custom Params: { "nProbes" : 3 }
+               ->  Index Scan using foo_1 on documentdb_data.documents_3500 collection
+                     Output: collection.document
+                     Order By: (public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)
+(10 rows)
+
 ROLLBACK;
 -- Vector search with knnBeta
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 5.0, 1.1 ], "k": 1, "path": "v" }  } } ], "cursor": {} }');
-ERROR:  Similarity index was not found for a vector similarity search query.
+                                                                                                                  document                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "_id" : { "$numberInt" : "6" }, "a" : "some sentence", "v" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "5.0" }, { "$numberDouble" : "1.1000000000000000888" } ], "__cosmos_meta__" : { "score" : { "$numberDouble" : "1.0" } } }
+(1 row)
+
 EXPLAIN (COSTS OFF, VERBOSE ON) SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v" }  } } ], "cursor": {} }');
-ERROR:  Similarity index was not found for a vector similarity search query.
+                                                                                                                               QUERY PLAN                                                                                                                                
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Subquery Scan on agg_stage_0
+   Output: documentdb_api_internal.bson_document_add_score_field(agg_stage_0.document, ('1'::double precision - (public.vector(documentdb_api_internal.bson_extract_vector(agg_stage_0.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)))
+   ->  Limit
+         Output: collection.document, ((public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector))
+         ->  Custom Scan (DocumentDBApiQueryScan)
+               Output: collection.document, (public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)
+               CosmosSearch Custom Params: { "nProbes" : 3 }
+               ->  Index Scan using foo_1 on documentdb_data.documents_3500 collection
+                     Output: collection.document
+                     Order By: (public.vector(documentdb_api_internal.bson_extract_vector(collection.document, 'v'::text), 3, true) OPERATOR(public.<=>) '[3,4.9,1]'::public.vector)
+(10 rows)
+
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v", "filter": {"a": "some sentence"} }  } } ], "cursor": {} }');
 ERROR:  $filter is not supported for knnBeta queries.
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v", "filter": "some" }  } } ], "cursor": {} }');
 ERROR:  $filter must be a document value.
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 5.0, 1.1 ], "k": 1, "path": "v", "filter": {} }  } } ], "cursor": {} }');
-ERROR:  Similarity index was not found for a vector similarity search query.
+                                                                                                                  document                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "_id" : { "$numberInt" : "6" }, "a" : "some sentence", "v" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "5.0" }, { "$numberDouble" : "1.1000000000000000888" } ], "__cosmos_meta__" : { "score" : { "$numberDouble" : "1.0" } } }
+(1 row)
+
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v", "score": {"a": "some sentence"} }  } } ], "cursor": {} }');
 ERROR:  $score is not supported for knnBeta queries.
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v", "score": 100 }  } } ], "cursor": {} }');
 ERROR:  $score must be a document value.
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "knnBeta": { "vector": [ 3.0, 5.0, 1.1 ], "k": 1, "path": "v", "score": {} }  } } ], "cursor": {} }');
-ERROR:  Similarity index was not found for a vector similarity search query.
+                                                                                                                  document                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ { "_id" : { "$numberInt" : "6" }, "a" : "some sentence", "v" : [ { "$numberDouble" : "3.0" }, { "$numberDouble" : "5.0" }, { "$numberDouble" : "1.1000000000000000888" } ], "__cosmos_meta__" : { "score" : { "$numberDouble" : "1.0" } } }
+(1 row)
+
 SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregation_pipeline", "pipeline": [ { "$search": { "unknowType": { "vector": [ 3.0, 4.9, 1.0 ], "k": 1, "path": "v" }  } } ], "cursor": {} }');
 ERROR:  Unrecognized $search option: unknowType
 -- non supported vector index type

--- a/pg_documentdb/src/test/regress/sql/bson_aggregation_pipeline_tests.sql
+++ b/pg_documentdb/src/test/regress/sql/bson_aggregation_pipeline_tests.sql
@@ -291,7 +291,7 @@ SELECT document FROM bson_aggregation_pipeline('db', '{ "aggregate": "aggregatio
 
 -- numLists > data size, pgvector will generate randomized centroids, using original vector data to query
 CALL documentdb_api.drop_indexes('db', '{ "dropIndexes": "aggregation_pipeline", "index": "foo_1"}');
-SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "aggregation_pipeline", "indexes": [ { "key": { "v": "cosmosSearch" }, "name": "foo_1", "cosmosSearchOptions": { "kind": "vector-ivf", "numLists": 10000, "similarity": "COS", "dimensions": 3 } } ] }', true);
+SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "aggregation_pipeline", "indexes": [ { "key": { "v": "cosmosSearch" }, "name": "foo_1", "cosmosSearchOptions": { "kind": "vector-ivf", "numLists": 3, "similarity": "COS", "dimensions": 3 } } ] }', true);
 ANALYZE;
 BEGIN;
 SET LOCAL enable_seqscan = off;


### PR DESCRIPTION
## Summary

Standalone fix to unblock **`main`**'s daily **Functional tests**, which have failed every day since **2026-07-12** (e.g. run `29230752941`, and most recently `29394986244`). The `build-documentdb-local` -> **Build Debian Package** step fails at `make check`.

This cherry-picks **only** the vector-test fix (originally PR 2194508) so `main` goes green now, decoupled from the full sync (which also carries this fix but is currently blocked by an unrelated `$lookup` regression).

## Root cause

The `numLists > data size` IVFFLAT block in `bson_aggregation_pipeline_tests` hardcoded a pgvector build-memory pre-flight estimate in its expected output:

```
ERROR:  memory required is 394 MB, maintenance_work_mem is 64 MB
```

That number is a pgvector implementation detail, not DocumentDB behavior. PGDG shipped **pgvector 0.8.5** (commit `b383e4d1`), which changed IVFFLAT sampling to reduce build memory for small tables. The estimate dropped **394 MB -> 383 MB**, so the exact-output assertion failed in the Debian packaging path. The two CI paths also pin different pgvector versions (source build 0.8.1 = 394 MB; deb/PGDG 0.8.5 = 383 MB), so no single hardcoded MB value can satisfy both. The fix must be version-independent.

## Fix

Change `numLists` **10000 -> 3** on one SQL line (`3` is the smallest value still greater than the two-row data size, preserving the block's `numLists > data size` intent). The index now builds cheaply, the volatile `memory required is N MB` assertion disappears, and both searches return real deterministic results. The expected `.out` is regenerated accordingly. `nProbes` values are intentionally unchanged.

## Validation

- Full `make check` passes on pgvector **0.8.1** and **0.8.5** (`# All 100 tests passed.`); cross-version expected output is byte-identical.
- The identical change already passes the SQL-regress and deb `make check` jobs across PG15-18 (arm64 + amd64) in the in-flight sync PR.
