### PR TITLE
proposal(gw): harden pool eviction — recoverable 391 on missing pool + type-owned last-used encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### documentdb v0.117-0 (Unreleased) ###
+* Fix gateway data connection pools being reaped while still in active use once the gateway process had been up for ~2 hours, after which every request for an already-authenticated user failed with an internal error and `Connection pool missing for user.` in the logs. The pool's last-used timestamp was written as seconds since the UNIX epoch but read back as nanoseconds since the process epoch, so it no longer tracked actual usage and the pool reaper compared its idle threshold against process uptime instead. Regression introduced in v0.114-0. *[Bugfix]*
 * Default the RUM index library (`documentdb.rum_library_load_option`) to `require_documentdb_extended_rum` on all supported PostgreSQL versions, instead of only on PG 18+. The option can still be set to `none` to opt out. *[Refactor]*
 
 ### documentdb v0.116-0 (Unreleased) ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### documentdb v0.117-0 (Unreleased) ###
+* Return `ReauthenticationRequired` (error code 391) instead of an opaque internal error when a request arrives for a user whose gateway connection pool has been released (e.g. reaped after the idle threshold). Clients can recover by re-authenticating; previously the only recourse was a manual reconnect. *[Bugfix]*
 * Fix gateway data connection pools being reaped while still in active use once the gateway process had been up for ~2 hours, after which every request for an already-authenticated user failed with an internal error and `Connection pool missing for user.` in the logs. The pool's last-used timestamp was written as seconds since the UNIX epoch but read back as nanoseconds since the process epoch, so it no longer tracked actual usage and the pool reaper compared its idle threshold against process uptime instead. Regression introduced in v0.114-0. *[Bugfix]*
 * Default the RUM index library (`documentdb.rum_library_load_option`) to `require_documentdb_extended_rum` on all supported PostgreSQL versions, instead of only on PG 18+. The option can still be set to `none` to opt out. *[Refactor]*
 

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/connection_pool.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/connection_pool.rs
@@ -9,10 +9,7 @@
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    sync::Arc,
 };
 
 use deadpool::{
@@ -42,7 +39,7 @@ use crate::{
         QueryCatalog,
     },
     telemetry::TracingConfig,
-    time,
+    time::AtomicInstant,
 };
 
 fn pg_configuration(
@@ -147,16 +144,13 @@ pub struct ConnectionPool {
     /// `RecyclingMethod::Clean` to reset all session state when a
     /// connection is returned
     timeout_pool: DeadpoolPool<InstrumentedManager>,
-    /// Nanosecond offset from the process epoch of the last
-    /// `acquire_connection` call. Only ever written through
-    /// [`ConnectionPool::touch_last_used`] and read through
-    /// [`ConnectionPool::last_used`], which own that encoding — writing a
-    /// timestamp in any other unit or base here silently corrupts every
-    /// idleness decision made about this pool.
-    ///
-    /// Uses `AtomicU64` instead of `RwLock<Instant>` to avoid async lock
-    /// overhead on the hot acquire path.
-    last_used_nanos: AtomicU64,
+    /// Instant of the last `acquire_connection` call, the sole input to the
+    /// pool reaper's idleness decision. [`AtomicInstant`] owns the encoding,
+    /// so a timestamp in the wrong unit or base cannot be written here — the
+    /// v0.114 regression that evicted in-use pools after 2h of uptime is
+    /// unrepresentable at this call site. Lock-free to keep async lock
+    /// overhead off the hot acquire path.
+    last_used: AtomicInstant,
     metrics: Arc<ConnectionPoolMetrics>,
     identifier: String,
     prune_task: JoinHandle<()>,
@@ -258,9 +252,7 @@ impl ConnectionPool {
         Ok(Self {
             pool,
             timeout_pool,
-            // Use the exact `Instant::now()` at pool creation time to avoid reporting
-            // an earlier cached timestamp for a freshly constructed pool.
-            last_used_nanos: AtomicU64::new(time::instant_to_u64(Instant::now())),
+            last_used: AtomicInstant::now(),
             metrics,
             identifier: pool_identifier,
             prune_task,
@@ -337,28 +329,15 @@ impl ConnectionPool {
         self.metrics.record_connection_timeout();
     }
 
-    /// Marks the pool as used as of now.
-    ///
-    /// Deliberately uses the precise `Instant::now()` rather than either of the
-    /// `EpochClock` coarse readings. This stamp is the sole input to the pool
-    /// reaper, so it must not depend on the coarse clock's updater task still
-    /// being alive on the runtime that happened to initialise it, and it must
-    /// stay in the encoding [`Self::last_used`] decodes: nanoseconds since the
-    /// process epoch. `EpochClock::almost_now_timestamp()` in particular looks
-    /// interchangeable here and is not — it returns *seconds since the UNIX
-    /// epoch*, which decodes as a point roughly two seconds after process start
-    /// that then advances by a nanosecond per second, making every pool look
-    /// idle for as long as the process has been up.
-    ///
-    /// The `Instant::now()` syscall costs ~20ns against a call that goes on to
-    /// check out a pooled connection, so the coarse clock buys nothing here.
+    /// Marks the pool as used as of now. See [`AtomicInstant`] for why the
+    /// stamp is written with the precise clock and why the encoding is owned
+    /// by the cell rather than this call site.
     fn touch_last_used(&self) {
-        self.last_used_nanos
-            .store(time::instant_to_u64(Instant::now()), Ordering::Relaxed);
+        self.last_used.store_now();
     }
 
     pub fn last_used(&self) -> Instant {
-        time::u64_to_instant(self.last_used_nanos.load(Ordering::Relaxed))
+        self.last_used.load()
     }
 
     /// Whether sampled queries from this pool should carry a `SQLCommenter`

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/connection_pool.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/connection_pool.rs
@@ -42,7 +42,7 @@ use crate::{
         QueryCatalog,
     },
     telemetry::TracingConfig,
-    time::{self, EpochClock},
+    time,
 };
 
 fn pg_configuration(
@@ -147,7 +147,13 @@ pub struct ConnectionPool {
     /// `RecyclingMethod::Clean` to reset all session state when a
     /// connection is returned
     timeout_pool: DeadpoolPool<InstrumentedManager>,
-    /// Nanosecond offset from `EPOCH` of the last `acquire_connection` call.
+    /// Nanosecond offset from the process epoch of the last
+    /// `acquire_connection` call. Only ever written through
+    /// [`ConnectionPool::touch_last_used`] and read through
+    /// [`ConnectionPool::last_used`], which own that encoding — writing a
+    /// timestamp in any other unit or base here silently corrupts every
+    /// idleness decision made about this pool.
+    ///
     /// Uses `AtomicU64` instead of `RwLock<Instant>` to avoid async lock
     /// overhead on the hot acquire path.
     last_used_nanos: AtomicU64,
@@ -278,8 +284,7 @@ impl ConnectionPool {
     pub async fn acquire_connection(
         &self,
     ) -> std::result::Result<PoolConnection, deadpool_postgres::PoolError> {
-        self.last_used_nanos
-            .store(EpochClock::almost_now_timestamp(), Ordering::Relaxed);
+        self.touch_last_used();
 
         self.pool.get().await.inspect_err(|error| {
             self.metrics.record_timeout_if_pool_timeout(error);
@@ -306,8 +311,7 @@ impl ConnectionPool {
     pub async fn acquire_timeout_connection(
         &self,
     ) -> std::result::Result<PoolConnection, deadpool_postgres::PoolError> {
-        self.last_used_nanos
-            .store(EpochClock::almost_now_timestamp(), Ordering::Relaxed);
+        self.touch_last_used();
 
         self.timeout_pool.get().await.inspect_err(|error| {
             self.metrics.record_timeout_if_pool_timeout(error);
@@ -331,6 +335,26 @@ impl ConnectionPool {
     #[cfg(test)]
     pub(crate) fn record_connection_timeout(&self) {
         self.metrics.record_connection_timeout();
+    }
+
+    /// Marks the pool as used as of now.
+    ///
+    /// Deliberately uses the precise `Instant::now()` rather than either of the
+    /// `EpochClock` coarse readings. This stamp is the sole input to the pool
+    /// reaper, so it must not depend on the coarse clock's updater task still
+    /// being alive on the runtime that happened to initialise it, and it must
+    /// stay in the encoding [`Self::last_used`] decodes: nanoseconds since the
+    /// process epoch. `EpochClock::almost_now_timestamp()` in particular looks
+    /// interchangeable here and is not — it returns *seconds since the UNIX
+    /// epoch*, which decodes as a point roughly two seconds after process start
+    /// that then advances by a nanosecond per second, making every pool look
+    /// idle for as long as the process has been up.
+    ///
+    /// The `Instant::now()` syscall costs ~20ns against a call that goes on to
+    /// check out a pooled connection, so the coarse clock buys nothing here.
+    fn touch_last_used(&self) {
+        self.last_used_nanos
+            .store(time::instant_to_u64(Instant::now()), Ordering::Relaxed);
     }
 
     pub fn last_used(&self) -> Instant {
@@ -391,8 +415,13 @@ mod tests {
 
     use crate::{
         postgres::create_query_catalog,
-        testing::{test_connection_pool, test_setup_configuration},
+        testing::{test_connection_pool, test_setup_configuration, wait_for_epoch_uptime},
     };
+
+    /// Long enough that a stamp written in the wrong unit or base cannot look
+    /// recent: such a stamp decodes to roughly two seconds past the epoch and
+    /// then stays effectively frozen there.
+    const EPOCH_UPTIME_FOR_IDLENESS_ASSERTS: Duration = Duration::from_secs(5);
 
     #[tokio::test]
     async fn test_new_with_user_with_valid_config_creates_pool() {
@@ -523,6 +552,46 @@ mod tests {
 
         assert!(pool.last_used() >= before);
         assert!(pool.last_used().elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_last_used_after_acquire_connection_reports_pool_as_recently_used() {
+        let setup_config = test_setup_configuration();
+        let pool =
+            test_connection_pool(&setup_config, &setup_config.postgres_system_user.clone(), 2)
+                .await;
+
+        wait_for_epoch_uptime(EPOCH_UPTIME_FOR_IDLENESS_ASSERTS).await;
+
+        // The last-used stamp is written before the pool is touched, so whether
+        // a local Postgres is reachable does not affect what is asserted here.
+        let _ = pool.acquire_connection().await;
+
+        let idle_for = pool.last_used().elapsed();
+        assert!(
+            idle_for < Duration::from_secs(1),
+            "a just-acquired pool must not look idle, but last_used() reports {idle_for:?} of \
+             idleness"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_last_used_after_acquire_timeout_connection_reports_pool_as_recently_used() {
+        let setup_config = test_setup_configuration();
+        let pool =
+            test_connection_pool(&setup_config, &setup_config.postgres_system_user.clone(), 2)
+                .await;
+
+        wait_for_epoch_uptime(EPOCH_UPTIME_FOR_IDLENESS_ASSERTS).await;
+
+        let _ = pool.acquire_timeout_connection().await;
+
+        let idle_for = pool.last_used().elapsed();
+        assert!(
+            idle_for < Duration::from_secs(1),
+            "a just-acquired pool must not look idle, but last_used() reports {idle_for:?} of \
+             idleness"
+        );
     }
 
     #[test]

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
@@ -342,6 +342,7 @@ mod tests {
         configuration::{CertInputType, CertificateOptions, DocumentDBSetupConfiguration},
         error::{ErrorCode, ErrorKind},
         postgres::create_query_catalog,
+        testing::wait_for_epoch_uptime,
     };
 
     #[derive(Debug)]
@@ -747,6 +748,44 @@ mod tests {
 
         // only 2 system pools should remain since user and shared pools are expired
         assert_eq!(2, pool_manager.report_pool_stats().len());
+    }
+
+    #[tokio::test]
+    async fn test_clean_unused_pools_with_actively_used_pool_keeps_pool_reachable() {
+        yield_now().await;
+
+        let dynamic_configuration = MaxConnectionConfig {
+            max_conn: 100.into(),
+        };
+        let pool_manager = test_pool_manager();
+
+        pool_manager
+            .allocate_data_pool("user", "password", &dynamic_configuration)
+            .unwrap();
+
+        wait_for_epoch_uptime(Duration::from_secs(5)).await;
+
+        // Drive the pool the way a live request does. The acquisition itself may
+        // fail without a local Postgres, but the last-used stamp is written
+        // before the pool is touched, which is what the reaper reads.
+        let _ = pool_manager
+            .get_data_pool("user", &dynamic_configuration)
+            .unwrap()
+            .acquire_connection()
+            .await;
+
+        pool_manager.clean_unused_pools(Duration::from_secs(1));
+
+        // The reaper has to key off how long a pool has been idle, not off how
+        // long the process has been running. Evicting a pool that is still in
+        // active use makes every subsequent request for that user fail with
+        // "Connection pool missing for user." until the client re-authenticates.
+        assert!(
+            pool_manager
+                .get_data_pool("user", &dynamic_configuration)
+                .is_ok(),
+            "a data pool that was just used was reaped as unused"
+        );
     }
 
     #[tokio::test]

--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
@@ -114,7 +114,19 @@ impl PoolManager {
     }
 
     /// # Errors
-    /// Returns error if the operation fails.
+    /// Returns [`ErrorCode::ReauthenticationRequired`] (wire code 391) if no
+    /// pool exists for the user.
+    ///
+    /// A missing pool is not an internal fault: pools are created at
+    /// authentication (the only point where the user's password is available)
+    /// and legitimately disappear when [`Self::clean_unused_pools`] disposes
+    /// of one that has sat idle past its threshold. The gateway cannot rebuild
+    /// it on its own — but the client can, by re-authenticating. Surfacing 391
+    /// tells the driver exactly that, instead of the previous
+    /// `InternalError`, which presented to clients as "An unexpected internal
+    /// error has occurred." with no recovery path short of a manual reconnect.
+    ///
+    /// [`ErrorCode::ReauthenticationRequired`]: crate::error::ErrorCode::ReauthenticationRequired
     pub fn get_data_pool(
         &self,
         username: &str,
@@ -123,9 +135,16 @@ impl PoolManager {
         let settings = PgPoolSettings::from_configuration(dynamic_configuration);
 
         match self.user_data_pools.get(&(username.to_owned(), settings)) {
-            None => Err(DocumentDBError::internal_error(
-                "Connection pool missing for user.".to_owned(),
-            )),
+            None => {
+                tracing::warn!(
+                    event_id = EventId::ConnectionPool.code(),
+                    "Connection pool missing for user; requesting client re-authentication."
+                );
+                Err(DocumentDBError::reauthentication_required(
+                    "Connection pool for this session was released. Please re-authenticate."
+                        .to_owned(),
+                ))
+            }
             Some(pool_ref) => Ok(Arc::clone(pool_ref.value())),
         }
     }
@@ -610,7 +629,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_data_pool_with_missing_user_returns_internal_error() {
+    async fn test_get_data_pool_with_missing_user_returns_reauthentication_required() {
         // We still need an async context to create the connection pool (see ConnectionPool::new_with_user),
         // but the test itself doesn't need to be async since we are not awaiting anything after the pool creation,
         // so we can use yield_now to just get into async context and then proceed with sync code.
@@ -626,7 +645,40 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.kind(), &ErrorKind::Gateway);
-        assert_eq!(err.error_code(), ErrorCode::InternalError);
+        assert_eq!(err.error_code(), ErrorCode::ReauthenticationRequired);
+    }
+
+    #[tokio::test]
+    async fn test_get_data_pool_after_eviction_recovers_via_reauthentication() {
+        yield_now().await;
+
+        let dynamic_configuration = MaxConnectionConfig {
+            max_conn: 100.into(),
+        };
+        let pool_manager = test_pool_manager();
+
+        pool_manager
+            .allocate_data_pool("user", "password", &dynamic_configuration)
+            .unwrap();
+        sleep(Duration::from_millis(1)).await;
+        pool_manager.clean_unused_pools(Duration::from_millis(0));
+
+        // An evicted pool must surface as a re-authentication request, not an
+        // internal error: the client can recover from 391, but has no recourse
+        // against "An unexpected internal error has occurred."
+        let err = pool_manager
+            .get_data_pool("user", &dynamic_configuration)
+            .unwrap_err();
+        assert_eq!(err.error_code(), ErrorCode::ReauthenticationRequired);
+
+        // Re-authenticating re-allocates the pool, completing the recovery
+        // cycle the 391 asks the client to perform.
+        pool_manager
+            .allocate_data_pool("user", "password", &dynamic_configuration)
+            .unwrap();
+        pool_manager
+            .get_data_pool("user", &dynamic_configuration)
+            .expect("pool should be reachable again after re-authentication");
     }
 
     #[tokio::test]

--- a/pg_documentdb_gw/documentdb_gateway_core/src/testing/mod.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/testing/mod.rs
@@ -24,7 +24,7 @@ pub use op_msg::{
     build_document_sequence_section, build_op_msg_parts, build_op_msg_parts_with_sections,
     build_op_msg_request, build_raw_document, decode_op_msg_response, decode_op_msg_responses,
 };
-pub use pool::{test_connection_pool, test_setup_configuration};
+pub use pool::{test_connection_pool, test_setup_configuration, wait_for_epoch_uptime};
 pub use request_documents::{
     invalid_transaction_find_document, logout_document, malformed_sasl_start_document,
     ping_document,

--- a/pg_documentdb_gw/documentdb_gateway_core/src/testing/pool.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/testing/pool.rs
@@ -9,7 +9,10 @@
  *-------------------------------------------------------------------------
  */
 
-use tokio::task::yield_now;
+use tokio::{
+    task::yield_now,
+    time::{sleep, Duration},
+};
 
 use crate::{
     configuration::{CertInputType, CertificateOptions, DocumentDBSetupConfiguration},
@@ -17,6 +20,7 @@ use crate::{
         conn_mgmt::{ConnectionPool, PgPoolSettings},
         create_query_catalog,
     },
+    time::EpochClock,
 };
 
 /// Returns a baseline `DocumentDBSetupConfiguration` suitable for connection
@@ -67,4 +71,19 @@ pub async fn test_connection_pool(
         PgPoolSettings::system_pool_settings(max_connections),
     )
     .expect("Failed to create connection pool")
+}
+
+/// Waits until the process-wide [`EpochClock`] epoch is at least `uptime` old.
+///
+/// `ConnectionPool::last_used` decodes its stored stamp as a nanosecond offset
+/// from that epoch. A stamp accidentally written in a different unit or base
+/// still decodes to *some* instant close to the epoch, so it only becomes
+/// distinguishable from a correct stamp once the process has been running for
+/// longer than the offset the bogus stamp decodes to. Tests that assert on pool
+/// idleness use this to get a deterministic result instead of one that depends
+/// on how far into the test binary's lifetime they happen to run.
+pub async fn wait_for_epoch_uptime(uptime: Duration) {
+    if let Some(remaining) = uptime.checked_sub(EpochClock::epoch().elapsed()) {
+        sleep(remaining).await;
+    }
 }

--- a/pg_documentdb_gw/documentdb_gateway_core/src/time/mod.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/time/mod.rs
@@ -6,7 +6,10 @@
  *-------------------------------------------------------------------------
  */
 
-use std::sync::OnceLock;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    OnceLock,
+};
 
 use tokio::time::{Duration, Instant};
 
@@ -25,6 +28,42 @@ pub fn instant_to_u64(instant: Instant) -> u64 {
 #[must_use]
 pub fn u64_to_instant(nanos: u64) -> Instant {
     EpochClock::epoch() + Duration::from_nanos(nanos)
+}
+
+/// A lock-free timestamp cell that can only hold "now".
+///
+/// Owns its wire encoding (nanoseconds since [`EpochClock::epoch`]) entirely:
+/// callers can store the current instant and load an [`Instant`] back, but can
+/// never supply a raw integer. This makes the class of bug where a timestamp in
+/// a different unit or base is written into an atomic and silently mis-decoded
+/// on read — the cause of the v0.114 connection-pool reaper regression —
+/// unrepresentable at the call site.
+///
+/// Writes use the precise `Instant::now()` (~20ns) rather than the coarse
+/// `EpochClock` readings: the coarse clock's updater is a tokio task bound to
+/// whichever runtime first initialised the global clock, and a liveness
+/// decision must not depend on that task still running.
+#[derive(Debug)]
+pub struct AtomicInstant(AtomicU64);
+
+impl AtomicInstant {
+    /// Creates a cell initialised to the current instant.
+    #[must_use]
+    pub fn now() -> Self {
+        Self(AtomicU64::new(instant_to_u64(Instant::now())))
+    }
+
+    /// Overwrites the cell with the current instant.
+    pub fn store_now(&self) {
+        self.0
+            .store(instant_to_u64(Instant::now()), Ordering::Relaxed);
+    }
+
+    /// Returns the most recently stored instant.
+    #[must_use]
+    pub fn load(&self) -> Instant {
+        u64_to_instant(self.0.load(Ordering::Relaxed))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

**Proposal PR** — follow-up to #690, for gateway-team discussion. Stacks on that branch: the first commit here is #690's hotfix and will drop out on rebase once it merges. The two new commits implement the parts of the longer-term hardening that are small enough to review as code; the third piece is sketched below for discussion before anyone writes it.

This PR intentionally carries the full RCA in its description (below) rather than as a file in the repo, per review feedback on #690 that an RCA document doesn't belong in the OSS tree.

## What this PR adds on top of the hotfix

### 1. `fix(gw)`: missing user pool → `ReauthenticationRequired` (391), not `InternalError`

A missing data pool is not an internal fault. Pools are created at authentication — the only point where the user's password is available — and legitimately disappear when the reaper disposes of one idle past its 2h threshold. The gateway cannot rebuild the pool on its own, **but the client can, by re-authenticating.** Previously `get_data_pool` returned `InternalError`, which reaches clients as `An unexpected internal error has occurred.` with no recovery path: in the soak run below, a connection that hit this state failed **193 consecutive operations** and never recovered until re-auth.

Returning wire code **391** (`ReauthenticationRequired`, already plumbed through the gateway's error machinery and used for expired identity tokens) converts every variant of this state — a legitimately reaped idle pool, or any future eviction bug — from an opaque outage into an actionable request. Note this gap **predates the v0.114 regression and exists on v0.112**: any client that authenticates and then idles >2h hits it today.

### 2. `refactor(gw)`: the last-used stamp becomes an `AtomicInstant` type

The regression was possible because the stamp was a bare `AtomicU64` whose encoding lived in a comment, while the clock API offers two `u64`-shaped readings with different units *and* bases that look interchangeable at a call site. The hotfix narrowed the field to one writer/one reader with warning comments; this goes the rest of the way: `AtomicInstant` is a lock-free cell that can only hold "now" — callers store the current instant and load an `Instant` back, and **can never supply a raw integer in any unit**. The bug class becomes unrepresentable, and the manual encode/decode disappears from `conn_mgmt` entirely.

### 3. Sketch only — evict on ground truth, not a proxy (requesting discussion)

The reaper currently asks *"when was this pool last touched?"* as a proxy for *"is anyone using this?"* — but the gateway holds the ground truth: connection contexts know which authenticated users have live connections. Tying eviction to **live-session count per user** (plus a grace period) would make the timestamp heuristic, and its entire category of encoding bugs, unnecessary.

This is also, I think, the constructive form of the session-idle-timeout point raised in review discussion: session lifecycle *should* drive pool cleanup — the current design's flaw is that it doesn't consult sessions at all (the pool is keyed by username; reaping an `lsid` doesn't touch it). Not implemented here because it needs a decision about where the per-user connection count lives and how it interacts with `max_connections`; if the team likes the direction I'll draft it as its own PR.

---

## RCA (moved here from the repo file, per feedback)

### Symptom

On v0.114+, any gateway process stays healthy until ~2h of uptime, then every request from already-authenticated users fails. Clients see `An unexpected internal error has occurred.` or a hang; the gateway log shows `Connection pool missing for user.` Recurs every ~5 min for the life of the process. Reported by an external user whose 12–48h soak harness passed on 0.112 and failed at ~2h on 0.114 across multiple machines.

### Root cause — three layers

**Proximate:** `last_used_nanos` is decoded as *nanoseconds since the process epoch*, but commit `f02641fe` wrote it with `EpochClock::almost_now_timestamp()` — *seconds since the UNIX epoch*. Decoded, the stamp freezes ~1.785s after process start. `last_used().elapsed()` therefore measured **process uptime, not pool idleness**, and the reaper (300s ticks, 7200s threshold) evicted every user data pool once uptime passed the threshold: the t=7200s tick reads 7198.2s and spares the pool; the **t=7500s tick evicts it → first failure at exactly 2h05m of uptime**.

**Enabling:** the type system never saw the bug. Two clock functions return `u64`-shaped values in different units and bases; the field's contract lived in a doc comment; the atomic erased the rest. A careful reviewer approved the regressing PR because there was nothing visibly wrong at the call site. (Commit 2 of this PR addresses exactly this.)

**Systemic:** pool lifetime is governed by a proxy heuristic while the gateway holds ground truth, and eviction sits on an **unrecoverable cliff** — `get_data_pool` can't rebuild without the password, so any eviction of a still-referenced pool becomes an opaque outage. The timestamp bug was the trigger; the cliff is what made it a customer-visible catastrophe. (Commit 1 removes the cliff; sketch 3 removes the proxy.)

### Why 2h05m exactly

| Quantity | Value |
| --- | --- |
| Frozen stamp decodes to | epoch + ~1.785s |
| Reaper tick / threshold | 300s / 7200s |
| Condition first true | ~7201.8s uptime |
| **First eviction (next tick)** | **t=7500s = 2h05m00s** |

Measured, not estimated: two independent broken builds first failed at **2h05m00.3s** and **2h05m00.1s** of gateway uptime. Consequence for testing: *a 2-hour run sits below the trigger and passes on a fully broken build.* Ask for 3 hours of continuous gateway uptime.

### Empirical validation — 8h three-arm soak

Three arms on `documentdb-local:pg17-0.114.0`, identical image/env/load, differing **only** in the gateway binary (verified by md5 in each container). Predictions, including the t=7500s tick, were recorded before the run.

| Arm | Binary | First failure | Failures in 8h |
| --- | --- | --- | --- |
| control | stock shipped v0.114.0 | **2h05m00.3s** | 43,812 |
| unfixed | local build of unmodified v0.114-0 | **2h05m00.1s** | 43,038 |
| fixed | local build + #690's hotfix | none | **0** (28,680 ops; reaper ticked 97×) |

The `unfixed` arm validates the method: same build-and-swap pipeline as `fixed`, so its on-schedule failure attributes the clean result to the fix, not the pipeline. Load was one long-lived authenticated connection per arm at 1 op/s — long-lived because `get_data_pool` only fails for clients authenticated *before* eviction; per-op reconnects would re-allocate the pool and mask the bug.

**Recovery/recurrence observed directly:** a fresh client on the broken control arm ran 226 clean ops (re-auth rebuilds the pool), then failed at the next predicted reaper tick — `OK` at 05:39:53.2Z, `FAIL` at 05:39:55.2Z, tick due 05:39:54.5Z. The failing connection was **3.8 minutes old**, and once broken never self-healed (193 consecutive failures).

### On the session-idle-timeout question

Raised in review: could this be about connections outliving MongoDB's 30-minute session idle timeout? The soak data says no on every axis: the failing connection was 3.8 minutes old (only needs to outlive one 5-min reaper tick); the load client was never idle (1 op/s) and was evicted anyway; the pool is keyed by username, not `lsid`, so session reaping doesn't touch it; and granting 30-min recycling arithmetic still fails ~92% of operations (first tick lands ~150s after auth, everything fails until recycle at 1800s). The "2 hours" is process uptime — a different clock from connection age entirely.

### Detection gaps worth keeping

- The client never sees the pool message — only `An unexpected internal error has occurred.` A client-side detector is blind; grep the **gateway** log. (An early watcher in this investigation did exactly that and reported a false negative for 3 hours while the bug reproduced perfectly.)
- The failure can present as the workload **hanging**, matching the original "appears to become unresponsive" report.
- Nothing in CI runs long enough to see uptime-dependent failures. The regression tests in #690 close this specific gap by making uptime a controllable input (`wait_for_epoch_uptime`) instead of something to wait out.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring / code cleanup
- [ ] DevOps / tooling
- [ ] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Traced the regression to the introducing commit, designed and ran the three-arm soak, and drafted the fixes, tests, RCA, and this proposal. All findings verified against code and by running tests and the soak locally.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
