### PR TITLE
gateway: say 'Authentication failed.' when the SCRAM proof is rejected

### DIFF
--- a/documentdb-local/scripts/documentdb_local_tests/test_image.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_image.py
@@ -493,7 +493,10 @@ class DefaultContainerTests(_ContainerTestBase):
         )
 
     def test_mongosh_ping_rejected_with_wrong_password(self):
-        """Authentication must be enforced - a wrong password must fail."""
+        """Authentication must be enforced - a wrong password must fail,
+        and the client-facing message must say so. The gateway used to
+        surface 'Invalid key' here, which reads like a TLS/key-file
+        problem and sent users debugging in the wrong direction."""
         result = self._mongosh(
             "db.runCommand({ping: 1})",
             password=self.password + "-wrong",
@@ -502,6 +505,19 @@ class DefaultContainerTests(_ContainerTestBase):
             result.returncode, 0,
             "mongosh unexpectedly succeeded with a wrong password\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        combined = result.stdout + result.stderr
+        self.assertIn(
+            "Authentication failed",
+            combined,
+            "wrong-password rejection should carry the canonical "
+            f"authentication-failure message\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}",
+        )
+        self.assertNotIn(
+            "Invalid key",
+            combined,
+            "the misleading 'Invalid key' wording must not come back",
         )
 
     def test_no_undefined_backend_function_errors_in_logs(self):

--- a/pg_documentdb_gw/documentdb_gateway_core/src/auth.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/auth.rs
@@ -729,8 +729,12 @@ async fn handle_sasl_continue(
             .map_err(DocumentDBError::pg_response_invalid)?
             != 1
         {
+            // The backend rejected the client's SCRAM proof, i.e. the
+            // password is wrong. Use MongoDB's wording: the previous
+            // "Invalid key" read like a TLS/key-file problem and sent users
+            // debugging in the wrong direction.
             return Err(DocumentDBError::authentication_failed(
-                "Invalid key".to_owned(),
+                "Authentication failed.".to_owned(),
             ));
         }
 


### PR DESCRIPTION
## Description

Authenticating with a wrong password returned the right error shape (code 18, `AuthenticationFailed`) but the human-readable message was **`Invalid key`** — which reads like a TLS certificate/key-file problem and sends users debugging in exactly the wrong direction. MongoDB's wording for this situation is `Authentication failed.`, and that's what tutorials and search results key off. Details in guanzhousongmicrosoft/documentdb#36.

Before:

```
OperationFailure: Invalid key, full error:
{'ok': 0.0, 'code': 18, 'codeName': 'AuthenticationFailed', 'errmsg': 'Invalid key'}
```

After:

```
MongoServerError: Authentication failed.
```

The change is confined to the client-facing message on the SCRAM-proof-rejection path in `auth.rs` (the backend said `ok != 1`, i.e. the password is wrong). Other `authentication_failed` messages (OIDC/token flows, protocol-shape errors) are untouched — they describe different situations and already say what they mean. The nearby unauthenticated-operation message was already good; this was the odd one out.

### Testing done

- Built the documentdb-local image from this branch (PG 17, same recipe as CI) and verified end-to-end with mongosh: wrong password → `MongoServerError: Authentication failed.`; correct password → ping ok.
- Strengthened `test_image.py`'s existing `test_mongosh_ping_rejected_with_wrong_password` to pin the canonical message and reject any return of the old `Invalid key` wording; ran it against the freshly built image through the normal harness (green).
- Confirmed nothing in the repo (Rust tests, Python tests, regress expected outputs) asserts the old string.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] DevOps / tooling
- [x] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Found the issue while probing failure modes from a new user's perspective, located the message in the SCRAM path, made the change and test update, and validated end-to-end against a locally built image under my direction.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
