### PR TITLE
create_indexes: tell users how to actually pass cosmosSearch options

### DIFF
--- a/internal/pg_documentdb_distributed/src/test/regress/expected/create_indexes_cosmos_vector.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/create_indexes_cosmos_vector.out
@@ -11,7 +11,7 @@ NOTICE:  creating collection
 
 -- now you get different errors
 SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "create_indexes_vector", "indexes": [ { "key": { "a": "cosmosSearch"}, "name": "foo_1"  } ] }', true);
-ERROR:  Error in specification { "key" : { "a" : "cosmosSearch" }, "name" : "foo_1" }:Index type 'CosmosSearch' was requested, but the 'cosmosSearch' options were not provided.
+ERROR:  Error in specification { "key" : { "a" : "cosmosSearch" }, "name" : "foo_1" }:Index type 'CosmosSearch' was requested, but the 'cosmosSearch' options were not provided. Add a 'cosmosSearchOptions' document to the index specification using the createIndexes command directly (e.g. db.runCommand({ createIndexes: ..., indexes: [ { name: ..., key: ..., cosmosSearchOptions: {...} } ] })); some shell helpers such as mongosh's createIndex() drop this non-standard option.
 SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "create_indexes_vector", "indexes": [ { "key": { "a": 1 }, "name": "foo_1", "cosmosSearchOptions": { } } ] }', true);
 ERROR:  Error in specification { "key" : { "a" : 1 }, "name" : "foo_1", "cosmosSearchOptions" : {  } }:cosmosSearch index kind must be specified
 SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "create_indexes_vector", "indexes": [ { "key": { "a": "cosmosSearch" }, "name": "foo_1", "cosmosSearchOptions": { "kind": "vector-ivf", "numLists": 100, "similarity": "COS", "dimensions": 1 } } ] }', true);

--- a/internal/pg_documentdb_distributed/src/test/regress/expected/feature_counters.out
+++ b/internal/pg_documentdb_distributed/src/test/regress/expected/feature_counters.out
@@ -22,7 +22,7 @@ select count(*)*0 as count from documentdb_api_internal.command_feature_counter_
 
 -- vector index creation error
 SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "feature_counter_col", "indexes": [ { "key": { "a": "cosmosSearch"}, "name": "foo_1"  } ] }', true);
-ERROR:  Error in specification { "key" : { "a" : "cosmosSearch" }, "name" : "foo_1" }:Index type 'CosmosSearch' was requested, but the 'cosmosSearch' options were not provided.
+ERROR:  Error in specification { "key" : { "a" : "cosmosSearch" }, "name" : "foo_1" }:Index type 'CosmosSearch' was requested, but the 'cosmosSearch' options were not provided. Add a 'cosmosSearchOptions' document to the index specification using the createIndexes command directly (e.g. db.runCommand({ createIndexes: ..., indexes: [ { name: ..., key: ..., cosmosSearchOptions: {...} } ] })); some shell helpers such as mongosh's createIndex() drop this non-standard option.
 SELECT documentdb_api_internal.create_indexes_non_concurrently('db', '{ "createIndexes": "feature_counter_col", "indexes": [ { "key": { "a": 1 }, "name": "foo_1", "cosmosSearchOptions": { } } ] }', true);
 ERROR:  Error in specification { "key" : { "a" : 1 }, "name" : "foo_1", "cosmosSearchOptions" : {  } }:cosmosSearch index kind must be specified
 -- create collection

--- a/pg_documentdb/src/commands/create_indexes.c
+++ b/pg_documentdb/src/commands/create_indexes.c
@@ -2470,9 +2470,16 @@ ParseIndexDefDocumentInternal(const bson_iter_t *indexesDocIter,
 	if (indexDef->key->hasCosmosIndexes &&
 		indexDef->cosmosSearchOptions == NULL)
 	{
+		/* The most common way to hit this is a shell/driver createIndex()
+		 * helper that silently drops the non-standard cosmosSearchOptions
+		 * field before the spec reaches the server, so tell the user what
+		 * the working form looks like instead of only what is missing. */
 		ereport(ERROR, (errcode(ERRCODE_DOCUMENTDB_CANNOTCREATEINDEX),
 						errmsg(
-							"Index type 'CosmosSearch' was requested, but the 'cosmosSearch' options were not provided.")));
+							"Index type 'CosmosSearch' was requested, but the 'cosmosSearch' options were not provided."
+							" Add a 'cosmosSearchOptions' document to the index specification using the createIndexes command directly"
+							" (e.g. db.runCommand({ createIndexes: ..., indexes: [ { name: ..., key: ..., cosmosSearchOptions: {...} } ] }));"
+							" some shell helpers such as mongosh's createIndex() drop this non-standard option.")));
 	}
 
 	if (!indexDef->key->hasTextIndexes &&


### PR DESCRIPTION
## Description

Creating a vector index the way a MongoDB user instinctively would — with the `createIndex()` shell helper — fails:

```javascript
t.vecs.createIndex(
  { v: 'cosmosSearch' },
  { cosmosSearchOptions: { kind: 'vector-ivf', numLists: 1, similarity: 'COS', dimensions: 3 } }
);
// MongoServerError[CannotCreateIndex]: ... Index type 'CosmosSearch' was requested,
// but the 'cosmosSearch' options were not provided.
```

The helper silently drops the non-standard `cosmosSearchOptions` field before the spec reaches the server (the spec echoed in the error shows it already gone), and the message says what's missing but not how to provide it — right at the front door of a headline feature. The raw `createIndexes` command works fine; nothing pointed the user there. Details in guanzhousongmicrosoft/documentdb#38.

This PR extends the error message with the working form and names the pitfall:

```
Index type 'CosmosSearch' was requested, but the 'cosmosSearch' options were not provided.
Add a 'cosmosSearchOptions' document to the index specification using the createIndexes
command directly (e.g. db.runCommand({ createIndexes: ..., indexes: [ { name: ..., key: ...,
cosmosSearchOptions: {...} } ] })); some shell helpers such as mongosh's createIndex() drop
this non-standard option.
```

The guidance lives in `errmsg` rather than `errhint` so every client sees it regardless of how the gateway maps hints. The two distributed-suite regress expected files that assert the exact text are updated to match.

### Testing done

- Rebuilt the .deb from this branch with the standard packaging flow — the full SQL regression suites ran as part of it and passed (5 + 104 + 3 + 56 tests across schedules).
- Built the documentdb-local image from that .deb and verified end-to-end with mongosh 2.9.2:
  - the `createIndex()` helper path now fails **with** the guidance text;
  - following the guidance verbatim (`runCommand({createIndexes: ...})`) succeeds (`ok: 1`) and a `$search`/`cosmosSearch` query returns correctly ranked results — i.e. the advice the error gives actually works.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] DevOps / tooling
- [ ] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Hit the failure while running first-day vector-search workloads from a new user's perspective, located the validation in create_indexes.c, wrote the extended message and expected-output updates, and validated end-to-end against a locally built image under my direction.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate (regress expected outputs assert the new text)
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
