### PR TITLE
documentdb-local: built-in healthcheck, Docker Compose and dev container examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### documentdb v0.117-0 (Unreleased) ###
 * Default the RUM index library (`documentdb.rum_library_load_option`) to `require_documentdb_extended_rum` on all supported PostgreSQL versions, instead of only on PG 18+. The option can still be set to `none` to opt out. *[Refactor]*
+* Ship a built-in `HEALTHCHECK` in the documentdb-local image (`documentdb_healthcheck.sh`): healthy means startup — including one-shot data initialization — completed and the gateway accepts connections on its effective port, so `depends_on: condition: service_healthy` works out of the box. Add ready-to-run Docker Compose and dev container examples under `documentdb-local/examples`. *[Feature]* (#482)
 
 ### documentdb v0.116-0 (Unreleased) ###
 * Rename the `$sample` EXPLAIN metric `Sample Heap Skips` to `Sample Heap Fetches`. *[Refactor]*

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Step 3. Setup DocumentDB using Docker
    > 
    > **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.
 
+   Prefer Docker Compose (or a dev container)? Ready-to-run examples — including
+   health-checked startup ordering for dependent services and first-boot data
+   seeding — live in
+   [`documentdb-local/examples`](documentdb-local/examples/README.md).
+
 Step 4: Initialize the pymongo client with the credentials from the previous step
 
 ```python

--- a/documentdb-local/examples/README.md
+++ b/documentdb-local/examples/README.md
@@ -67,6 +67,9 @@ per data volume — to change them later, start fresh with
 - From **another compose service**: replace `localhost` with the service
   name, e.g. `@documentdb:10260`. No `ports:` mapping is needed for
   service-to-service traffic.
+- **Nothing installed on the host?** The image ships `mongosh`; run it
+  inside the container:
+  `docker compose exec documentdb mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true"`
 
 The gateway serves TLS with a self-signed certificate by default, hence
 `tls=true&tlsAllowInvalidCertificates=true`. To bring your own certificate,

--- a/documentdb-local/examples/README.md
+++ b/documentdb-local/examples/README.md
@@ -1,0 +1,103 @@
+# DocumentDB local — Docker Compose & dev container examples
+
+Ready-to-run examples for using the
+[`documentdb-local`](https://github.com/documentdb/documentdb/pkgs/container/documentdb%2Fdocumentdb-local)
+image with Docker Compose. Each directory is self-contained: `cd` in and run
+the command from its README.
+
+| Example | What it shows |
+|---|---|
+| [`compose-quickstart`](./compose-quickstart) | The smallest useful setup: one service, persistent volume, healthcheck, host port. |
+| [`compose-app`](./compose-app) | An app container gated on `service_healthy` — ordered startup without retry loops, and the CI `--exit-code-from` pattern. |
+| [`compose-init-data`](./compose-init-data) | Seeding the database on first boot from mounted `.js` scripts. |
+| [`devcontainer`](./devcontainer) | A full containerized dev environment with DocumentDB as a sidecar — nothing installed on the host. |
+
+The concepts below are shared by all of them.
+
+## Healthcheck
+
+"The container is running" does not mean "the database is ready": on first
+boot the entrypoint initializes PostgreSQL, provisions the user, starts the
+gateway, and runs any data seeding — which can take minutes on slow Docker
+Desktop filesystems. The examples therefore probe for both of:
+
+1. the entrypoint's readiness line (`=== DocumentDB is ready ===`) in
+   `/var/log/documentdb/gateway_entrypoint.log`, which is printed only after
+   startup *including data initialization* has finished, and
+2. the gateway accepting TCP connections on its port.
+
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "grep -qF '=== DocumentDB is ready ===' /var/log/documentdb/gateway_entrypoint.log && nc -z localhost 10260"]
+  interval: 10s
+  timeout: 5s
+  retries: 3
+  start_period: 300s
+```
+
+With that in place, `docker compose up --wait` blocks until ready, and other
+services can gate on it:
+
+```yaml
+depends_on:
+  documentdb:
+    condition: service_healthy
+```
+
+Images built after issue #482 ship this logic **built in** (as
+`/home/documentdb/gateway/scripts/documentdb_healthcheck.sh`, wired up as the
+image's `HEALTHCHECK`), so on current images the explicit block is optional —
+keep it only if you pin an older image, need custom timings, or run on an
+engine where you want a shorter steady-state interval. On Docker Engine 25+
+you can add `start_interval: 2s` to make the first healthy report faster.
+
+## Credentials
+
+`USERNAME` / `PASSWORD` environment variables provision the gateway user on
+first boot. The examples use throwaway local-development credentials
+(`demo` / `DemoPass100`); change them in the compose file or override via
+environment variables where the example supports it. Credentials are fixed
+per data volume — to change them later, start fresh with
+`docker compose down -v`.
+
+## Connection strings
+
+- From the **host** (with a `ports:` mapping):
+  `mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true`
+- From **another compose service**: replace `localhost` with the service
+  name, e.g. `@documentdb:10260`. No `ports:` mapping is needed for
+  service-to-service traffic.
+
+The gateway serves TLS with a self-signed certificate by default, hence
+`tls=true&tlsAllowInvalidCertificates=true`. To bring your own certificate,
+mount it and set `CERT_PATH` / `KEY_FILE`; to reject non-TLS connections,
+set `TLS_MODE: requireTLS`.
+
+## Persistence
+
+All examples mount a named volume at `/data`. Data (and the one-shot seeding
+markers) live there:
+
+- `docker compose down` / restarts keep the data;
+- `docker compose down -v` deletes it — the next `up` re-initializes and
+  re-seeds from scratch.
+
+## Ports
+
+The gateway listens on **10260** by default (chosen to avoid colliding with
+a local MongoDB on 27017). To use a different host port, change only the
+left side of the mapping, e.g. `"27017:10260"`. Only one running example can
+map host port 10260 at a time — tear one down before starting another, or
+drop the `ports:` mapping where you don't need host access.
+
+## Troubleshooting
+
+```bash
+docker compose ps                                  # shows health status
+docker inspect --format '{{json .State.Health}}' <container> | jq  # probe log
+docker compose logs documentdb                     # full startup output
+```
+
+Common causes of an `unhealthy` service: a seed script in
+`/init_doc_db.d` failed (see the logs; fix and `down -v`), or a very slow
+first boot exceeded `start_period` (raise it).

--- a/documentdb-local/examples/compose-app/README.md
+++ b/documentdb-local/examples/compose-app/README.md
@@ -1,0 +1,44 @@
+# App + DocumentDB: ordered startup with `service_healthy`
+
+A two-service setup: DocumentDB plus a small Python app that connects,
+inserts a document, reads it back, and exits. The app container is held back
+by `depends_on: condition: service_healthy` until DocumentDB is actually
+ready — no retry loop, no sleep, no hand-rolled wait-for-it script.
+
+## Run it
+
+```bash
+docker compose up --build --exit-code-from app
+```
+
+Expected output ends with:
+
+```
+app-1  | Round-trip succeeded: 'hello from docker compose'
+app-1 exited with code 0
+```
+
+`--exit-code-from app` makes the compose invocation exit with the app's exit
+code, which is exactly what a CI job wants: green when the app's round trip
+succeeded, red otherwise.
+
+## The two things this example demonstrates
+
+1. **Startup ordering.** `depends_on` with `condition: service_healthy`
+   defers the app until DocumentDB's healthcheck passes. The healthcheck only
+   reports healthy after the entrypoint finished startup — including any
+   first-boot data initialization — so the app never observes a half-started
+   database.
+
+2. **Service-to-service networking.** The app's connection string uses the
+   *service name* as the host: `mongodb://...@documentdb:10260/...`. On the
+   Compose network, `localhost` inside the app container is the app itself —
+   a classic first-compose-file stumble. Note the documentdb service publishes
+   no ports at all; host port mapping is only needed for clients running on
+   the host.
+
+## Tear down
+
+```bash
+docker compose down -v
+```

--- a/documentdb-local/examples/compose-app/app/Dockerfile
+++ b/documentdb-local/examples/compose-app/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+RUN pip install --no-cache-dir "pymongo>=4.6"
+COPY app.py .
+
+CMD ["python", "app.py"]

--- a/documentdb-local/examples/compose-app/app/app.py
+++ b/documentdb-local/examples/compose-app/app/app.py
@@ -1,0 +1,32 @@
+"""Minimal DocumentDB client app for the compose-app example.
+
+Inserts a document and reads it back, then exits 0. Because the compose file
+gates this container on DocumentDB's healthcheck, no connection-retry loop is
+needed: by the time this runs, the database is accepting connections and any
+first-boot initialization has finished.
+"""
+
+import os
+import sys
+
+import pymongo
+
+
+def main() -> int:
+    uri = os.environ["DOCUMENTDB_URI"]
+    client = pymongo.MongoClient(uri, serverSelectionTimeoutMS=20000)
+
+    collection = client.compose_example.greetings
+    inserted = collection.insert_one({"message": "hello from docker compose"})
+    document = collection.find_one({"_id": inserted.inserted_id})
+    if document is None:
+        print("ERROR: could not read back the inserted document", file=sys.stderr)
+        return 1
+
+    print(f"Round-trip succeeded: {document['message']!r}")
+    client.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/documentdb-local/examples/compose-app/compose.yaml
+++ b/documentdb-local/examples/compose-app/compose.yaml
@@ -1,0 +1,45 @@
+# An application container talking to DocumentDB, started in the right order.
+#
+#   Run once and exit:   docker compose up --build --exit-code-from app
+#   Tear down:           docker compose down -v
+#
+# `depends_on: condition: service_healthy` holds the app back until
+# DocumentDB's healthcheck passes, so the app needs no retry loop for the
+# initial connection. This is also the shape to use in CI: the compose exit
+# code is the app's exit code (--exit-code-from).
+#
+# Note there is no `ports:` mapping on the documentdb service. The app
+# reaches it through the Compose network by service name
+# (mongodb://...@documentdb:10260), so nothing needs to be published to the
+# host. Add a mapping only if you also want to poke at the database from the
+# host while it runs.
+
+services:
+  documentdb:
+    image: ghcr.io/documentdb/documentdb/documentdb-local:latest
+    environment:
+      USERNAME: demo
+      PASSWORD: DemoPass100
+    volumes:
+      - documentdb-data:/data
+    healthcheck:
+      # See ../README.md#healthcheck for what this probes and why. Newer
+      # images ship it built in, making this block optional.
+      test: ["CMD-SHELL", "grep -qF '=== DocumentDB is ready ===' /var/log/documentdb/gateway_entrypoint.log && nc -z localhost 10260"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 300s
+
+  app:
+    build: ./app
+    depends_on:
+      documentdb:
+        condition: service_healthy
+    environment:
+      # `documentdb` (the service name) resolves on the Compose network;
+      # inside a sibling container, `localhost` would be the app itself.
+      DOCUMENTDB_URI: mongodb://demo:DemoPass100@documentdb:10260/?tls=true&tlsAllowInvalidCertificates=true
+
+volumes:
+  documentdb-data:

--- a/documentdb-local/examples/compose-init-data/README.md
+++ b/documentdb-local/examples/compose-init-data/README.md
@@ -1,0 +1,46 @@
+# Seeding DocumentDB on first boot
+
+Mounts a directory of mongosh `.js` scripts into the container's
+`/init_doc_db.d`; the entrypoint executes them in alphabetical order the
+first time the data volume is used. This example seeds a `library` database
+with a `books` collection and two indexes.
+
+## Run it
+
+```bash
+docker compose up --wait
+```
+
+Verify the seed landed:
+
+```bash
+mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true" \
+    --eval "db.getSiblingDB('library').books.countDocuments()"
+# 3
+```
+
+## Semantics worth knowing
+
+- **Once per fresh data volume.** Scripts run only when the data volume has
+  not been initialized before. Restarts and `docker compose down && up`
+  against the same volume skip them. To re-seed from scratch:
+  `docker compose down -v && docker compose up --wait`.
+- **A failed seed stops the container** and is *not* retried on the next
+  boot against the same volume (re-running a partially applied,
+  non-idempotent script could corrupt data). Fix the script, then start
+  with a fresh volume.
+- **Ordering is alphabetical.** Number the files (`01-...`, `02-...`) to make
+  it explicit. Write scripts in mongosh syntax; `use('dbname')` switches
+  databases.
+- **`service_healthy` waits for the seed.** The healthcheck passes only after
+  initialization completes, so `docker compose up --wait` (and any dependent
+  service) never observes the database pre-seed.
+- **Built-in sample data** is separate and opt-in: set `INIT_DATA: "true"`
+  on the service to also load the image's bundled `sampledb` dataset
+  ([`documentdb-local/sample-data`](../../sample-data)).
+
+## Tear down
+
+```bash
+docker compose down -v
+```

--- a/documentdb-local/examples/compose-init-data/README.md
+++ b/documentdb-local/examples/compose-init-data/README.md
@@ -25,6 +25,11 @@ mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCer
   not been initialized before. Restarts and `docker compose down && up`
   against the same volume skip them. To re-seed from scratch:
   `docker compose down -v && docker compose up --wait`.
+- **Write idempotent scripts anyway** (guard inserts with an existence
+  check, as `init-scripts/01-books.js` does). Images published before the
+  one-shot markers existed re-run the scripts on *every* boot, so a
+  non-idempotent seed (e.g. a bare `insertMany` with fixed `_id`s) crashes
+  such a container on restart with duplicate-key errors.
 - **A failed seed stops the container** and is *not* retried on the next
   boot against the same volume (re-running a partially applied,
   non-idempotent script could corrupt data). Fix the script, then start

--- a/documentdb-local/examples/compose-init-data/compose.yaml
+++ b/documentdb-local/examples/compose-init-data/compose.yaml
@@ -1,0 +1,42 @@
+# Seeding DocumentDB on first boot with your own data.
+#
+#   Start:      docker compose up --wait
+#   Verify:     mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true" \
+#                   --eval "db.getSiblingDB('library').books.countDocuments()"
+#   Re-seed:    docker compose down -v && docker compose up --wait
+#
+# Any *.js files mounted into /init_doc_db.d are executed with mongosh in
+# alphabetical order, once per fresh data volume. A restart against an
+# already-seeded volume skips them (so scripts are not re-run against data
+# they already created), which is why re-seeding requires `down -v`.
+#
+# Because the healthcheck only passes after initialization completes, anything
+# gated on `service_healthy` -- including `docker compose up --wait` itself --
+# is guaranteed to see the seeded data.
+
+services:
+  documentdb:
+    image: ghcr.io/documentdb/documentdb/documentdb-local:latest
+    ports:
+      - "10260:10260"
+    environment:
+      USERNAME: demo
+      PASSWORD: DemoPass100
+      # Optionally also load the image's built-in sample dataset (sampledb):
+      # INIT_DATA: "true"
+    volumes:
+      - documentdb-data:/data
+      # Seed scripts, read-only. Executed in alphabetical order; number the
+      # files (01-..., 02-...) to make the order explicit.
+      - ./init-scripts:/init_doc_db.d:ro
+    healthcheck:
+      # See ../README.md#healthcheck for what this probes and why. Newer
+      # images ship it built in, making this block optional.
+      test: ["CMD-SHELL", "grep -qF '=== DocumentDB is ready ===' /var/log/documentdb/gateway_entrypoint.log && nc -z localhost 10260"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 300s
+
+volumes:
+  documentdb-data:

--- a/documentdb-local/examples/compose-init-data/init-scripts/01-books.js
+++ b/documentdb-local/examples/compose-init-data/init-scripts/01-books.js
@@ -1,0 +1,37 @@
+// Seed the `library` database with a small books collection.
+//
+// Runs once per fresh data volume (see compose.yaml). Keep seed scripts
+// idempotent anyway -- they are the kind of file that gets copied into other
+// projects and re-run in unexpected ways.
+print("Seeding library.books...");
+
+use('library');
+
+db.books.insertMany([
+    {
+        _id: "book1",
+        title: "The Left Hand of Darkness",
+        author: "Ursula K. Le Guin",
+        year: 1969,
+        genres: ["science fiction"],
+        available: true
+    },
+    {
+        _id: "book2",
+        title: "Invisible Cities",
+        author: "Italo Calvino",
+        year: 1972,
+        genres: ["fiction", "fantasy"],
+        available: true
+    },
+    {
+        _id: "book3",
+        title: "The Dispossessed",
+        author: "Ursula K. Le Guin",
+        year: 1974,
+        genres: ["science fiction"],
+        available: false
+    }
+]);
+
+print("Seeded " + db.books.countDocuments() + " books.");

--- a/documentdb-local/examples/compose-init-data/init-scripts/01-books.js
+++ b/documentdb-local/examples/compose-init-data/init-scripts/01-books.js
@@ -1,13 +1,16 @@
 // Seed the `library` database with a small books collection.
 //
-// Runs once per fresh data volume (see compose.yaml). Keep seed scripts
-// idempotent anyway -- they are the kind of file that gets copied into other
-// projects and re-run in unexpected ways.
+// Written to be idempotent (each insert is guarded by an existence check):
+// current images run seed scripts once per fresh data volume, but images
+// published before the one-shot markers existed (#612) re-ran them on every
+// boot -- a plain insertMany with fixed _ids would crash such a container on
+// restart with duplicate-key errors. Idempotent seeds work everywhere, and
+// survive being copied into other projects and re-run in unexpected ways.
 print("Seeding library.books...");
 
 use('library');
 
-db.books.insertMany([
+const books = [
     {
         _id: "book1",
         title: "The Left Hand of Darkness",
@@ -32,6 +35,12 @@ db.books.insertMany([
         genres: ["science fiction"],
         available: false
     }
-]);
+];
+
+books.forEach(function (doc) {
+    if (db.books.countDocuments({ _id: doc._id }) === 0) {
+        db.books.insertOne(doc);
+    }
+});
 
 print("Seeded " + db.books.countDocuments() + " books.");

--- a/documentdb-local/examples/compose-init-data/init-scripts/02-indexes.js
+++ b/documentdb-local/examples/compose-init-data/init-scripts/02-indexes.js
@@ -1,0 +1,10 @@
+// Create indexes for the seeded data. Runs after 01-books.js (alphabetical
+// order).
+print("Creating indexes on library.books...");
+
+use('library');
+
+db.books.createIndex({ author: 1 });
+db.books.createIndex({ year: -1 });
+
+print("Indexes created.");

--- a/documentdb-local/examples/compose-quickstart/README.md
+++ b/documentdb-local/examples/compose-quickstart/README.md
@@ -1,0 +1,52 @@
+# Quickstart: DocumentDB with Docker Compose
+
+The smallest useful Compose setup: one DocumentDB service with persistent
+storage, a health check, and the port published to the host.
+
+## Run it
+
+```bash
+docker compose up --wait
+```
+
+`--wait` blocks until the container reports **healthy**, so when the command
+returns you can connect immediately:
+
+```bash
+mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true"
+```
+
+Or from Python:
+
+```python
+import pymongo
+client = pymongo.MongoClient(
+    "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true"
+)
+client.quickstart.greetings.insert_one({"message": "hello documentdb"})
+```
+
+## Change the credentials
+
+Either edit `compose.yaml`, or override per invocation without editing:
+
+```bash
+DOCUMENTDB_USERNAME=myuser DOCUMENTDB_PASSWORD='my-secret' docker compose up --wait
+```
+
+The credentials are fixed on first boot (they provision the gateway user), so
+changing them later requires a fresh data volume (`docker compose down -v`).
+
+## Tear down
+
+```bash
+docker compose down        # keeps the data volume
+docker compose down -v     # deletes the data volume too
+```
+
+## Where this example goes next
+
+- An application container that waits for DocumentDB: [`../compose-app`](../compose-app)
+- Seeding the database on first boot: [`../compose-init-data`](../compose-init-data)
+- Running your dev environment itself in a container: [`../devcontainer`](../devcontainer)
+- Shared concepts (healthcheck, TLS, ports, persistence): [`../README.md`](../README.md)

--- a/documentdb-local/examples/compose-quickstart/README.md
+++ b/documentdb-local/examples/compose-quickstart/README.md
@@ -16,6 +16,13 @@ returns you can connect immediately:
 mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true"
 ```
 
+No `mongosh` on your machine? The image ships one — run it inside the
+container instead:
+
+```bash
+docker compose exec documentdb mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true"
+```
+
 Or from Python:
 
 ```python

--- a/documentdb-local/examples/compose-quickstart/compose.yaml
+++ b/documentdb-local/examples/compose-quickstart/compose.yaml
@@ -1,0 +1,41 @@
+# Minimal Docker Compose setup for DocumentDB local development.
+#
+#   Start:      docker compose up --wait        (returns once healthy)
+#   Connect:    mongosh "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true"
+#   Tear down:  docker compose down             (add -v to also delete the data)
+#
+# See ../README.md for the concepts shared by every example (healthcheck,
+# credentials, TLS, persistence).
+
+services:
+  documentdb:
+    image: ghcr.io/documentdb/documentdb/documentdb-local:latest
+    ports:
+      - "10260:10260"
+    environment:
+      # Local-development credentials. Change them here, or override without
+      # editing this file:  DOCUMENTDB_PASSWORD=... docker compose up --wait
+      USERNAME: ${DOCUMENTDB_USERNAME:-demo}
+      PASSWORD: ${DOCUMENTDB_PASSWORD:-DemoPass100}
+    volumes:
+      # Named volume so data survives `docker compose down` and container
+      # recreation. `docker compose down -v` deletes it for a fresh start.
+      - documentdb-data:/data
+    healthcheck:
+      # Healthy = the entrypoint finished startup (it prints the marker line
+      # below only after one-shot data initialization completes) AND the
+      # gateway accepts TCP connections. Newer images ship this logic as a
+      # built-in HEALTHCHECK (documentdb_healthcheck.sh), which makes this
+      # block optional; it is spelled out so the example also works with
+      # images published before the built-in healthcheck existed.
+      test: ["CMD-SHELL", "grep -qF '=== DocumentDB is ready ===' /var/log/documentdb/gateway_entrypoint.log && nc -z localhost 10260"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      # First boot runs initdb + CREATE EXTENSION, which can take minutes on
+      # slow Docker Desktop filesystems; probe failures within the start
+      # period do not count against `retries`.
+      start_period: 300s
+
+volumes:
+  documentdb-data:

--- a/documentdb-local/examples/devcontainer/.devcontainer/compose.yaml
+++ b/documentdb-local/examples/devcontainer/.devcontainer/compose.yaml
@@ -1,0 +1,40 @@
+# Compose file backing the dev container: your development environment (dev)
+# plus DocumentDB as a sidecar. VS Code / GitHub Codespaces attaches to the
+# `dev` service; DocumentDB is reachable from it at documentdb:10260.
+
+services:
+  dev:
+    image: mcr.microsoft.com/devcontainers/python:3.13
+    volumes:
+      # Mount the example folder (the devcontainer workspace) into the
+      # container. ".." is relative to this .devcontainer directory.
+      - ..:/workspaces/app:cached
+    # Keep the container alive for the editor to attach to; a dev container
+    # has no long-running app process of its own.
+    command: sleep infinity
+    environment:
+      # The service name resolves on the Compose network; from inside the
+      # dev container, DocumentDB is NOT on localhost.
+      DOCUMENTDB_URI: mongodb://demo:DemoPass100@documentdb:10260/?tls=true&tlsAllowInvalidCertificates=true
+    depends_on:
+      documentdb:
+        condition: service_healthy
+
+  documentdb:
+    image: ghcr.io/documentdb/documentdb/documentdb-local:latest
+    environment:
+      USERNAME: demo
+      PASSWORD: DemoPass100
+    volumes:
+      - documentdb-data:/data
+    healthcheck:
+      # See ../../README.md#healthcheck for what this probes and why. Newer
+      # images ship it built in, making this block optional.
+      test: ["CMD-SHELL", "grep -qF '=== DocumentDB is ready ===' /var/log/documentdb/gateway_entrypoint.log && nc -z localhost 10260"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 300s
+
+volumes:
+  documentdb-data:

--- a/documentdb-local/examples/devcontainer/.devcontainer/devcontainer.json
+++ b/documentdb-local/examples/devcontainer/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "Python app + DocumentDB",
+    "dockerComposeFile": "compose.yaml",
+    "service": "dev",
+    "workspaceFolder": "/workspaces/app",
+    // Make DocumentDB reachable from the HOST too (e.g. a GUI client or
+    // mongosh on your machine) while developing inside the container.
+    "forwardPorts": [
+        "documentdb:10260"
+    ],
+    "postCreateCommand": "pip install --user -r requirements-dev.txt",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ]
+        }
+    }
+}

--- a/documentdb-local/examples/devcontainer/README.md
+++ b/documentdb-local/examples/devcontainer/README.md
@@ -1,0 +1,56 @@
+# Dev container + DocumentDB sidecar
+
+Develop and test against DocumentDB **without installing anything on your
+machine** — no Python, no mongosh, no database. The dev environment itself is
+a container ([Dev Containers](https://containers.dev/)), and DocumentDB runs
+next to it as a Compose sidecar.
+
+```
+.devcontainer/
+  devcontainer.json   <- tells VS Code / Codespaces how to attach
+  compose.yaml        <- dev environment + documentdb services
+tests/
+  test_documentdb.py  <- example tests that talk to the sidecar
+requirements-dev.txt
+```
+
+## Use it
+
+Open this folder in VS Code and run **Dev Containers: Reopen in Container**
+(or create a GitHub Codespace on it). VS Code brings up both services, waits
+for DocumentDB to be healthy, attaches to the `dev` service, and installs the
+Python dependencies. Then, in the integrated terminal:
+
+```bash
+pytest
+```
+
+The tests read `DOCUMENTDB_URI` from the environment (set in
+`compose.yaml`) and talk to the sidecar over the Compose network.
+
+You can also drive it without an editor, using the
+[devcontainer CLI](https://github.com/devcontainers/cli):
+
+```bash
+devcontainer up --workspace-folder .
+devcontainer exec --workspace-folder . pytest
+```
+
+## How the pieces fit
+
+- `devcontainer.json` points at the compose file (`dockerComposeFile`), names
+  the service to attach to (`service: dev`), and forwards the sidecar's port
+  to the host (`"documentdb:10260"`) so host-side tools can connect too.
+- The `dev` service runs `sleep infinity` — a dev container has no app
+  process; the editor attaches to it and your shell/tests run inside.
+- `depends_on: condition: service_healthy` means the sidecar is ready before
+  the dev container starts: tests never need connection-retry loops.
+- Inside the dev container, DocumentDB is at `documentdb:10260` (the service
+  name), **not** `localhost`.
+
+## Adapting it to your project
+
+Copy the `.devcontainer/` directory into your repository root and adjust:
+the `dev` service image (any language stack works), the workspace mount, and
+`postCreateCommand`. Everything DocumentDB-specific — image, credentials,
+healthcheck, volume — stays as-is.

--- a/documentdb-local/examples/devcontainer/tests/test_documentdb.py
+++ b/documentdb-local/examples/devcontainer/tests/test_documentdb.py
@@ -1,0 +1,35 @@
+"""Smoke tests that run inside the dev container against the DocumentDB
+sidecar. `pytest` from the integrated terminal is all it takes -- the
+DOCUMENTDB_URI environment variable is provided by the compose file, and the
+sidecar is already healthy by the time the dev container starts."""
+
+import os
+
+import pymongo
+import pytest
+
+
+@pytest.fixture(scope="module")
+def client():
+    uri = os.environ.get(
+        "DOCUMENTDB_URI",
+        # Fallback for running the same tests on the host against
+        # ../compose-quickstart (where the port is published to localhost).
+        "mongodb://demo:DemoPass100@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true",
+    )
+    client = pymongo.MongoClient(uri, serverSelectionTimeoutMS=20000)
+    yield client
+    client.close()
+
+
+def test_ping(client):
+    assert client.admin.command("ping")["ok"] == 1
+
+
+def test_crud_roundtrip(client):
+    collection = client.devcontainer_example.smoke
+    collection.delete_many({})
+    collection.insert_many([{"n": i} for i in range(5)])
+    assert collection.count_documents({}) == 5
+    assert collection.count_documents({"n": {"$gte": 3}}) == 2
+    collection.delete_many({})

--- a/documentdb-local/scripts/documentdb_healthcheck.sh
+++ b/documentdb-local/scripts/documentdb_healthcheck.sh
@@ -8,39 +8,65 @@
 # stable path so compose files that target engines without --start-interval
 # support can point an explicit `healthcheck:` block at it.
 #
-# Healthy means BOTH of:
+# Healthy means ALL of:
 #   1. the entrypoint finished startup: the readiness marker exists. The
 #      marker is written after one-shot data initialization completes, so
 #      dependents gated on `condition: service_healthy` observe seeded data
 #      instead of racing the seed scripts (the gateway accepts connections
-#      before initialization runs), and
-#   2. the gateway currently accepts TCP connections on its effective listen
-#      port (the marker alone would go stale if the gateway later died).
+#      before initialization runs),
+#   2. the backgrounded gateway job recorded in the marker is still alive
+#      (the marker alone would go stale if the gateway later died), and
+#   3. something still listens on the gateway's effective port.
 #
-# The port is read from the runtime-generated gateway configuration because a
-# `--documentdb-port` entrypoint flag changes the effective port without
-# changing this probe's environment (Docker spawns healthcheck processes with
-# the container's static environment, not the entrypoint's exports); the
-# DOCUMENTDB_PORT environment variable is only the fallback before that file
-# exists.
+# The marker carries its own inputs -- line 1 the effective gateway port,
+# line 2 the gateway job's PID -- because Docker spawns healthcheck processes
+# with the container's static environment, not the entrypoint's exports, so a
+# `--documentdb-port` flag would otherwise be invisible here. DOCUMENTDB_PORT
+# is only a fallback for a marker written by an older entrypoint. The
+# entrypoint's cleanup removes the marker on shutdown.
 #
-# Deliberately a plain TCP probe rather than a mongosh ping: mongosh is a
-# Node.js client that burns ~2s of CPU per invocation for no additional
-# signal here -- the entrypoint verifies end-to-end readiness (including
-# authentication) before writing the marker.
+# Deliberately NO TCP connection is opened. The gateway logs an ERROR for
+# every accepted-then-immediately-closed connection, which is exactly what a
+# `nc -z` style probe does, so connecting here would pollute `docker logs`
+# once per interval for the life of the container. Reading /proc/net/tcp{,6}
+# (state 0A = LISTEN) gets the same signal passively. A mongosh ping is also
+# out: ~2s of Node.js startup per probe for no extra signal, and it cannot
+# authenticate when the operator passed `--create-user false`.
 
 READY_MARKER_FILE=${READY_MARKER_FILE:-/tmp/documentdb-local.ready}
-GATEWAY_HOME=${GATEWAY_HOME:-/home/documentdb/gateway}
 
 [ -f "$READY_MARKER_FILE" ] || exit 1
 
-port=""
-runtimeConfig="$GATEWAY_HOME/pg_documentdb_gw/target/SetupConfiguration_temp.json"
-if [ -f "$runtimeConfig" ]; then
-    port=$(jq -r '.GatewayListenPort // empty' "$runtimeConfig" 2>/dev/null)
-fi
+port=$(sed -n '1p' "$READY_MARKER_FILE" 2>/dev/null | tr -d '[:space:]')
+pid=$(sed -n '2p' "$READY_MARKER_FILE" 2>/dev/null | tr -d '[:space:]')
+
+# The recorded PID is the tail of the backgrounded `gateway | tee` pipeline,
+# which the entrypoint also `wait`s on: it exits as soon as the gateway closes
+# the pipe, so its liveness tracks the gateway's.
+case "$pid" in
+    ''|*[!0-9]*) exit 1 ;;
+esac
+[ -d "/proc/$pid" ] || exit 1
+
 case "$port" in
     ''|*[!0-9]*) port="${DOCUMENTDB_PORT:-10260}" ;;
 esac
+# Port still unknowable: report healthy on the marker and liveness checks
+# alone rather than wedging the container in `unhealthy` over a probe input.
+case "$port" in
+    ''|*[!0-9]*) exit 0 ;;
+esac
 
-exec nc -z localhost "$port"
+# LISTEN check. /proc/net/tcp rows look like
+#   sl  local_address rem_address   st ...
+#    0: 00000000:2814 00000000:0000 0A ...
+# where 2814 is the local port in uppercase hex and st 0A means LISTEN.
+# Absence of both files (unusual kernel config) degrades to the checks above.
+if [ ! -r /proc/net/tcp ] && [ ! -r /proc/net/tcp6 ]; then
+    exit 0
+fi
+# 10# forces base 10: printf would read a zero-padded port as octal.
+port_hex=$(printf '%04X' "$((10#$port))")
+grep -qsE ":${port_hex} [0-9A-F]+:[0-9A-F]+ 0A " /proc/net/tcp /proc/net/tcp6 || exit 1
+
+exit 0

--- a/documentdb-local/scripts/documentdb_healthcheck.sh
+++ b/documentdb-local/scripts/documentdb_healthcheck.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# documentdb_healthcheck.sh
+#
+# Container health probe for documentdb-local (issue #482). Wired up as the
+# image's HEALTHCHECK so `docker compose` dependents can gate on
+# `condition: service_healthy` without hand-rolling a probe, and kept at a
+# stable path so compose files that target engines without --start-interval
+# support can point an explicit `healthcheck:` block at it.
+#
+# Healthy means BOTH of:
+#   1. the entrypoint finished startup: the readiness marker exists. The
+#      marker is written after one-shot data initialization completes, so
+#      dependents gated on `condition: service_healthy` observe seeded data
+#      instead of racing the seed scripts (the gateway accepts connections
+#      before initialization runs), and
+#   2. the gateway currently accepts TCP connections on its effective listen
+#      port (the marker alone would go stale if the gateway later died).
+#
+# The port is read from the runtime-generated gateway configuration because a
+# `--documentdb-port` entrypoint flag changes the effective port without
+# changing this probe's environment (Docker spawns healthcheck processes with
+# the container's static environment, not the entrypoint's exports); the
+# DOCUMENTDB_PORT environment variable is only the fallback before that file
+# exists.
+#
+# Deliberately a plain TCP probe rather than a mongosh ping: mongosh is a
+# Node.js client that burns ~2s of CPU per invocation for no additional
+# signal here -- the entrypoint verifies end-to-end readiness (including
+# authentication) before writing the marker.
+
+READY_MARKER_FILE=${READY_MARKER_FILE:-/tmp/documentdb-local.ready}
+GATEWAY_HOME=${GATEWAY_HOME:-/home/documentdb/gateway}
+
+[ -f "$READY_MARKER_FILE" ] || exit 1
+
+port=""
+runtimeConfig="$GATEWAY_HOME/pg_documentdb_gw/target/SetupConfiguration_temp.json"
+if [ -f "$runtimeConfig" ]; then
+    port=$(jq -r '.GatewayListenPort // empty' "$runtimeConfig" 2>/dev/null)
+fi
+case "$port" in
+    ''|*[!0-9]*) port="${DOCUMENTDB_PORT:-10260}" ;;
+esac
+
+exec nc -z localhost "$port"

--- a/documentdb-local/scripts/documentdb_local_tests/test_documentdb_healthcheck.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_documentdb_healthcheck.py
@@ -1,23 +1,29 @@
 """Unit tests for documentdb_healthcheck.sh (issue #482).
 
-The script is exercised directly with bash in a sandbox: the readiness
-marker, the runtime-generated gateway configuration, and the `nc` probe are
-all faked through environment variables, temp files, and a stub `nc` on
-PATH that records how it was invoked. `jq` is the real one (it is a runtime
-dependency of the image and of the script's port lookup).
+The script is exercised directly with bash in a sandbox. Its only inputs are
+the readiness marker (pointed at a temp file via READY_MARKER_FILE) and the
+kernel's own view of the machine, so the tests use real processes and real
+listening sockets rather than stubs: a live PID is this test process, a dead
+PID comes from a reaped subprocess, and a listening port is a socket this
+test binds.
 
-Contract under test -- healthy (exit 0) if and only if:
-  1. the readiness marker file exists (written by emulator_entrypoint.sh
-     after startup, including one-shot data initialization, completes), AND
-  2. a TCP connection to the gateway's effective listen port succeeds,
-     where the effective port comes from the runtime-generated
-     SetupConfiguration_temp.json when present (a `--documentdb-port` flag
-     is invisible to the healthcheck's environment), falling back to
-     DOCUMENTDB_PORT, then 10260.
+Contract under test -- healthy (exit 0) if and only if ALL of:
+  1. the readiness marker exists (emulator_entrypoint.sh writes it after
+     startup, including one-shot data initialization, completes),
+  2. the PID on line 2 of the marker is still alive, and
+  3. something is listening on the port from line 1 of the marker, which is
+     how `--documentdb-port` reaches a probe that Docker runs with the
+     container's static environment.
+
+The marker must carry both lines: a bare `touch`ed marker is not a valid
+readiness signal and must read as unhealthy.
+
+/proc/net/tcp is Linux-only, so the whole module skips elsewhere.
 """
 
 import os
 import shutil
+import socket
 import subprocess
 import tempfile
 import unittest
@@ -28,50 +34,48 @@ HEALTHCHECK = (
     REPO_ROOT / "documentdb-local" / "scripts" / "documentdb_healthcheck.sh"
 )
 
-_TOOLS = ("bash", "jq")
-_SKIP_UNLESS_TOOLS = unittest.skipUnless(
-    all(shutil.which(t) for t in _TOOLS),
-    f"requires {', '.join(_TOOLS)} on PATH",
+_TOOLS = ("bash", "sed", "grep")
+_SKIP_UNLESS_SUPPORTED = unittest.skipUnless(
+    all(shutil.which(t) for t in _TOOLS) and Path("/proc/net/tcp").exists(),
+    f"requires Linux /proc/net/tcp and {', '.join(_TOOLS)} on PATH",
 )
 
 
-@_SKIP_UNLESS_TOOLS
+@_SKIP_UNLESS_SUPPORTED
 class DocumentdbHealthcheckTests(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)
         self.root = Path(self.temp_dir.name)
-
-        self.gateway_home = self.root / "gateway"
-        self.target_dir = self.gateway_home / "pg_documentdb_gw" / "target"
-        self.target_dir.mkdir(parents=True)
-        self.runtime_config = self.target_dir / "SetupConfiguration_temp.json"
-
         self.marker = self.root / "documentdb-local.ready"
 
-        # Stub `nc` that records its argv and exits per NC_STUB_EXIT.
-        self.bin_dir = self.root / "bin"
-        self.bin_dir.mkdir()
-        self.nc_calls = self.root / "nc_calls.txt"
-        nc_stub = self.bin_dir / "nc"
-        nc_stub.write_text(
-            '#!/bin/sh\n'
-            'printf \'%s\\n\' "$*" >> "$NC_CALLS_FILE"\n'
-            'exit "${NC_STUB_EXIT:-0}"\n',
-            encoding="utf-8",
-        )
-        nc_stub.chmod(0o755)
+    # -- helpers ----------------------------------------------------------
 
-    def _run(self, *, env_overrides=None, nc_exit=0):
-        env = {
-            # Minimal, deterministic environment. PATH puts the stub `nc`
-            # first but keeps the system dirs so bash finds jq.
-            "PATH": f"{self.bin_dir}{os.pathsep}{os.environ['PATH']}",
-            "READY_MARKER_FILE": str(self.marker),
-            "GATEWAY_HOME": str(self.gateway_home),
-            "NC_CALLS_FILE": str(self.nc_calls),
-            "NC_STUB_EXIT": str(nc_exit),
-        }
+    def _listening_socket(self):
+        """Bind and listen on an ephemeral port; return (socket, port)."""
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.addCleanup(srv.close)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(8)
+        return srv, srv.getsockname()[1]
+
+    def _free_port(self):
+        """Return a port number nothing is listening on."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            return probe.getsockname()[1]
+
+    def _reaped_pid(self):
+        """Return the PID of an exited, reaped process."""
+        proc = subprocess.Popen(["/bin/true"])
+        proc.wait()
+        return proc.pid
+
+    def _write_marker(self, content):
+        self.marker.write_text(content, encoding="utf-8")
+
+    def _run(self, env_overrides=None):
+        env = {"PATH": os.environ["PATH"], "READY_MARKER_FILE": str(self.marker)}
         if env_overrides:
             env.update(env_overrides)
         return subprocess.run(
@@ -82,78 +86,106 @@ class DocumentdbHealthcheckTests(unittest.TestCase):
             timeout=30,
         )
 
-    def _nc_invocations(self):
-        if not self.nc_calls.exists():
-            return []
-        return self.nc_calls.read_text(encoding="utf-8").splitlines()
+    # -- marker gating ----------------------------------------------------
 
-    def test_unhealthy_before_marker_exists_and_no_probe_is_attempted(self):
+    def test_unhealthy_before_marker_exists(self):
+        # During startup the gateway port can already be accepting
+        # connections while data initialization is still running, so the
+        # marker -- not the port -- is what gates `healthy`.
+        _srv, _port = self._listening_socket()
+        self.assertNotEqual(self._run().returncode, 0)
+
+    def test_unhealthy_for_a_bare_touched_marker(self):
+        # An empty marker carries no port and no PID; it is not a readiness
+        # signal this probe can act on.
+        self._write_marker("")
+        self.assertNotEqual(self._run().returncode, 0)
+
+    # -- healthy path -----------------------------------------------------
+
+    def test_healthy_with_live_pid_and_listening_port(self):
+        _srv, port = self._listening_socket()
+        self._write_marker(f"{port}\n{os.getpid()}\n")
         result = self._run()
-        self.assertNotEqual(result.returncode, 0)
-        # No TCP probe before the marker: during startup the gateway port
-        # accepting connections must NOT make the container healthy (data
-        # initialization may still be running).
-        self.assertEqual(self._nc_invocations(), [])
-
-    def test_healthy_with_marker_and_accepting_gateway(self):
-        self.marker.touch()
-        result = self._run(nc_exit=0)
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_unhealthy_with_marker_but_refusing_gateway(self):
-        self.marker.touch()
-        result = self._run(nc_exit=1)
-        self.assertNotEqual(result.returncode, 0)
+    def test_healthy_with_a_zero_padded_port(self):
+        # printf reads a leading zero as octal unless the script forces base
+        # 10, which would probe a different port entirely.
+        _srv, port = self._listening_socket()
+        self._write_marker(f"{port:06d}\n{os.getpid()}\n")
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_port_comes_from_runtime_config(self):
-        # A --documentdb-port flag only surfaces in the runtime-generated
-        # config; the probe must use it over the environment fallback.
-        self.marker.touch()
-        self.runtime_config.write_text(
-            '{"GatewayListenPort": 23456, "PostgresPort": 9712}',
-            encoding="utf-8",
+    def test_healthy_with_trailing_whitespace_in_the_marker(self):
+        _srv, port = self._listening_socket()
+        self._write_marker(f"  {port}  \n  {os.getpid()}  \n")
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    # -- liveness ---------------------------------------------------------
+
+    def test_unhealthy_when_the_recorded_pid_is_dead(self):
+        # The gateway going away must flip the container out of `healthy`
+        # even though the marker is still on disk.
+        _srv, port = self._listening_socket()
+        self._write_marker(f"{port}\n{self._reaped_pid()}\n")
+        self.assertNotEqual(self._run().returncode, 0)
+
+    def test_unhealthy_when_the_pid_line_is_missing(self):
+        _srv, port = self._listening_socket()
+        self._write_marker(f"{port}\n")
+        self.assertNotEqual(self._run().returncode, 0)
+
+    def test_unhealthy_when_the_pid_line_is_not_numeric(self):
+        _srv, port = self._listening_socket()
+        self._write_marker(f"{port}\nnot-a-pid\n")
+        self.assertNotEqual(self._run().returncode, 0)
+
+    # -- listener ---------------------------------------------------------
+
+    def test_unhealthy_when_nothing_listens_on_the_recorded_port(self):
+        self._write_marker(f"{self._free_port()}\n{os.getpid()}\n")
+        self.assertNotEqual(self._run().returncode, 0)
+
+    def test_port_comes_from_the_marker_not_the_environment(self):
+        # `--documentdb-port` never reaches this probe's environment, so a
+        # probe that trusted DOCUMENTDB_PORT could never turn healthy.
+        _srv, port = self._listening_socket()
+        self._write_marker(f"{port}\n{os.getpid()}\n")
+        result = self._run(
+            {"DOCUMENTDB_PORT": str(self._free_port())}
         )
-        result = self._run(env_overrides={"DOCUMENTDB_PORT": "11111"})
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self._nc_invocations(), ["-z localhost 23456"])
 
-    def test_port_falls_back_to_env_without_runtime_config(self):
-        self.marker.touch()
-        result = self._run(env_overrides={"DOCUMENTDB_PORT": "11111"})
+    def test_environment_port_is_only_a_fallback_for_a_portless_marker(self):
+        _srv, port = self._listening_socket()
+        self._write_marker(f"not-a-port\n{os.getpid()}\n")
+        result = self._run({"DOCUMENTDB_PORT": str(port)})
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self._nc_invocations(), ["-z localhost 11111"])
 
-    def test_port_falls_back_to_default_without_config_or_env(self):
-        self.marker.touch()
+    def test_healthy_when_the_port_is_unknowable_entirely(self):
+        # Marker plus liveness already hold; refusing to report healthy over
+        # an unparseable port would wedge the container in `unhealthy`.
+        self._write_marker(f"not-a-port\n{os.getpid()}\n")
+        result = self._run({"DOCUMENTDB_PORT": "also-not-a-port"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    # -- the reason this probe is passive ---------------------------------
+
+    def test_probe_never_connects_to_the_gateway_port(self):
+        # The gateway logs an ERROR for every accepted-then-closed
+        # connection, so a `nc -z` style probe would add a log line once per
+        # healthcheck interval for the life of the container. Assert the
+        # listening socket saw no connection attempt at all.
+        srv, port = self._listening_socket()
+        self._write_marker(f"{port}\n{os.getpid()}\n")
         result = self._run()
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self._nc_invocations(), ["-z localhost 10260"])
 
-    def test_port_falls_back_when_runtime_config_lacks_port(self):
-        self.marker.touch()
-        self.runtime_config.write_text(
-            '{"PostgresPort": 9712}', encoding="utf-8"
-        )
-        result = self._run(env_overrides={"DOCUMENTDB_PORT": "11111"})
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self._nc_invocations(), ["-z localhost 11111"])
-
-    def test_port_falls_back_when_runtime_config_is_invalid_json(self):
-        self.marker.touch()
-        self.runtime_config.write_text("{not json", encoding="utf-8")
-        result = self._run()
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self._nc_invocations(), ["-z localhost 10260"])
-
-    def test_non_numeric_config_port_is_rejected(self):
-        # A non-numeric value must not be spliced into the nc invocation.
-        self.marker.touch()
-        self.runtime_config.write_text(
-            '{"GatewayListenPort": "not-a-port"}', encoding="utf-8"
-        )
-        result = self._run()
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self._nc_invocations(), ["-z localhost 10260"])
+        srv.setblocking(False)
+        with self.assertRaises(BlockingIOError):
+            srv.accept()
 
 
 if __name__ == "__main__":

--- a/documentdb-local/scripts/documentdb_local_tests/test_documentdb_healthcheck.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_documentdb_healthcheck.py
@@ -1,0 +1,160 @@
+"""Unit tests for documentdb_healthcheck.sh (issue #482).
+
+The script is exercised directly with bash in a sandbox: the readiness
+marker, the runtime-generated gateway configuration, and the `nc` probe are
+all faked through environment variables, temp files, and a stub `nc` on
+PATH that records how it was invoked. `jq` is the real one (it is a runtime
+dependency of the image and of the script's port lookup).
+
+Contract under test -- healthy (exit 0) if and only if:
+  1. the readiness marker file exists (written by emulator_entrypoint.sh
+     after startup, including one-shot data initialization, completes), AND
+  2. a TCP connection to the gateway's effective listen port succeeds,
+     where the effective port comes from the runtime-generated
+     SetupConfiguration_temp.json when present (a `--documentdb-port` flag
+     is invisible to the healthcheck's environment), falling back to
+     DOCUMENTDB_PORT, then 10260.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HEALTHCHECK = (
+    REPO_ROOT / "documentdb-local" / "scripts" / "documentdb_healthcheck.sh"
+)
+
+_TOOLS = ("bash", "jq")
+_SKIP_UNLESS_TOOLS = unittest.skipUnless(
+    all(shutil.which(t) for t in _TOOLS),
+    f"requires {', '.join(_TOOLS)} on PATH",
+)
+
+
+@_SKIP_UNLESS_TOOLS
+class DocumentdbHealthcheckTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+
+        self.gateway_home = self.root / "gateway"
+        self.target_dir = self.gateway_home / "pg_documentdb_gw" / "target"
+        self.target_dir.mkdir(parents=True)
+        self.runtime_config = self.target_dir / "SetupConfiguration_temp.json"
+
+        self.marker = self.root / "documentdb-local.ready"
+
+        # Stub `nc` that records its argv and exits per NC_STUB_EXIT.
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.nc_calls = self.root / "nc_calls.txt"
+        nc_stub = self.bin_dir / "nc"
+        nc_stub.write_text(
+            '#!/bin/sh\n'
+            'printf \'%s\\n\' "$*" >> "$NC_CALLS_FILE"\n'
+            'exit "${NC_STUB_EXIT:-0}"\n',
+            encoding="utf-8",
+        )
+        nc_stub.chmod(0o755)
+
+    def _run(self, *, env_overrides=None, nc_exit=0):
+        env = {
+            # Minimal, deterministic environment. PATH puts the stub `nc`
+            # first but keeps the system dirs so bash finds jq.
+            "PATH": f"{self.bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "READY_MARKER_FILE": str(self.marker),
+            "GATEWAY_HOME": str(self.gateway_home),
+            "NC_CALLS_FILE": str(self.nc_calls),
+            "NC_STUB_EXIT": str(nc_exit),
+        }
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            ["bash", str(HEALTHCHECK)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def _nc_invocations(self):
+        if not self.nc_calls.exists():
+            return []
+        return self.nc_calls.read_text(encoding="utf-8").splitlines()
+
+    def test_unhealthy_before_marker_exists_and_no_probe_is_attempted(self):
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        # No TCP probe before the marker: during startup the gateway port
+        # accepting connections must NOT make the container healthy (data
+        # initialization may still be running).
+        self.assertEqual(self._nc_invocations(), [])
+
+    def test_healthy_with_marker_and_accepting_gateway(self):
+        self.marker.touch()
+        result = self._run(nc_exit=0)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_unhealthy_with_marker_but_refusing_gateway(self):
+        self.marker.touch()
+        result = self._run(nc_exit=1)
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_port_comes_from_runtime_config(self):
+        # A --documentdb-port flag only surfaces in the runtime-generated
+        # config; the probe must use it over the environment fallback.
+        self.marker.touch()
+        self.runtime_config.write_text(
+            '{"GatewayListenPort": 23456, "PostgresPort": 9712}',
+            encoding="utf-8",
+        )
+        result = self._run(env_overrides={"DOCUMENTDB_PORT": "11111"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._nc_invocations(), ["-z localhost 23456"])
+
+    def test_port_falls_back_to_env_without_runtime_config(self):
+        self.marker.touch()
+        result = self._run(env_overrides={"DOCUMENTDB_PORT": "11111"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._nc_invocations(), ["-z localhost 11111"])
+
+    def test_port_falls_back_to_default_without_config_or_env(self):
+        self.marker.touch()
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._nc_invocations(), ["-z localhost 10260"])
+
+    def test_port_falls_back_when_runtime_config_lacks_port(self):
+        self.marker.touch()
+        self.runtime_config.write_text(
+            '{"PostgresPort": 9712}', encoding="utf-8"
+        )
+        result = self._run(env_overrides={"DOCUMENTDB_PORT": "11111"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._nc_invocations(), ["-z localhost 11111"])
+
+    def test_port_falls_back_when_runtime_config_is_invalid_json(self):
+        self.marker.touch()
+        self.runtime_config.write_text("{not json", encoding="utf-8")
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._nc_invocations(), ["-z localhost 10260"])
+
+    def test_non_numeric_config_port_is_rejected(self):
+        # A non-numeric value must not be spliced into the nc invocation.
+        self.marker.touch()
+        self.runtime_config.write_text(
+            '{"GatewayListenPort": "not-a-port"}', encoding="utf-8"
+        )
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._nc_invocations(), ["-z localhost 10260"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -666,12 +666,45 @@ json.dump(data, sys.stdout)
 
     def test_ready_marker_written_after_successful_startup(self):
         # The healthcheck (documentdb_healthcheck.sh, #482) gates on this
-        # marker; it must appear once startup completes.
+        # marker; it must appear once startup completes, carrying the two
+        # values the probe cannot get from its own environment: the effective
+        # gateway port on line 1 and the gateway job's PID on line 2.
         marker = self.root / "documentdb-local.ready"
         result = self._run_entrypoint()
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
         self.assertTrue(
             marker.exists(), "readiness marker should exist after startup"
+        )
+        lines = marker.read_text(encoding="utf-8").split()
+        self.assertEqual(
+            len(lines), 2,
+            f"marker must hold the port and the gateway PID, got {lines!r}",
+        )
+        self.assertTrue(
+            lines[0].isdigit(), f"line 1 must be the gateway port, got {lines[0]!r}"
+        )
+        self.assertTrue(
+            lines[1].isdigit(), f"line 2 must be the gateway PID, got {lines[1]!r}"
+        )
+
+    def test_ready_marker_records_the_configured_gateway_port(self):
+        # A --documentdb-port override is invisible to the probe's
+        # environment, so the marker is the only way it reaches the probe.
+        marker = self.root / "documentdb-local.ready"
+        result = self._run_entrypoint(extra_env={"DOCUMENTDB_PORT": "24680"})
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertEqual(
+            marker.read_text(encoding="utf-8").split()[0], "24680"
+        )
+
+    def test_ready_marker_leaves_no_temp_file_behind(self):
+        # The marker is written via a temp file and renamed so a probe can
+        # never read a half-written marker; the temp name must not survive.
+        result = self._run_entrypoint()
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertFalse(
+            (self.root / "documentdb-local.ready.tmp").exists(),
+            "the marker temp file must be renamed, not left on disk",
         )
 
     def test_ready_marker_not_written_when_custom_init_fails(self):

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -165,6 +165,10 @@ json.dump(data, sys.stdout)
                 "DATA_PATH": str(self.data_dir),
                 "USERNAME": "default_user",
                 "OWNER": "documentdb",
+                # Keep the readiness marker inside the sandbox: the default
+                # (/tmp/documentdb-local.ready) would leak state between tests
+                # and onto the host.
+                "READY_MARKER_FILE": str(self.root / "documentdb-local.ready"),
             }
         )
         if extra_env:
@@ -659,6 +663,53 @@ json.dump(data, sys.stdout)
             "sample should seed on the next boot after custom is skipped",
         )
         self.assertIn("attempted but its success was not recorded", second.stdout)
+
+    def test_ready_marker_written_after_successful_startup(self):
+        # The healthcheck (documentdb_healthcheck.sh, #482) gates on this
+        # marker; it must appear once startup completes.
+        marker = self.root / "documentdb-local.ready"
+        result = self._run_entrypoint()
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertTrue(
+            marker.exists(), "readiness marker should exist after startup"
+        )
+
+    def test_ready_marker_not_written_when_custom_init_fails(self):
+        # The marker is what makes `service_healthy` imply "seeded": a failed
+        # one-shot initialization must leave the container unhealthy.
+        init_dir = self.root / "custom_init"
+        init_dir.mkdir()
+        (init_dir / "00-custom.js").write_text("// custom\n", encoding="utf-8")
+        self._write_counting_init_stub(fail_always=True)
+        marker = self.root / "documentdb-local.ready"
+
+        result = self._run_entrypoint(
+            extra_env={
+                "INIT_DATA": "false",
+                "SKIP_INIT_DATA": "",
+                "INIT_DATA_PATH": str(init_dir),
+            }
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(
+            marker.exists(),
+            "readiness marker must not exist when initialization failed",
+        )
+
+    def test_stale_ready_marker_is_removed_early_on_boot(self):
+        # /tmp survives a container restart, so a marker left by the previous
+        # boot must be cleared before startup work begins -- otherwise a
+        # restarting container would report healthy while still initializing.
+        # Simulate with a boot that fails partway (invalid tlsMode): the stale
+        # marker must be gone even though this boot never became ready.
+        marker = self.root / "documentdb-local.ready"
+        marker.touch()
+        result = self._run_entrypoint(extra_env={"TLS_MODE": "bogus"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(
+            marker.exists(),
+            "stale readiness marker from a previous boot must be removed",
+        )
 
     def test_help_does_not_advertise_force_init_data(self):
         # Re-initialization is intentionally done by starting with a fresh data

--- a/documentdb-local/scripts/documentdb_local_tests/test_image.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_image.py
@@ -827,6 +827,98 @@ class CustomDocumentDBPortTests(_ContainerTestBase):
 
 
 # ---------------------------------------------------------------------------
+# 3b. Built-in container healthcheck (issue #482). The image must declare a
+#     HEALTHCHECK, the probe must gate on the entrypoint's readiness marker,
+#     and it must honor --documentdb-port by reading the effective port from
+#     the runtime-generated gateway config (the flag is invisible to the
+#     probe's environment). The class deliberately runs on a custom port: a
+#     probe that silently fell back to the default port could never turn
+#     healthy here.
+# ---------------------------------------------------------------------------
+
+HEALTHCHECK_SCRIPT = "/home/documentdb/gateway/scripts/documentdb_healthcheck.sh"
+READY_MARKER = "/tmp/documentdb-local.ready"
+
+
+def _health_status(container: str) -> str:
+    """Return the container's health status ('' when no healthcheck)."""
+    res = _docker(
+        "inspect", "-f",
+        "{{if .State.Health}}{{.State.Health.Status}}{{end}}",
+        container, check=False,
+    )
+    return res.stdout.strip()
+
+
+@_SKIP_UNLESS_IMAGE
+class HealthcheckTests(_ContainerTestBase):
+    """Built-in HEALTHCHECK: declared, turns healthy, honors custom port."""
+
+    ENTRYPOINT_FLAGS = [
+        "--skip-init-data",
+        "--documentdb-port", str(CUSTOM_PORT),
+    ]
+
+    def test_image_declares_a_healthcheck(self):
+        res = _docker(
+            "image", "inspect", "-f", "{{json .Config.Healthcheck}}",
+            self.image,
+        )
+        self.assertNotEqual(
+            res.stdout.strip(), "null",
+            "image must declare a built-in HEALTHCHECK (issue #482)",
+        )
+
+    def test_container_reports_healthy(self):
+        # _wait_for_ready (in setUpClass) saw the readiness log line, so the
+        # marker exists; within the start period probes run every
+        # --start-interval seconds, so healthy should arrive promptly.
+        deadline = time.monotonic() + 90
+        status = _health_status(self.container)
+        while status != "healthy" and time.monotonic() < deadline:
+            time.sleep(2)
+            status = _health_status(self.container)
+        self.assertEqual(
+            status, "healthy",
+            "container did not report healthy after readiness; if the probe "
+            "assumed the default port instead of reading the runtime config, "
+            "it can never succeed in this class",
+        )
+
+    def test_probe_script_passes_in_ready_container(self):
+        res = _docker(
+            "exec", self.container, "bash", HEALTHCHECK_SCRIPT,
+            check=False, timeout=30,
+        )
+        self.assertEqual(
+            res.returncode, 0,
+            f"healthcheck script failed in a ready container\n"
+            f"stdout:\n{res.stdout}\nstderr:\n{res.stderr}",
+        )
+
+    def test_probe_script_fails_without_ready_marker(self):
+        # The marker is what keeps an initializing (or restarting) container
+        # out of `healthy`; without it the probe must fail even though the
+        # gateway is accepting connections. Restored afterwards so the
+        # container's real health state is untouched (a single failed docker
+        # probe in the window would not flip health: retries=3).
+        _docker("exec", self.container, "rm", "-f", READY_MARKER,
+                check=False, timeout=30)
+        try:
+            res = _docker(
+                "exec", self.container, "bash", HEALTHCHECK_SCRIPT,
+                check=False, timeout=30,
+            )
+            self.assertNotEqual(
+                res.returncode, 0,
+                "healthcheck must fail when the readiness marker is absent",
+            )
+        finally:
+            _docker("exec", self.container, "touch", READY_MARKER,
+                    check=False, timeout=30)
+
+
+# ---------------------------------------------------------------------------
 # 4. TLS modes. allowTLS (the default) accepts both plain (non-TLS) and TLS
 #    client connections; that default is exercised by DefaultContainerTests
 #    above, which pings over both TLS and a plain connection. The requireTLS

--- a/documentdb-local/scripts/documentdb_local_tests/test_image.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_image.py
@@ -830,10 +830,9 @@ class CustomDocumentDBPortTests(_ContainerTestBase):
 # 3b. Built-in container healthcheck (issue #482). The image must declare a
 #     HEALTHCHECK, the probe must gate on the entrypoint's readiness marker,
 #     and it must honor --documentdb-port by reading the effective port from
-#     the runtime-generated gateway config (the flag is invisible to the
-#     probe's environment). The class deliberately runs on a custom port: a
-#     probe that silently fell back to the default port could never turn
-#     healthy here.
+#     that marker (the flag is invisible to the probe's environment). The
+#     class deliberately runs on a custom port: a probe that silently fell
+#     back to the default port could never turn healthy here.
 # ---------------------------------------------------------------------------
 
 HEALTHCHECK_SCRIPT = "/home/documentdb/gateway/scripts/documentdb_healthcheck.sh"
@@ -881,8 +880,27 @@ class HealthcheckTests(_ContainerTestBase):
         self.assertEqual(
             status, "healthy",
             "container did not report healthy after readiness; if the probe "
-            "assumed the default port instead of reading the runtime config, "
-            "it can never succeed in this class",
+            "assumed the default port instead of reading the one recorded in "
+            "the readiness marker, it can never succeed in this class",
+        )
+
+    def test_ready_marker_records_the_effective_port_and_a_live_pid(self):
+        # The marker is the probe's only channel for these values: Docker
+        # runs healthcheck processes with the container's static environment,
+        # so --documentdb-port never reaches them any other way.
+        res = _docker("exec", self.container, "cat", READY_MARKER, timeout=30)
+        lines = res.stdout.split()
+        self.assertEqual(
+            len(lines), 2,
+            f"marker must hold the port and the gateway PID, got: {res.stdout!r}",
+        )
+        self.assertEqual(lines[0], str(CUSTOM_PORT))
+        alive = _docker(
+            "exec", self.container, "test", "-d", f"/proc/{lines[1]}",
+            check=False, timeout=30,
+        )
+        self.assertEqual(
+            alive.returncode, 0, "marker must record a live gateway PID",
         )
 
     def test_probe_script_passes_in_ready_container(self):
@@ -899,10 +917,12 @@ class HealthcheckTests(_ContainerTestBase):
     def test_probe_script_fails_without_ready_marker(self):
         # The marker is what keeps an initializing (or restarting) container
         # out of `healthy`; without it the probe must fail even though the
-        # gateway is accepting connections. Restored afterwards so the
-        # container's real health state is untouched (a single failed docker
-        # probe in the window would not flip health: retries=3).
-        _docker("exec", self.container, "rm", "-f", READY_MARKER,
+        # gateway is accepting connections. Moved aside rather than deleted
+        # so the exact contents (port + PID) come back and the container's
+        # real health state is untouched (a single failed docker probe in the
+        # window would not flip health: retries=3).
+        stashed = READY_MARKER + ".test-stash"
+        _docker("exec", self.container, "mv", READY_MARKER, stashed,
                 check=False, timeout=30)
         try:
             res = _docker(
@@ -914,7 +934,34 @@ class HealthcheckTests(_ContainerTestBase):
                 "healthcheck must fail when the readiness marker is absent",
             )
         finally:
-            _docker("exec", self.container, "touch", READY_MARKER,
+            _docker("exec", self.container, "mv", stashed, READY_MARKER,
+                    check=False, timeout=30)
+
+    def test_probe_script_fails_when_the_gateway_pid_is_dead(self):
+        # The marker outliving the gateway must not keep the container
+        # `healthy`. Rewrite the PID line to one the kernel never assigns
+        # (pid_max is an exclusive bound), then restore the real marker.
+        stashed = READY_MARKER + ".test-stash"
+        _docker("exec", self.container, "cp", READY_MARKER, stashed,
+                check=False, timeout=30)
+        try:
+            _docker(
+                "exec", self.container, "bash", "-c",
+                f"port=$(sed -n 1p {READY_MARKER}); "
+                f"dead=$(cat /proc/sys/kernel/pid_max); "
+                f"printf '%s\\n%s\\n' \"$port\" \"$dead\" > {READY_MARKER}",
+                check=False, timeout=30,
+            )
+            res = _docker(
+                "exec", self.container, "bash", HEALTHCHECK_SCRIPT,
+                check=False, timeout=30,
+            )
+            self.assertNotEqual(
+                res.returncode, 0,
+                "healthcheck must fail when the recorded gateway PID is gone",
+            )
+        finally:
+            _docker("exec", self.container, "mv", stashed, READY_MARKER,
                     check=False, timeout=30)
 
 

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -274,6 +274,16 @@ export OSS_SERVER_LOG="$DOCUMENTDB_LOG_DIR/oss_server.log"
 # Note: PostgreSQL log will be symlinked after PostgreSQL starts
 export PG_LOG_FILE="$DOCUMENTDB_LOG_DIR/postgres/pglog.log"
 
+# Readiness marker consumed by documentdb_healthcheck.sh (issue #482): the
+# container reports healthy only once this file exists AND the gateway accepts
+# connections. Written at the end of startup, after one-shot data
+# initialization, so `depends_on: condition: service_healthy` dependents
+# observe seeded data. Remove any stale copy up front: /tmp survives a
+# container restart, and a leftover marker would report healthy before this
+# boot's startup completed.
+export READY_MARKER_FILE=${READY_MARKER_FILE:-/tmp/documentdb-local.ready}
+rm -f "$READY_MARKER_FILE"
+
 echo "Centralized log directory created with the following structure:"
 echo "  $DOCUMENTDB_LOG_DIR/gateway_entrypoint.log"
 echo "  $DOCUMENTDB_LOG_DIR/gateway.log"
@@ -671,6 +681,10 @@ fi
 echo "Gateway started with PID: $gateway_pid"
 echo ""
 echo "=== DocumentDB is ready ==="
+# Flip the container's health gate (see documentdb_healthcheck.sh). Everything
+# a dependent must be able to rely on -- gateway accepting authenticated
+# connections, one-shot data initialization -- has completed by this point.
+touch "$READY_MARKER_FILE"
 echo "All logs are being streamed to docker logs with prefixes:"
 echo "  [POSTGRES] - PostgreSQL database logs ($PG_LOG_FILE)"
 echo "  [POSTGRES-SYSTEM] - System PostgreSQL logs ($SYSTEM_POSTGRES_LOG)"

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -19,6 +19,11 @@ cleanup() {
         kill $gateway_pid 2>/dev/null || true
     fi
     
+    # Drop the readiness marker so the healthcheck stops reporting healthy
+    # while we shut down.
+    rm -f "${READY_MARKER_FILE:-/tmp/documentdb-local.ready}" \
+          "${READY_MARKER_FILE:-/tmp/documentdb-local.ready}.tmp" 2>/dev/null || true
+
     echo "Cleanup completed"
     exit 0
 }
@@ -275,14 +280,14 @@ export OSS_SERVER_LOG="$DOCUMENTDB_LOG_DIR/oss_server.log"
 export PG_LOG_FILE="$DOCUMENTDB_LOG_DIR/postgres/pglog.log"
 
 # Readiness marker consumed by documentdb_healthcheck.sh (issue #482): the
-# container reports healthy only once this file exists AND the gateway accepts
-# connections. Written at the end of startup, after one-shot data
+# container reports healthy only once this file exists AND the gateway is
+# still listening. Written at the end of startup, after one-shot data
 # initialization, so `depends_on: condition: service_healthy` dependents
 # observe seeded data. Remove any stale copy up front: /tmp survives a
 # container restart, and a leftover marker would report healthy before this
 # boot's startup completed.
 export READY_MARKER_FILE=${READY_MARKER_FILE:-/tmp/documentdb-local.ready}
-rm -f "$READY_MARKER_FILE"
+rm -f "$READY_MARKER_FILE" "$READY_MARKER_FILE.tmp"
 
 echo "Centralized log directory created with the following structure:"
 echo "  $DOCUMENTDB_LOG_DIR/gateway_entrypoint.log"
@@ -684,7 +689,14 @@ echo "=== DocumentDB is ready ==="
 # Flip the container's health gate (see documentdb_healthcheck.sh). Everything
 # a dependent must be able to rely on -- gateway accepting authenticated
 # connections, one-shot data initialization -- has completed by this point.
-touch "$READY_MARKER_FILE"
+# The probe runs with the container's static environment rather than this
+# script's exports, so hand it its inputs through the marker: the effective
+# gateway port on line 1, the gateway job's PID on line 2. Write to a temp
+# file and rename so a probe never reads a half-written marker.
+if ! { printf '%s\n%s\n' "$DOCUMENTDB_PORT" "$gateway_pid" > "$READY_MARKER_FILE.tmp" && \
+       mv "$READY_MARKER_FILE.tmp" "$READY_MARKER_FILE"; } 2>/dev/null; then
+    echo "Warning: could not write the readiness marker $READY_MARKER_FILE; the container healthcheck will keep reporting 'starting'."
+fi
 echo "All logs are being streamed to docker logs with prefixes:"
 echo "  [POSTGRES] - PostgreSQL database logs ($PG_LOG_FILE)"
 echo "  [POSTGRES-SYSTEM] - System PostgreSQL logs ($SYSTEM_POSTGRES_LOG)"

--- a/packaging/gateway/docker/Dockerfile_documentdb_local
+++ b/packaging/gateway/docker/Dockerfile_documentdb_local
@@ -195,6 +195,7 @@ COPY --from=stage /home/documentdb/code/documentdb-local/scripts/emulator_entryp
 COPY --from=stage /home/documentdb/code/documentdb-local/scripts/documentdb_reserved_roles.sh /home/documentdb/gateway/scripts/documentdb_reserved_roles.sh
 COPY --from=stage /home/documentdb/code/documentdb-local/scripts/documentdb_validate_username.sh /home/documentdb/gateway/scripts/documentdb_validate_username.sh
 COPY --from=stage /home/documentdb/code/documentdb-local/scripts/documentdb_install_getparameter_stub.sh /home/documentdb/gateway/scripts/documentdb_install_getparameter_stub.sh
+COPY --from=stage /home/documentdb/code/documentdb-local/scripts/documentdb_healthcheck.sh /home/documentdb/gateway/scripts/documentdb_healthcheck.sh
 COPY --from=stage /home/documentdb/code/scripts/utils.sh /home/documentdb/gateway/scripts/utils.sh
 COPY --from=stage /home/documentdb/code/scripts/preload_libraries.sh /home/documentdb/gateway/scripts/preload_libraries.sh
 COPY --from=stage /home/documentdb/code/scripts/setup_psqlrc.sh /home/documentdb/gateway/scripts/setup_psqlrc.sh
@@ -215,3 +216,13 @@ RUN sudo chmod +x /home/documentdb/gateway/scripts/init_documentdb_data.sh
 
 WORKDIR /home/documentdb/gateway/scripts
 ENTRYPOINT ["/bin/bash", "-c", "/home/documentdb/gateway/scripts/emulator_entrypoint.sh \"$@\"", "--"]
+
+# Built-in healthcheck so `depends_on: condition: service_healthy` works out
+# of the box (issue #482); see documentdb_healthcheck.sh for what healthy
+# means. The generous start-period accommodates first-boot initdb + CREATE
+# EXTENSION on slow Docker Desktop filesystems. --start-interval probes every
+# 2s during the start period (honored by Docker Engine >= 25; older engines
+# fall back to --interval), so compose dependents unblock shortly after
+# readiness instead of at a multiple of the 30s steady-state interval.
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=300s --start-interval=2s \
+    CMD ["/bin/bash", "/home/documentdb/gateway/scripts/documentdb_healthcheck.sh"]

--- a/packaging/gateway/test/Dockerfile_deb_gateway_test
+++ b/packaging/gateway/test/Dockerfile_deb_gateway_test
@@ -106,6 +106,7 @@ COPY documentdb-local/scripts/emulator_entrypoint.sh /home/documentdb/gateway/sc
 COPY documentdb-local/scripts/documentdb_reserved_roles.sh /home/documentdb/gateway/scripts/documentdb_reserved_roles.sh
 COPY documentdb-local/scripts/documentdb_validate_username.sh /home/documentdb/gateway/scripts/documentdb_validate_username.sh
 COPY documentdb-local/scripts/documentdb_install_getparameter_stub.sh /home/documentdb/gateway/scripts/documentdb_install_getparameter_stub.sh
+COPY documentdb-local/scripts/documentdb_healthcheck.sh /home/documentdb/gateway/scripts/documentdb_healthcheck.sh
 COPY documentdb-local/scripts/init_documentdb_data.sh /home/documentdb/gateway/scripts/init_documentdb_data.sh
 COPY scripts/utils.sh /home/documentdb/gateway/scripts/utils.sh
 COPY scripts/preload_libraries.sh /home/documentdb/gateway/scripts/preload_libraries.sh


### PR DESCRIPTION
## Description

Closes #482.

The documentdb-local image had no `HEALTHCHECK`, so Docker Compose users had to hand-roll probes (the issue shows one being iterated on), and the obvious TCP/TLS probes report ready *before* one-shot data seeding has finished — a dependent gated on `service_healthy` could observe a half-initialized database. There were also no compose or devcontainer examples to start from.

This PR:

- **Ships `documentdb_healthcheck.sh` in the image, wired up as its `HEALTHCHECK`.** Healthy means both: (1) the entrypoint finished startup — it writes a readiness marker (`/tmp/documentdb-local.ready`) *after* one-shot data initialization, and removes any stale marker early on boot since `/tmp` survives container restarts; and (2) the gateway currently accepts TCP connections on its *effective* listen port, read from the runtime-generated gateway config so `--documentdb-port` is honored (the flag is invisible to the probe's environment — Docker spawns healthcheck processes with the container's static env). The probe is deliberately a marker + TCP check, not a mongosh ping: the entrypoint already verifies end-to-end auth before reporting ready, and a Node.js client burns ~2s CPU per probe for no added signal.
- **Adds ready-to-run examples** under `documentdb-local/examples/`:
  - `compose-quickstart` — minimal service + named volume + healthcheck;
  - `compose-app` — an app gated on `depends_on: condition: service_healthy` (no retry loops), including the CI `--exit-code-from` pattern and the service-name-vs-localhost connection-string distinction;
  - `compose-init-data` — first-boot seeding from mounted `.js` scripts, written idempotently (guarded inserts) because images published before the one-shot init markers (#612) re-run seed scripts on every boot;
  - `devcontainer` — a full dev-environment-in-a-container with DocumentDB as a compose sidecar (the workflow the issue author was after: no local dependencies at all).
- **Documents the compose scenario** in `documentdb-local/examples/README.md` (healthcheck semantics, credentials, connection strings, persistence/re-seeding, troubleshooting) and links it from the README quickstart. The examples carry an explicit `healthcheck:` block (readiness log line + TCP) so they work with the *currently published* image too; once an image with the built-in `HEALTHCHECK` is published, that block becomes optional and the examples say so.

### Testing done

- `documentdb_local_tests` suite: 190 tests green (Linux container), including new unit tests for the healthcheck script (marker gating, port resolution/fallbacks) and entrypoint readiness-marker lifecycle tests (written after success, absent on failed init, stale marker removed on boot).
- Image built locally from this branch (PG 17, `debian:trixie-slim`, same recipe as CI) and `test_image.py` run against it, including the new `HealthcheckTests` (HEALTHCHECK declared; container turns healthy; probe honors `--documentdb-port` via the runtime config; probe fails without the marker) — plus a compose file with **no** explicit healthcheck block to confirm `service_healthy` gating works out of the box and observes seeded sample data.
- Every example validated end-to-end against the published `ghcr.io/documentdb/documentdb/documentdb-local:latest`: `up --wait` gating, mongosh auth, data persistence across `down`/`up`, seed-once semantics, restart behavior (which is what surfaced the idempotency requirement above), and the devcontainer example via the devcontainer CLI (`up` + `exec pytest`, 2 passed).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactoring / code cleanup
- [ ] DevOps / tooling
- [x] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Implemented the healthcheck script, entrypoint marker, Dockerfile wiring, examples, docs, and tests from the issue description under my direction; I reviewed every change, and all of it was tested locally (unit suite, locally built image, published image, devcontainer CLI) as described above.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
