### PR TITLE
documentdb-local: refuse to start without an explicit password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### documentdb v0.117-0 (Unreleased) ###
 * Default the RUM index library (`documentdb.rum_library_load_option`) to `require_documentdb_extended_rum` on all supported PostgreSQL versions, instead of only on PG 18+. The option can still be set to `none` to opt out. *[Refactor]*
+* **Breaking (documentdb-local):** the container now refuses to start when no password is provided, instead of silently falling back to the well-known default `Admin100`. `--help` and the README always documented the password as required; now it is. Pass `--password <secret>` or `-e PASSWORD=<secret>` (or the old default explicitly, to keep prior behavior). *[Bugfix]*
 
 ### documentdb v0.116-0 (Unreleased) ###
 * Rename the `$sample` EXPLAIN metric `Sample Heap Skips` to `Sample Heap Fetches`. *[Refactor]*

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -335,6 +335,28 @@ exit 1
             result.stdout + result.stderr,
         )
 
+    def test_missing_password_fails_fast_with_actionable_message(self):
+        # Regression guard: PASSWORD used to silently default to the
+        # well-known 'Admin100', which made the "PASSWORD is required"
+        # validation unreachable and let a container started without
+        # credentials accept a password anyone could look up in the
+        # entrypoint source.
+        result = self._run_entrypoint(extra_env={"PASSWORD": ""})
+        self.assertNotEqual(result.returncode, 0)
+        out = result.stdout + result.stderr
+        self.assertIn("no password provided", out)
+        # The message must show both ways of supplying one.
+        self.assertIn("--password", out)
+        self.assertIn("PASSWORD=", out)
+        # Startup must not have proceeded past validation.
+        self.assertNotIn("Using username", out)
+
+    def test_password_flag_alone_satisfies_the_requirement(self):
+        result = self._run_entrypoint(
+            "--password", "flagpass", extra_env={"PASSWORD": ""}
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+
     def test_enforce_tls_write_failure_aborts(self):
         failing_jq = """#!/usr/bin/env python3
 import json

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -246,7 +246,11 @@ export DATA_PATH=${DATA_PATH:-/data}
 export DOCUMENTDB_PORT=${DOCUMENTDB_PORT:-10260}
 export POSTGRESQL_PORT=${POSTGRESQL_PORT:-9712}
 export USERNAME=${USERNAME:-default_user}
-export PASSWORD=${PASSWORD:-Admin100}
+# PASSWORD deliberately has no default. It used to fall back to a well-known
+# value (Admin100), which meant a container started without credentials
+# silently accepted a password anyone could look up in this file -- while
+# --help and the README both said a password was required. The validation
+# below now actually enforces that.
 export CREATE_USER=${CREATE_USER:-true}
 export START_POSTGRESQL=${START_POSTGRESQL:-true}
 export INIT_DATA=${INIT_DATA:-}
@@ -282,7 +286,12 @@ echo "  $DOCUMENTDB_LOG_DIR/postgres/pglog.log (will be symlinked)"
 
 # Validate required parameters
 if [ -z "${PASSWORD:-}" ]; then
-    echo "Error: PASSWORD is required. Please provide a password using --password argument or PASSWORD environment variable."
+    echo "Error: no password provided. Set one with:"
+    echo "  docker run ... --password <secret>        (entrypoint flag)"
+    echo "  docker run -e PASSWORD=<secret> ...       (environment variable)"
+    echo "Earlier versions silently fell back to the well-known default password"
+    echo "'Admin100'. If you relied on that, pass it explicitly (not recommended"
+    echo "outside throwaway environments): --password Admin100"
     exit 1
 fi
 


### PR DESCRIPTION
## Description

A documentdb-local container started with **no** `--password` flag and no `PASSWORD` environment variable silently fell back to the well-known default `Admin100`:

```bash
export PASSWORD=${PASSWORD:-Admin100}   # emulator_entrypoint.sh
...
if [ -z "${PASSWORD:-}" ]; then         # can never fire
```

Meanwhile `--help` marks `--password` as **REQUIRED** and the README says *"You must set these when creating the container for authentication to work."* The quickstart also publishes the port (`-p 10260:10260`), so on a shared/LAN-exposed dev machine an instance started without flags accepts a password anyone can look up in seconds. Details in guanzhousongmicrosoft/documentdb#37.

This PR makes the entrypoint enforce what the docs already promise:

- Drop the `Admin100` fallback so the existing "password is required" validation actually fires.
- Make the error actionable — it shows both ways to supply a password and names the old default explicitly, so anyone whose scripts relied on the silent fallback has a one-line fix (passing it *on purpose*):

  ```
  Error: no password provided. Set one with:
    docker run ... --password <secret>        (entrypoint flag)
    docker run -e PASSWORD=<secret> ...       (environment variable)
  Earlier versions silently fell back to the well-known default password
  'Admin100'. If you relied on that, pass it explicitly (not recommended
  outside throwaway environments): --password Admin100
  ```

**This is a breaking change** for setups that relied on the silent default (CHANGELOG entry included; mirrors the `postgres` image's `POSTGRES_PASSWORD` behavior). The repo's own tooling is unaffected — `test_image.py` and `run-functional-tests.sh` always pass credentials explicitly, and image-build initialization runs with user creation disabled. `USERNAME` keeps its `default_user` default (the username is not the secret).

### Testing done

- **Unit** (`test_emulator_entrypoint.py`, full suite green — 52 tests): new tests assert that a missing password fails fast with the actionable message *before* any startup work, and that `--password` alone satisfies the requirement (regression guard on the unreachable-validation bug).
- **E2E** against a locally built image with this entrypoint:
  - no credentials → container exits `1` immediately with the message above;
  - `--password` flag → container reaches `=== DocumentDB is ready ===`;
  - `-e PASSWORD=...` → ready, and `mongosh -u default_user -p <env password>` authenticates and pings successfully.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] DevOps / tooling
- [x] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Found the issue while probing failure modes from a new user's perspective, implemented the fix and tests, and validated end-to-end against a locally built image under my direction.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
