### PR TITLE
README: mount a volume in the Docker quickstart and document readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,17 @@ Step 3. Setup DocumentDB using Docker
    docker tag ghcr.io/documentdb/documentdb/documentdb-local:latest documentdb
 
    # Run the container with your chosen username and password
-   docker run -dt -p 10260:10260 --name documentdb-container documentdb --username <YOUR_USERNAME> --password <YOUR_PASSWORD>
+   docker run -dt -p 10260:10260 -v documentdb-data:/data --name documentdb-container documentdb --username <YOUR_USERNAME> --password <YOUR_PASSWORD>
 
 ```
 
    > **Note:** Replace `<YOUR_USERNAME>` and `<YOUR_PASSWORD>` with your desired credentials. You must set these when creating the container for authentication to work.
    > 
    > **Port Note:** Port `10260` is used by default in these instructions to avoid conflicts with other local database services. You can use port `27017` (the standard MongoDB port) or any other available port if you prefer. If you do, be sure to update the port number in both your `docker run` command and your connection string accordingly.
+   > 
+   > **Data Note:** `-v documentdb-data:/data` keeps your data in a named Docker volume, so it survives container removal and image upgrades — without it, removing the container deletes all data. To start fresh later, remove the volume: `docker volume rm documentdb-data`.
+   > 
+   > **Readiness Note:** On first start the container initializes the database before accepting connections, which can take a while on slow filesystems. It is ready once `docker logs documentdb-container` prints `=== DocumentDB is ready ===`. Most drivers retry long enough that connecting right away usually just works.
 
 Step 4: Initialize the pymongo client with the credentials from the previous step
 


### PR DESCRIPTION
## Description

The README quickstart's `docker run` command mounts no volume, so all data lives in the container's writable layer: it survives `docker restart` but is **silently lost** on `docker rm` / image upgrade / re-run. Verified empirically: insert 3 documents per the quickstart, `docker rm -f` + re-run → 0 documents. The quickstart also never says how to tell when the container is ready (first boot initializes the database before accepting connections).

This PR (docs only):

- Adds `-v documentdb-data:/data` to the quickstart command, plus a **Data Note** explaining the volume lifecycle and how to start fresh (`docker volume rm documentdb-data`).
- Adds a **Readiness Note** pointing at the `=== DocumentDB is ready ===` log marker (already a de-facto contract — the image test suite keys off the same line), with the caveat that driver-side retry usually hides the wait.

Detailed investigation in guanzhousongmicrosoft/documentdb#39.

### Testing done

Ran the updated commands verbatim against `ghcr.io/documentdb/documentdb/documentdb-local:latest`:
- insert 3 documents → `docker rm -f` → same `docker run` again → **3 documents still present** (previously 0);
- confirmed `docker logs` prints the documented readiness marker.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring / code cleanup
- [ ] DevOps / tooling
- [ ] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Found the gap while dry-running the README from a new user's perspective, drafted the doc changes, and verified the before/after behavior end-to-end against the published image under my direction.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate (docs-only; verified commands manually)
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
