### PR TITLE
fix(gw): stop reaping in-use connection pools after 2h of uptime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### documentdb v0.117-0 (Unreleased) ###
+* Fix gateway data connection pools being reaped while still in active use once the gateway process had been up for ~2 hours, after which every request for an already-authenticated user failed with an internal error and `Connection pool missing for user.` in the logs. The pool's last-used timestamp was written as seconds since the UNIX epoch but read back as nanoseconds since the process epoch, so it no longer tracked actual usage and the pool reaper compared its idle threshold against process uptime instead. Regression introduced in v0.114-0. *[Bugfix]*
 * Default the RUM index library (`documentdb.rum_library_load_option`) to `require_documentdb_extended_rum` on all supported PostgreSQL versions, instead of only on PG 18+. The option can still be set to `none` to opt out. *[Refactor]*
 
 ### documentdb v0.116-0 (Unreleased) ###

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/connection_pool.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/connection_pool.rs
@@ -42,7 +42,7 @@ use crate::{
         QueryCatalog,
     },
     telemetry::TracingConfig,
-    time::{self, EpochClock},
+    time,
 };
 
 fn pg_configuration(
@@ -147,7 +147,13 @@ pub struct ConnectionPool {
     /// `RecyclingMethod::Clean` to reset all session state when a
     /// connection is returned
     timeout_pool: DeadpoolPool<InstrumentedManager>,
-    /// Nanosecond offset from `EPOCH` of the last `acquire_connection` call.
+    /// Nanosecond offset from the process epoch of the last
+    /// `acquire_connection` call. Only ever written through
+    /// [`ConnectionPool::touch_last_used`] and read through
+    /// [`ConnectionPool::last_used`], which own that encoding — writing a
+    /// timestamp in any other unit or base here silently corrupts every
+    /// idleness decision made about this pool.
+    ///
     /// Uses `AtomicU64` instead of `RwLock<Instant>` to avoid async lock
     /// overhead on the hot acquire path.
     last_used_nanos: AtomicU64,
@@ -278,8 +284,7 @@ impl ConnectionPool {
     pub async fn acquire_connection(
         &self,
     ) -> std::result::Result<PoolConnection, deadpool_postgres::PoolError> {
-        self.last_used_nanos
-            .store(EpochClock::almost_now_timestamp(), Ordering::Relaxed);
+        self.touch_last_used();
 
         self.pool.get().await.inspect_err(|error| {
             self.metrics.record_timeout_if_pool_timeout(error);
@@ -306,8 +311,7 @@ impl ConnectionPool {
     pub async fn acquire_timeout_connection(
         &self,
     ) -> std::result::Result<PoolConnection, deadpool_postgres::PoolError> {
-        self.last_used_nanos
-            .store(EpochClock::almost_now_timestamp(), Ordering::Relaxed);
+        self.touch_last_used();
 
         self.timeout_pool.get().await.inspect_err(|error| {
             self.metrics.record_timeout_if_pool_timeout(error);
@@ -331,6 +335,26 @@ impl ConnectionPool {
     #[cfg(test)]
     pub(crate) fn record_connection_timeout(&self) {
         self.metrics.record_connection_timeout();
+    }
+
+    /// Marks the pool as used as of now.
+    ///
+    /// Deliberately uses the precise `Instant::now()` rather than either of the
+    /// `EpochClock` coarse readings. This stamp is the sole input to the pool
+    /// reaper, so it must not depend on the coarse clock's updater task still
+    /// being alive on the runtime that happened to initialise it, and it must
+    /// stay in the encoding [`Self::last_used`] decodes: nanoseconds since the
+    /// process epoch. `EpochClock::almost_now_timestamp()` in particular looks
+    /// interchangeable here and is not — it returns *seconds since the UNIX
+    /// epoch*, which decodes as a point roughly two seconds after process start
+    /// that then advances by a nanosecond per second, making every pool look
+    /// idle for as long as the process has been up.
+    ///
+    /// The `Instant::now()` syscall costs ~20ns against a call that goes on to
+    /// check out a pooled connection, so the coarse clock buys nothing here.
+    fn touch_last_used(&self) {
+        self.last_used_nanos
+            .store(time::instant_to_u64(Instant::now()), Ordering::Relaxed);
     }
 
     pub fn last_used(&self) -> Instant {
@@ -391,8 +415,13 @@ mod tests {
 
     use crate::{
         postgres::create_query_catalog,
-        testing::{test_connection_pool, test_setup_configuration},
+        testing::{test_connection_pool, test_setup_configuration, wait_for_epoch_uptime},
     };
+
+    /// Long enough that a stamp written in the wrong unit or base cannot look
+    /// recent: such a stamp decodes to roughly two seconds past the epoch and
+    /// then stays effectively frozen there.
+    const EPOCH_UPTIME_FOR_IDLENESS_ASSERTS: Duration = Duration::from_secs(5);
 
     #[tokio::test]
     async fn test_new_with_user_with_valid_config_creates_pool() {
@@ -523,6 +552,46 @@ mod tests {
 
         assert!(pool.last_used() >= before);
         assert!(pool.last_used().elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_last_used_after_acquire_connection_reports_pool_as_recently_used() {
+        let setup_config = test_setup_configuration();
+        let pool =
+            test_connection_pool(&setup_config, &setup_config.postgres_system_user.clone(), 2)
+                .await;
+
+        wait_for_epoch_uptime(EPOCH_UPTIME_FOR_IDLENESS_ASSERTS).await;
+
+        // The last-used stamp is written before the pool is touched, so whether
+        // a local Postgres is reachable does not affect what is asserted here.
+        let _ = pool.acquire_connection().await;
+
+        let idle_for = pool.last_used().elapsed();
+        assert!(
+            idle_for < Duration::from_secs(1),
+            "a just-acquired pool must not look idle, but last_used() reports {idle_for:?} of \
+             idleness"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_last_used_after_acquire_timeout_connection_reports_pool_as_recently_used() {
+        let setup_config = test_setup_configuration();
+        let pool =
+            test_connection_pool(&setup_config, &setup_config.postgres_system_user.clone(), 2)
+                .await;
+
+        wait_for_epoch_uptime(EPOCH_UPTIME_FOR_IDLENESS_ASSERTS).await;
+
+        let _ = pool.acquire_timeout_connection().await;
+
+        let idle_for = pool.last_used().elapsed();
+        assert!(
+            idle_for < Duration::from_secs(1),
+            "a just-acquired pool must not look idle, but last_used() reports {idle_for:?} of \
+             idleness"
+        );
     }
 
     #[test]

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
@@ -342,6 +342,7 @@ mod tests {
         configuration::{CertInputType, CertificateOptions, DocumentDBSetupConfiguration},
         error::{ErrorCode, ErrorKind},
         postgres::create_query_catalog,
+        testing::wait_for_epoch_uptime,
     };
 
     #[derive(Debug)]
@@ -747,6 +748,44 @@ mod tests {
 
         // only 2 system pools should remain since user and shared pools are expired
         assert_eq!(2, pool_manager.report_pool_stats().len());
+    }
+
+    #[tokio::test]
+    async fn test_clean_unused_pools_with_actively_used_pool_keeps_pool_reachable() {
+        yield_now().await;
+
+        let dynamic_configuration = MaxConnectionConfig {
+            max_conn: 100.into(),
+        };
+        let pool_manager = test_pool_manager();
+
+        pool_manager
+            .allocate_data_pool("user", "password", &dynamic_configuration)
+            .unwrap();
+
+        wait_for_epoch_uptime(Duration::from_secs(5)).await;
+
+        // Drive the pool the way a live request does. The acquisition itself may
+        // fail without a local Postgres, but the last-used stamp is written
+        // before the pool is touched, which is what the reaper reads.
+        let _ = pool_manager
+            .get_data_pool("user", &dynamic_configuration)
+            .unwrap()
+            .acquire_connection()
+            .await;
+
+        pool_manager.clean_unused_pools(Duration::from_secs(1));
+
+        // The reaper has to key off how long a pool has been idle, not off how
+        // long the process has been running. Evicting a pool that is still in
+        // active use makes every subsequent request for that user fail with
+        // "Connection pool missing for user." until the client re-authenticates.
+        assert!(
+            pool_manager
+                .get_data_pool("user", &dynamic_configuration)
+                .is_ok(),
+            "a data pool that was just used was reaped as unused"
+        );
     }
 
     #[tokio::test]

--- a/pg_documentdb_gw/documentdb_gateway_core/src/testing/mod.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/testing/mod.rs
@@ -24,7 +24,7 @@ pub use op_msg::{
     build_document_sequence_section, build_op_msg_parts, build_op_msg_parts_with_sections,
     build_op_msg_request, build_raw_document, decode_op_msg_response, decode_op_msg_responses,
 };
-pub use pool::{test_connection_pool, test_setup_configuration};
+pub use pool::{test_connection_pool, test_setup_configuration, wait_for_epoch_uptime};
 pub use request_documents::{
     invalid_transaction_find_document, logout_document, malformed_sasl_start_document,
     ping_document,

--- a/pg_documentdb_gw/documentdb_gateway_core/src/testing/pool.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/testing/pool.rs
@@ -9,7 +9,10 @@
  *-------------------------------------------------------------------------
  */
 
-use tokio::task::yield_now;
+use tokio::{
+    task::yield_now,
+    time::{sleep, Duration},
+};
 
 use crate::{
     configuration::{CertInputType, CertificateOptions, DocumentDBSetupConfiguration},
@@ -17,6 +20,7 @@ use crate::{
         conn_mgmt::{ConnectionPool, PgPoolSettings},
         create_query_catalog,
     },
+    time::EpochClock,
 };
 
 /// Returns a baseline `DocumentDBSetupConfiguration` suitable for connection
@@ -67,4 +71,19 @@ pub async fn test_connection_pool(
         PgPoolSettings::system_pool_settings(max_connections),
     )
     .expect("Failed to create connection pool")
+}
+
+/// Waits until the process-wide [`EpochClock`] epoch is at least `uptime` old.
+///
+/// `ConnectionPool::last_used` decodes its stored stamp as a nanosecond offset
+/// from that epoch. A stamp accidentally written in a different unit or base
+/// still decodes to *some* instant close to the epoch, so it only becomes
+/// distinguishable from a correct stamp once the process has been running for
+/// longer than the offset the bogus stamp decodes to. Tests that assert on pool
+/// idleness use this to get a deterministic result instead of one that depends
+/// on how far into the test binary's lifetime they happen to run.
+pub async fn wait_for_epoch_uptime(uptime: Duration) {
+    if let Some(remaining) = uptime.checked_sub(EpochClock::epoch().elapsed()) {
+        sleep(remaining).await;
+    }
 }


### PR DESCRIPTION
## Description

Fixes a regression, introduced in v0.114-0, where the gateway stops serving already-authenticated clients after **2h05m of process uptime**, returning internal errors with `Connection pool missing for user.` in the gateway log.

Reported by an external user whose 12–48 hour soak harness passed consistently on 0.112 and began failing at ~2 hours on 0.114, reproducibly across multiple machines.

### Root cause

`ConnectionPool::last_used_nanos` holds **nanoseconds since the process epoch**, and that is how `last_used()` decodes it:

```rust
pub fn last_used(&self) -> Instant {
    time::u64_to_instant(self.last_used_nanos.load(Ordering::Relaxed))
    // == EpochClock::epoch() + Duration::from_nanos(v)
}
```

`f02641fe` ("[RustGW] Correctly migrate to EpochClock in connection pool") changed both acquisition paths to write it with `EpochClock::almost_now_timestamp()`, which returns **seconds since the UNIX epoch** (~1.785e9). Decoded as nanoseconds that lands ~1.785 s after process start and then advances one nanosecond per elapsed second — effectively frozen. The two functions look interchangeable at a call site and are not.

So `last_used().elapsed()` stopped measuring pool idleness and started measuring **process uptime**. The reaper wakes every 300 s and disposes pools idle beyond 7200 s, so with a frozen stamp:

- tick at t=7200 s reads 7198.2 s → spares the pool
- tick at t=7500 s reads 7498.2 s → **evicts it**

From then on *every* user data pool is evicted regardless of load, and re-evicted on each subsequent tick. `get_data_pool` cannot rebuild an evicted pool because the user's password is not retained past authentication, so requests from an authenticated client fail until it re-authenticates.

Ancestry confirms the reported release boundary: `f02641fe` is not an ancestor of `v0.112-0` or `v0.113-0`, and is an ancestor of `v0.114-0`.

### Fix

Both acquisition paths now route through a single `touch_last_used()` helper that writes the encoding `last_used()` decodes. Two deliberate choices:

1. **One writer.** The field is written only by `touch_last_used` and read only by `last_used`, so the encoding is owned in one place. Both carry doc comments naming the trap.

2. **Precise `Instant::now()`, not the coarse clock.** The minimal fix preserving the original commit's intent would be `instant_to_u64(EpochClock::almost_now())`. That was tried first and the new tests still failed, at *5.004 s* of reported idleness: `EpochClock`'s coarse updater is a tokio task spawned on whichever runtime first initialises the global clock, so `almost_now()` stops advancing when that runtime goes away. The gateway daemon has one long-lived runtime so it does advance in production, but the reaper's only input shouldn't depend on a background task's liveness. `Instant::now()` is ~20 ns on a path that then checks out a pooled Postgres connection.

The other `almost_now_timestamp()` callers (`ttl_cache.rs`, `transaction_store.rs`) were audited and are correct — both compare unix-seconds to unix-seconds. The connection pool was the only site mixing bases.

### Validation: 8-hour three-arm soak

Beyond the unit tests, this was validated on `documentdb-local:pg17-0.114.0` (PG17 + documentdb extensions). Three arms, same image, environment, network and load, differing **only** in the gateway binary — each verified by md5 inside its container rather than assumed:

| Arm | Gateway binary | First failure | Failures in 8h |
| --- | --- | --- | --- |
| control | stock shipped v0.114.0 (`88921707…`) | **2h05m00.3s** | 43,812 |
| unfixed | local build of unmodified v0.114-0 (`3411723d…`) | **2h05m00.1s** | 43,038 |
| fixed | local build of v0.114-0 + this fix (`dc4de0eb…`) | **none** | **0** |

The fixed arm completed 28,680 operations with zero client errors while its reaper ticked 97 times — so the reaper ran and evaluated the pool every cycle and simply found nothing to evict. Both broken arms were still failing continuously at cutoff.

The `unfixed` arm validates the method rather than the bug: it comes through the same build-and-swap pipeline as `fixed`, so its failing on schedule establishes that a clean `fixed` result is attributable to the fix and not to an artifact of how the binary was produced. Predictions (including the t=7500 s tick) were recorded before the run.

**Recovery and recurrence were demonstrated directly.** A fresh client pointed at the already-broken control arm ran 226 clean operations — authenticating rebuilds the pool — then failed at the very next reaper tick:

```
[05:39:53.202Z] OK   i=225 ok=226 bad=0
[05:39:55.212Z] FAIL i=227 ok=227 bad=1 msg=An unexpected internal error has occurred.
```

That gateway started at 02:19:54.5 Z, so the tick was due at 05:39:54.5 Z — the transition brackets it within two seconds.

Two notes for anyone reproducing this: the client sees `An unexpected internal error has occurred.`, never the pool message, so a client-side detector is blind — grep the **gateway** log. And the failure can present as the workload *hanging* rather than erroring, matching the original report of the database "appearing to become unresponsive."

### Tests

Three regression tests, all failing on the unfixed code:

| Test | File |
| --- | --- |
| `test_last_used_after_acquire_connection_reports_pool_as_recently_used` | `connection_pool.rs` |
| `test_last_used_after_acquire_timeout_connection_reports_pool_as_recently_used` | `connection_pool.rs` |
| `test_clean_unused_pools_with_actively_used_pool_keeps_pool_reachable` | `pool_manager.rs` |

Making them deterministic took some care — a stamp in the wrong unit still decodes to *some* instant near the epoch, so it only becomes distinguishable once the process has been up longer than the offset the bad stamp decodes to (~1.785 s). The new `testing::wait_for_epoch_uptime` helper pins uptime past that point first, making it a controllable input rather than something to wait out.

The pre-existing `test_last_used_with_fresh_pool_returns_recent_instant` covers only a freshly constructed pool, and the regressing commit left the constructor writing the correct encoding — which is why it kept passing throughout.

### Also included

- Changelog entry under v0.117-0.
- An RCA at `docs/rca/2026-07-27-gateway-connection-pool-last-used-regression.md`, including two follow-ups deliberately **not** addressed here: (a) even with correct timestamps, a >2h-idle authenticated client hits the same error because the pool can't be rebuilt without the password — pre-existing behaviour, also present in 0.112; (b) the `EpochClock` updater's runtime-lifetime coupling, which `ttl_cache` and `transaction_store` also depend on. Happy to drop the RCA file from this PR if maintainers would rather it live outside the repo.

### Verification

- 462/462 `documentdb_gateway_core` unit tests pass
- `cargo fmt --all --check` and `cargo clippy -p documentdb_gateway_core --all-targets` clean
- 8h three-arm soak as above

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] DevOps / tooling
- [ ] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Used to trace the regression from the customer report to the introducing commit, build a deterministic reproduction of an uptime-dependent failure, design and run the three-arm soak, and draft the fix, tests, and RCA. All findings were verified against the code and by running the tests and the soak locally; the first candidate fix was rejected after its tests failed, which is what surfaced the `EpochClock` updater lifetime issue documented above.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
