### PR TITLE
documentdb-local: ship a built-in health check and a docker-compose example

### DIFF
--- a/documentdb-local/examples/docker-compose/.env.example
+++ b/documentdb-local/examples/docker-compose/.env.example
@@ -1,4 +1,0 @@
-# Copy this file to .env (same directory as docker-compose.yml) and fill in
-# your credentials; docker compose reads .env automatically.
-DOCUMENTDB_USERNAME=
-DOCUMENTDB_PASSWORD=

--- a/documentdb-local/examples/docker-compose/.env.example
+++ b/documentdb-local/examples/docker-compose/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env (same directory as docker-compose.yml) and fill in
+# your credentials; docker compose reads .env automatically.
+DOCUMENTDB_USERNAME=
+DOCUMENTDB_PASSWORD=

--- a/documentdb-local/examples/docker-compose/README.md
+++ b/documentdb-local/examples/docker-compose/README.md
@@ -13,7 +13,7 @@ cd documentdb-local/examples/docker-compose
 # 1. Generate credentials for this run. They live only in your shell
 #    environment -- nothing is written to disk, and you get a fresh secret
 #    every time rather than reusing one committed to a file.
-export DOCUMENTDB_USERNAME=documentdb_user
+export DOCUMENTDB_USERNAME=appuser
 export DOCUMENTDB_PASSWORD="$(openssl rand -base64 24)"
 
 # 2. Start DocumentDB
@@ -33,6 +33,11 @@ mongosh "mongodb://localhost:10260/?tls=true&tlsAllowInvalidCertificates=true" \
 start with a clear error if either is unset, so an unconfigured stack cannot
 silently come up on the image's well-known default credentials.
 
+Pick any username that does not start with a reserved role prefix —
+`documentdb`, `citus`, `pg` or `internal_role`. The gateway would refuse such
+a name at authentication time, so the container rejects it at startup rather
+than coming up with a login that can never work.
+
 Because the password is generated per run, treat the stack as disposable: to
 rotate credentials, tear it down (`docker compose down -v`, which also clears
 the data volume) and repeat step 1. Restarting an existing stack with a new
@@ -46,6 +51,12 @@ The image ships a built-in health probe at
 [`documentdb-local/scripts/healthcheck.sh`](../../scripts/healthcheck.sh)),
 so this compose file needs no `healthcheck:` block. The probe reports
 healthy only when all of the following hold:
+
+> **Image requirement:** the probe ships with the image, so `:latest` reports
+> health only from the first release that contains it. On an older image the
+> container has no health state, and anything gated on `service_healthy` —
+> including the `wait-for-healthy` service below — cannot start. Pull a fresh
+> `:latest` (or build the image from this source tree) before relying on it.
 
 1. **Startup completed** — the entrypoint publishes its resolved runtime
    settings to `/tmp/documentdb-local-runtime.env` only after initialization
@@ -62,9 +73,14 @@ tracks a non-default port whether you set it via the `DOCUMENTDB_PORT`
 environment variable or the `--documentdb-port` CLI flag.
 
 Default timings (override with a `healthcheck:` block if needed):
-`interval=30s`, `timeout=10s`, `retries=3`, `start_period=120s`. The start
-period covers first-boot database initialization on slow machines; failing
-probes during it do not count toward `retries`.
+`interval=30s`, `timeout=10s`, `retries=3`, `start_period=600s`. The start
+period matches the entrypoint's own 600s budget for PostgreSQL to come up, so
+a slow first boot on a cold volume is never reported unhealthy before the
+entrypoint itself gives up — which matters because `depends_on:
+condition: service_healthy` aborts the dependent service as soon as the
+dependency turns unhealthy. It does not delay a fast boot: failing probes
+during the start period do not count toward `retries`, and the first
+succeeding probe ends it.
 
 To inspect health status and the probe's last output:
 

--- a/documentdb-local/examples/docker-compose/README.md
+++ b/documentdb-local/examples/docker-compose/README.md
@@ -1,0 +1,113 @@
+# Running DocumentDB Local with Docker Compose
+
+A ready-to-use `docker compose` setup for the
+[`documentdb-local`](https://github.com/documentdb/documentdb) image, with a
+container health check, persistent storage, and an optional smoke test.
+
+## Quick start
+
+```bash
+cd documentdb-local/examples/docker-compose
+
+# 1. Set your credentials
+cp .env.example .env
+$EDITOR .env
+
+# 2. Start DocumentDB
+docker compose up -d
+
+# 3. Wait for it to report healthy
+docker compose ps
+# NAME                        ...   STATUS
+# docker-compose-documentdb-1 ...   Up 45 seconds (healthy)
+
+# 4. Connect (from the host)
+mongosh "mongodb://localhost:10260/?tls=true&tlsAllowInvalidCertificates=true" \
+    --username <your-username> --password <your-password>
+```
+
+Or run the bundled one-shot connectivity check, which waits for the health
+check before connecting:
+
+```bash
+docker compose run --rm smoke-test
+```
+
+## The health check
+
+The image ships a built-in health probe at
+`/usr/local/bin/documentdb-healthcheck` (source:
+[`documentdb-local/scripts/healthcheck.sh`](../../scripts/healthcheck.sh)),
+so this compose file needs no `healthcheck:` block. The probe reports
+healthy only when all of the following hold:
+
+1. **Startup completed** — the entrypoint publishes its resolved runtime
+   settings to `/tmp/documentdb-local-runtime.env` only after initialization
+   (including sample/custom data seeding) finishes. Services gated on
+   `depends_on: condition: service_healthy` therefore never see a
+   half-initialized database.
+2. **PostgreSQL accepts connections** (when the container runs the bundled
+   PostgreSQL, i.e. the default `START_POSTGRESQL=true`).
+3. **The gateway completes a TLS handshake** on the DocumentDB port. The
+   gateway serves TLS in every `tlsMode`, so the probe is valid in all modes.
+
+Because the probe reads the entrypoint's published state, it automatically
+tracks a non-default port whether you set it via the `DOCUMENTDB_PORT`
+environment variable or the `--documentdb-port` CLI flag.
+
+Default timings (override with a `healthcheck:` block if needed):
+`interval=30s`, `timeout=10s`, `retries=3`, `start_period=120s`. The start
+period covers first-boot database initialization on slow machines; failing
+probes during it do not count toward `retries`.
+
+To inspect health status and the probe's last output:
+
+```bash
+docker inspect --format '{{json .State.Health}}' <container> | jq
+```
+
+## Waiting for DocumentDB in your own services
+
+Add a `depends_on` condition to any service that needs the database (see the
+`smoke-test` service in [`docker-compose.yml`](docker-compose.yml) for a full
+example):
+
+```yaml
+services:
+  my-app:
+    depends_on:
+      documentdb:
+        condition: service_healthy
+```
+
+Inside the compose network, connect to `documentdb:10260` (the service
+name), with `tls=true&tlsAllowInvalidCertificates=true` — the emulator's
+auto-generated certificate is self-signed.
+
+## Data persistence
+
+Data lives in the named volume `documentdb-data`, mounted at `/data`, and
+survives `docker compose down` / `up`. To start over from scratch (which
+also re-runs data initialization):
+
+```bash
+docker compose down -v
+```
+
+## Seeding data
+
+- **Built-in sample data:** add `INIT_DATA: "true"` to the `environment:`
+  block to load the sample `sampledb` database on first boot.
+- **Your own scripts:** uncomment the `./init-data:/init_doc_db.d:ro` volume
+  in `docker-compose.yml` and put `.js` files (run with mongosh, in
+  alphabetical order) in `./init-data/`.
+
+Both run once per fresh data volume; recreate the volume (`down -v`) to
+re-seed.
+
+## Changing the port
+
+To publish a different host port, change only the left side of the mapping
+(e.g. `"27017:10260"`). To change the port inside the container as well, set
+`DOCUMENTDB_PORT` in the `environment:` block and update both sides of the
+mapping — the health check picks up the new port automatically.

--- a/documentdb-local/examples/docker-compose/README.md
+++ b/documentdb-local/examples/docker-compose/README.md
@@ -2,16 +2,19 @@
 
 A ready-to-use `docker compose` setup for the
 [`documentdb-local`](https://github.com/documentdb/documentdb) image, with a
-container health check, persistent storage, and an optional smoke test.
+container health check, persistent storage, and readiness gating for dependent
+services.
 
 ## Quick start
 
 ```bash
 cd documentdb-local/examples/docker-compose
 
-# 1. Set your credentials
-cp .env.example .env
-$EDITOR .env
+# 1. Generate credentials for this run. They live only in your shell
+#    environment -- nothing is written to disk, and you get a fresh secret
+#    every time rather than reusing one committed to a file.
+export DOCUMENTDB_USERNAME=documentdb_user
+export DOCUMENTDB_PASSWORD="$(openssl rand -base64 24)"
 
 # 2. Start DocumentDB
 docker compose up -d
@@ -21,17 +24,20 @@ docker compose ps
 # NAME                        ...   STATUS
 # docker-compose-documentdb-1 ...   Up 45 seconds (healthy)
 
-# 4. Connect (from the host)
+# 4. Connect (from the host), using the credentials generated in step 1
 mongosh "mongodb://localhost:10260/?tls=true&tlsAllowInvalidCertificates=true" \
     --username <your-username> --password <your-password>
 ```
 
-Or run the bundled one-shot connectivity check, which waits for the health
-check before connecting:
+`docker compose` reads both variables from your environment; it refuses to
+start with a clear error if either is unset, so an unconfigured stack cannot
+silently come up on the image's well-known default credentials.
 
-```bash
-docker compose run --rm smoke-test
-```
+Because the password is generated per run, treat the stack as disposable: to
+rotate credentials, tear it down (`docker compose down -v`, which also clears
+the data volume) and repeat step 1. Restarting an existing stack with a new
+password will not change the already-provisioned user — that user is created
+once, on a fresh data volume.
 
 ## The health check
 
@@ -68,9 +74,7 @@ docker inspect --format '{{json .State.Health}}' <container> | jq
 
 ## Waiting for DocumentDB in your own services
 
-Add a `depends_on` condition to any service that needs the database (see the
-`smoke-test` service in [`docker-compose.yml`](docker-compose.yml) for a full
-example):
+Add a `depends_on` condition to any service that needs the database:
 
 ```yaml
 services:
@@ -80,9 +84,21 @@ services:
         condition: service_healthy
 ```
 
+The `wait-for-healthy` service in [`docker-compose.yml`](docker-compose.yml)
+is a runnable example of exactly that — it blocks until the health check
+passes, then exits:
+
+```bash
+docker compose run --rm wait-for-healthy
+```
+
+Swap in your own image and command to turn it into your application service.
+
 Inside the compose network, connect to `documentdb:10260` (the service
 name), with `tls=true&tlsAllowInvalidCertificates=true` — the emulator's
-auto-generated certificate is self-signed.
+auto-generated certificate is self-signed. Pass the credentials to your
+service the same way this file does, via the environment, so they stay out of
+your compose file and out of your image.
 
 ## Data persistence
 

--- a/documentdb-local/examples/docker-compose/docker-compose.yml
+++ b/documentdb-local/examples/docker-compose/docker-compose.yml
@@ -1,5 +1,9 @@
-# DocumentDB Local via docker compose. See README.md in this directory for
-# the full walkthrough (credentials, health check, persistence, seeding).
+# DocumentDB Local via docker compose. See README.md in this directory for the
+# full walkthrough (credentials, health check, persistence, seeding).
+#
+# Credentials are read from the environment and are meant to be generated
+# fresh for every run, so no credential is ever stored in this directory.
+# README.md shows the one-liner that generates them.
 
 services:
   documentdb:
@@ -7,10 +11,10 @@ services:
     ports:
       - "10260:10260"
     environment:
-      # Prefixed names (not USERNAME/PASSWORD) so values from .env are not
-      # shadowed by shell variables — Windows always defines USERNAME.
-      USERNAME: ${DOCUMENTDB_USERNAME:?Set DOCUMENTDB_USERNAME in .env or the environment}
-      PASSWORD: ${DOCUMENTDB_PASSWORD:?Set DOCUMENTDB_PASSWORD in .env or the environment}
+      # Prefixed names (not USERNAME/PASSWORD) so values from the environment
+      # are not shadowed by shell variables — Windows always defines USERNAME.
+      USERNAME: ${DOCUMENTDB_USERNAME:?generate credentials first - see README.md}
+      PASSWORD: ${DOCUMENTDB_PASSWORD:?generate credentials first - see README.md}
     volumes:
       - documentdb-data:/data
       # Uncomment to run your own mongosh .js seed scripts once per fresh
@@ -28,26 +32,19 @@ services:
     #   retries: 3
     #   start_period: 60s
 
-  # One-shot connectivity check, and a template for your own application
-  # service: `depends_on: condition: service_healthy` holds it back until
-  # DocumentDB is fully initialized. Reuses the documentdb-local image only
-  # because it already bundles mongosh. Run with:
-  #   docker compose run --rm smoke-test
-  smoke-test:
+  # Demonstrates readiness gating, and is the template for your own service:
+  # `depends_on: condition: service_healthy` holds this back until DocumentDB
+  # reports healthy, so it never races a half-initialized database. Swap in
+  # your own image and command. Run with:
+  #   docker compose run --rm wait-for-healthy
+  wait-for-healthy:
     image: ghcr.io/documentdb/documentdb/documentdb-local:latest
-    profiles: ["smoke-test"]
+    profiles: ["wait-for-healthy"]
     depends_on:
       documentdb:
         condition: service_healthy
-    entrypoint: ["mongosh"]
-    command:
-      - "mongodb://documentdb:10260/?tls=true&tlsAllowInvalidCertificates=true"
-      - "--username"
-      - ${DOCUMENTDB_USERNAME:?Set DOCUMENTDB_USERNAME in .env or the environment}
-      - "--password"
-      - ${DOCUMENTDB_PASSWORD:?Set DOCUMENTDB_PASSWORD in .env or the environment}
-      - "--eval"
-      - "db.runCommand({ ping: 1 })"
+    entrypoint: ["bash", "-c"]
+    command: ["echo 'DocumentDB reports healthy - a dependent service would start here.'"]
 
 volumes:
   documentdb-data:

--- a/documentdb-local/examples/docker-compose/docker-compose.yml
+++ b/documentdb-local/examples/docker-compose/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     #   interval: 10s
     #   timeout: 5s
     #   retries: 3
-    #   start_period: 60s
+    #   start_period: 600s
 
   # Demonstrates readiness gating, and is the template for your own service:
   # `depends_on: condition: service_healthy` holds this back until DocumentDB

--- a/documentdb-local/examples/docker-compose/docker-compose.yml
+++ b/documentdb-local/examples/docker-compose/docker-compose.yml
@@ -1,0 +1,53 @@
+# DocumentDB Local via docker compose. See README.md in this directory for
+# the full walkthrough (credentials, health check, persistence, seeding).
+
+services:
+  documentdb:
+    image: ghcr.io/documentdb/documentdb/documentdb-local:latest
+    ports:
+      - "10260:10260"
+    environment:
+      # Prefixed names (not USERNAME/PASSWORD) so values from .env are not
+      # shadowed by shell variables — Windows always defines USERNAME.
+      USERNAME: ${DOCUMENTDB_USERNAME:?Set DOCUMENTDB_USERNAME in .env or the environment}
+      PASSWORD: ${DOCUMENTDB_PASSWORD:?Set DOCUMENTDB_PASSWORD in .env or the environment}
+    volumes:
+      - documentdb-data:/data
+      # Uncomment to run your own mongosh .js seed scripts once per fresh
+      # data volume (alphabetical order):
+      # - ./init-data:/init_doc_db.d:ro
+    restart: unless-stopped
+    # No healthcheck block needed: the image ships a built-in probe
+    # (/usr/local/bin/documentdb-healthcheck) that reports healthy only after
+    # initialization finished and the gateway answers a TLS handshake.
+    # Override it only to tune timings, e.g.:
+    # healthcheck:
+    #   test: ["CMD", "/usr/local/bin/documentdb-healthcheck"]
+    #   interval: 10s
+    #   timeout: 5s
+    #   retries: 3
+    #   start_period: 60s
+
+  # One-shot connectivity check, and a template for your own application
+  # service: `depends_on: condition: service_healthy` holds it back until
+  # DocumentDB is fully initialized. Reuses the documentdb-local image only
+  # because it already bundles mongosh. Run with:
+  #   docker compose run --rm smoke-test
+  smoke-test:
+    image: ghcr.io/documentdb/documentdb/documentdb-local:latest
+    profiles: ["smoke-test"]
+    depends_on:
+      documentdb:
+        condition: service_healthy
+    entrypoint: ["mongosh"]
+    command:
+      - "mongodb://documentdb:10260/?tls=true&tlsAllowInvalidCertificates=true"
+      - "--username"
+      - ${DOCUMENTDB_USERNAME:?Set DOCUMENTDB_USERNAME in .env or the environment}
+      - "--password"
+      - ${DOCUMENTDB_PASSWORD:?Set DOCUMENTDB_PASSWORD in .env or the environment}
+      - "--eval"
+      - "db.runCommand({ ping: 1 })"
+
+volumes:
+  documentdb-data:

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -277,7 +277,9 @@ exit 1
         self.assertIn("DOCUMENTDB_PORT=12345\n", state)
         self.assertIn("POSTGRESQL_PORT=9712\n", state)
         self.assertIn("START_POSTGRESQL=false\n", state)
-        self.assertIn("TLS_MODE=allowTLS\n", state)
+        # Only what the probe reads: an unread key would be dead weight the
+        # probe's parser has to skip and this test would pin in place.
+        self.assertNotIn("TLS_MODE", state)
 
     def test_stale_runtime_state_file_removed_when_startup_fails(self):
         # A leftover file from a previous boot (docker restart) must not let

--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -260,6 +260,40 @@ exit 1
         self.assertFalse(psql_called.exists())
         self.assertIn("Skipping PostgreSQL server start", result.stdout)
 
+    def test_runtime_state_file_written_with_resolved_settings(self):
+        # healthcheck.sh keys off this file: it must appear only after startup
+        # completes and must carry the resolved values (CLI flags included,
+        # since health probes never see them in their exec environment).
+        state_file = self.root / "runtime-state.env"
+        result = self._run_entrypoint(
+            "--password",
+            "mypassword",
+            "--documentdb-port",
+            "12345",
+            extra_env={"DOCUMENTDB_RUNTIME_STATE_FILE": str(state_file)},
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        state = state_file.read_text(encoding="utf-8")
+        self.assertIn("DOCUMENTDB_PORT=12345\n", state)
+        self.assertIn("POSTGRESQL_PORT=9712\n", state)
+        self.assertIn("START_POSTGRESQL=false\n", state)
+        self.assertIn("TLS_MODE=allowTLS\n", state)
+
+    def test_stale_runtime_state_file_removed_when_startup_fails(self):
+        # A leftover file from a previous boot (docker restart) must not let
+        # the healthcheck report healthy while this boot is failing.
+        state_file = self.root / "runtime-state.env"
+        state_file.write_text("DOCUMENTDB_PORT=10260\n", encoding="utf-8")
+        result = self._run_entrypoint(
+            "--password",
+            "mypassword",
+            "--documentdb-port",
+            "banana",
+            extra_env={"DOCUMENTDB_RUNTIME_STATE_FILE": str(state_file)},
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(state_file.exists())
+
     def test_default_mode_sets_allowTLS_in_config(self):
         result = self._run_entrypoint("--password", "mypassword")
         self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)

--- a/documentdb-local/scripts/documentdb_local_tests/test_healthcheck.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_healthcheck.py
@@ -7,6 +7,7 @@ their exit codes map to the health verdict.
 """
 
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -14,6 +15,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 HEALTHCHECK = REPO_ROOT / "documentdb-local" / "scripts" / "healthcheck.sh"
+# Absolute, so PATH in the child env is purely the stub search path and a test
+# may narrow it to the stub directory alone.
+BASH = shutil.which("bash") or "bash"
 
 
 class HealthcheckTests(unittest.TestCase):
@@ -59,7 +63,7 @@ class HealthcheckTests(unittest.TestCase):
         if extra_env:
             env.update(extra_env)
         return subprocess.run(
-            ["bash", str(HEALTHCHECK), *args],
+            [BASH, str(HEALTHCHECK), *args],
             env=env,
             text=True,
             capture_output=True,
@@ -167,6 +171,50 @@ class HealthcheckTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
         self.assertIn("invalid DocumentDB port", result.stdout)
+        self.assertFalse(self.openssl_args.exists())
+
+    def test_state_file_values_are_not_executed(self):
+        # The entrypoint publishes START_POSTGRESQL unvalidated, so the probe
+        # must read the file literally rather than sourcing it.
+        self.state_file.write_text(
+            "DOCUMENTDB_PORT=12345\n"
+            "POSTGRESQL_PORT=9712\n"
+            "START_POSTGRESQL=false; echo INJECTED\n",
+            encoding="utf-8",
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertNotIn("INJECTED", result.stdout + result.stderr)
+        # Not exactly "true", so PostgreSQL is not probed -- same verdict the
+        # entrypoint's own `= "true"` test reached when it did not start it.
+        self.assertFalse(self.pg_isready_args.exists())
+
+    def test_state_file_value_with_whitespace_is_read_intact(self):
+        # A truncating parser would read "true" here and probe a PostgreSQL
+        # the entrypoint never started, leaving the container unhealthy forever.
+        self._write_state(
+            DOCUMENTDB_PORT=12345, POSTGRESQL_PORT=9712, START_POSTGRESQL="true "
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertFalse(self.pg_isready_args.exists())
+
+    def test_missing_pg_isready_is_unhealthy(self):
+        # Reporting healthy without the probe would mean reporting healthy
+        # with a dead database whenever the gateway's TLS listener answers.
+        (self.bin_dir / "pg_isready").unlink()
+        self._write_state(
+            DOCUMENTDB_PORT=12345, POSTGRESQL_PORT=9712, START_POSTGRESQL="true"
+        )
+
+        result = self._run(extra_env={"PATH": str(self.bin_dir)})
+
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("pg_isready not found", result.stdout)
         self.assertFalse(self.openssl_args.exists())
 
     def test_environment_used_when_state_file_omits_keys(self):

--- a/documentdb-local/scripts/documentdb_local_tests/test_healthcheck.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_healthcheck.py
@@ -1,0 +1,186 @@
+"""Unit tests for documentdb-local/scripts/healthcheck.sh.
+
+Same stub-PATH harness as test_emulator_entrypoint.py: the real script runs
+under bash with `openssl` / `pg_isready` replaced by stubs that record their
+argv, so the tests assert which probes ran, against which ports, and how
+their exit codes map to the health verdict.
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HEALTHCHECK = REPO_ROOT / "documentdb-local" / "scripts" / "healthcheck.sh"
+
+
+class HealthcheckTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.state_file = self.root / "runtime-state.env"
+        # Default stubs: both probes succeed. Individual tests re-stub.
+        self.openssl_args = self._stub_probe("openssl", 0)
+        self.pg_isready_args = self._stub_probe("pg_isready", 0)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _stub_probe(self, name: str, exit_code: int) -> Path:
+        capture = self.root / f"{name}.args"
+        stub = self.bin_dir / name
+        stub.write_text(
+            f'#!/bin/sh\necho "$@" >> "{capture}"\nexit {exit_code}\n',
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        return capture
+
+    def _write_state(self, **values):
+        lines = "".join(f"{key}={value}\n" for key, value in values.items())
+        self.state_file.write_text(lines, encoding="utf-8")
+
+    def _run(self, *args, extra_env=None):
+        env = os.environ.copy()
+        # The exec environment must not leak these into the run; tests set
+        # them explicitly when the env-fallback path is under test.
+        for var in ("DOCUMENTDB_PORT", "POSTGRESQL_PORT", "START_POSTGRESQL"):
+            env.pop(var, None)
+        env.update(
+            {
+                "PATH": f"{self.bin_dir}:{env['PATH']}",
+                "DOCUMENTDB_RUNTIME_STATE_FILE": str(self.state_file),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            ["bash", str(HEALTHCHECK), *args],
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+
+    def test_missing_state_file_reports_unhealthy_without_probing(self):
+        result = self._run()
+
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("startup has not completed", result.stdout)
+        self.assertFalse(self.openssl_args.exists())
+        self.assertFalse(self.pg_isready_args.exists())
+
+    def test_healthy_when_all_probes_succeed(self):
+        self._write_state(
+            DOCUMENTDB_PORT=12345,
+            POSTGRESQL_PORT=9876,
+            START_POSTGRESQL="true",
+            TLS_MODE="allowTLS",
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("healthy", result.stdout)
+        self.assertIn("localhost:12345", self.openssl_args.read_text(encoding="utf-8"))
+        pg_args = self.pg_isready_args.read_text(encoding="utf-8")
+        self.assertIn("-p 9876", pg_args)
+        self.assertIn("-h localhost", pg_args)
+
+    def test_state_file_port_beats_exec_environment(self):
+        # HEALTHCHECK / docker exec sessions see only the image's ENV
+        # defaults; the entrypoint's published state must win over them.
+        self._write_state(
+            DOCUMENTDB_PORT=12345, POSTGRESQL_PORT=9712, START_POSTGRESQL="false"
+        )
+
+        result = self._run(extra_env={"DOCUMENTDB_PORT": "59999"})
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("localhost:12345", self.openssl_args.read_text(encoding="utf-8"))
+
+    def test_port_argument_beats_state_file(self):
+        self._write_state(
+            DOCUMENTDB_PORT=12345, POSTGRESQL_PORT=9712, START_POSTGRESQL="false"
+        )
+
+        result = self._run("23456")
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("localhost:23456", self.openssl_args.read_text(encoding="utf-8"))
+
+    def test_gateway_probe_failure_is_unhealthy(self):
+        self._write_state(
+            DOCUMENTDB_PORT=12345, POSTGRESQL_PORT=9712, START_POSTGRESQL="false"
+        )
+        self._stub_probe("openssl", 1)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("TLS handshake", result.stdout)
+
+    def test_postgres_probe_failure_is_unhealthy(self):
+        self._write_state(
+            DOCUMENTDB_PORT=12345, POSTGRESQL_PORT=9712, START_POSTGRESQL="true"
+        )
+        self._stub_probe("pg_isready", 2)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("PostgreSQL is not accepting connections", result.stdout)
+        self.assertFalse(self.openssl_args.exists())
+
+    def test_postgres_probe_skipped_for_external_postgres(self):
+        self._write_state(
+            DOCUMENTDB_PORT=12345, POSTGRESQL_PORT=9712, START_POSTGRESQL="false"
+        )
+        self._stub_probe("pg_isready", 2)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertFalse(self.pg_isready_args.exists())
+
+    def test_non_numeric_port_fails_without_probing(self):
+        self._write_state(
+            DOCUMENTDB_PORT="banana", POSTGRESQL_PORT=9712, START_POSTGRESQL="false"
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("invalid DocumentDB port", result.stdout)
+        self.assertFalse(self.openssl_args.exists())
+
+    def test_out_of_range_port_fails_without_probing(self):
+        self._write_state(
+            DOCUMENTDB_PORT=70000, POSTGRESQL_PORT=9712, START_POSTGRESQL="false"
+        )
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 1, msg=result.stdout + result.stderr)
+        self.assertIn("invalid DocumentDB port", result.stdout)
+        self.assertFalse(self.openssl_args.exists())
+
+    def test_environment_used_when_state_file_omits_keys(self):
+        # An (empty) state file still gates readiness; missing keys fall back
+        # to the exec environment, then to the built-in defaults.
+        self.state_file.write_text("", encoding="utf-8")
+
+        result = self._run(
+            extra_env={"DOCUMENTDB_PORT": "31000", "START_POSTGRESQL": "false"}
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stdout + result.stderr)
+        self.assertIn("localhost:31000", self.openssl_args.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/documentdb-local/scripts/documentdb_local_tests/test_image.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_image.py
@@ -172,6 +172,35 @@ def _wait_for_ready(container: str, *, timeout: int = DEFAULT_READY_TIMEOUT,
     )
 
 
+def _wait_for_healthy(container: str, *, timeout: int = 120,
+                      poll_interval: float = 2.0) -> None:
+    """Poll `docker inspect` until the built-in HEALTHCHECK reports healthy.
+    The probe runs on a 30s interval, so allow at least one full interval
+    past readiness. Raises RuntimeError on timeout or premature exit."""
+    deadline = time.monotonic() + timeout
+    status = "<never inspected>"
+    while time.monotonic() < deadline:
+        result = _docker(
+            "inspect", "-f", "{{.State.Health.Status}}", container, check=False,
+        )
+        status = result.stdout.strip()
+        if status == "healthy":
+            return
+        running = _docker(
+            "inspect", "-f", "{{.State.Running}}", container, check=False,
+        )
+        if running.returncode != 0 or running.stdout.strip() != "true":
+            raise RuntimeError(
+                f"container {container!r} exited while waiting for healthy "
+                f"(last health status: {status!r})"
+            )
+        time.sleep(poll_interval)
+    raise RuntimeError(
+        f"container {container!r} did not report healthy within {timeout}s "
+        f"(last health status: {status!r})"
+    )
+
+
 def _start_container(image: str, *, extra_run_args: list[str] | None = None,
                      entrypoint_flags: list[str] | None = None,
                      name: str | None = None) -> str:
@@ -448,6 +477,29 @@ class DefaultContainerTests(_ContainerTestBase):
             whoami.stdout.strip(), "root",
             "in-container `whoami` reports root; expected a non-root user.",
         )
+
+    def test_builtin_healthcheck_probe_succeeds(self):
+        """The shipped probe must pass on a ready default container. Runs it
+        directly (not via the HEALTHCHECK schedule) for a fast, attributable
+        verdict with the probe's own diagnostic output on failure."""
+        result = _docker(
+            "exec", self.container, "/usr/local/bin/documentdb-healthcheck",
+            check=False, timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"health probe failed on a ready container.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_builtin_healthcheck_reports_healthy(self):
+        """The HEALTHCHECK instruction must be wired up: docker itself (and
+        thus compose `depends_on: condition: service_healthy`) must converge
+        on healthy without any healthcheck configuration by the user."""
+        try:
+            _wait_for_healthy(self.container)
+        except RuntimeError as exc:
+            self.fail(str(exc))
 
     def test_mongosh_binary_is_shipped_in_image(self):
         """The image must ship mongosh - we rely on it for in-container
@@ -806,6 +858,23 @@ class CustomDocumentDBPortTests(_ContainerTestBase):
             _last_nonempty_line(result.stdout), "1",
             f"expected ping ok=1 on custom port {CUSTOM_PORT}\n"
             f"full stdout:\n{result.stdout}",
+        )
+
+    def test_builtin_healthcheck_tracks_custom_port(self):
+        """The probe must follow the CLI-configured port. `docker exec`
+        sessions still see the image default DOCUMENTDB_PORT=10260 in the
+        environment (where nothing is listening here), so this passes only
+        if the probe reads the entrypoint's published runtime state."""
+        result = _docker(
+            "exec", self.container, "/usr/local/bin/documentdb-healthcheck",
+            check=False, timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"health probe failed with --documentdb-port {CUSTOM_PORT}; it "
+            f"is likely probing the default port from the exec environment "
+            f"instead of the entrypoint's runtime state.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
         )
 
     def test_default_port_not_listening(self):

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -261,6 +261,14 @@ export SYSTEM_POSTGRES_LOG=${SYSTEM_POSTGRES_LOG:-/var/log/postgresql/postgresql
 export DOCUMENTDB_RUNTIME_USER=${DOCUMENTDB_RUNTIME_USER:-documentdb}
 export DOCUMENTDB_RUNTIME_GROUP=${DOCUMENTDB_RUNTIME_GROUP:-$DOCUMENTDB_RUNTIME_USER}
 
+# Runtime state file consumed by healthcheck.sh. Written only once startup
+# completes (see the ready banner below), so its presence doubles as the
+# readiness marker. Remove any leftover from a previous boot of this
+# container (e.g. `docker restart`) so the healthcheck cannot report healthy
+# while this boot is still starting up.
+export DOCUMENTDB_RUNTIME_STATE_FILE=${DOCUMENTDB_RUNTIME_STATE_FILE:-/tmp/documentdb-local-runtime.env}
+rm -f "$DOCUMENTDB_RUNTIME_STATE_FILE"
+
 # Setup centralized log directory structure
 echo "Setting up centralized log directory at $DOCUMENTDB_LOG_DIR..."
 sudo mkdir -p "$DOCUMENTDB_LOG_DIR/postgres"
@@ -669,6 +677,24 @@ if [ -f "$GATEWAY_LOG" ]; then
 fi
 
 echo "Gateway started with PID: $gateway_pid"
+
+# Publish the resolved runtime settings for healthcheck.sh. This runs after
+# gateway readiness and data initialization so the healthcheck only reports
+# healthy on a fully initialized database, and it records the ports actually
+# in use — which may come from CLI flags that HEALTHCHECK / `docker exec`
+# sessions cannot see in their environment. Written via a temp file + mv so
+# the healthcheck never sources a partially written file. A write failure is
+# not fatal to the database, but the container will keep reporting unhealthy,
+# so warn loudly.
+if printf 'DOCUMENTDB_PORT=%s\nPOSTGRESQL_PORT=%s\nSTART_POSTGRESQL=%s\nTLS_MODE=%s\n' \
+        "$DOCUMENTDB_PORT" "$POSTGRESQL_PORT" "$START_POSTGRESQL" "$TLS_MODE" \
+        > "${DOCUMENTDB_RUNTIME_STATE_FILE}.tmp" \
+        && mv "${DOCUMENTDB_RUNTIME_STATE_FILE}.tmp" "$DOCUMENTDB_RUNTIME_STATE_FILE"; then
+    echo "Runtime state for the health check written to $DOCUMENTDB_RUNTIME_STATE_FILE"
+else
+    echo "Warning: could not write $DOCUMENTDB_RUNTIME_STATE_FILE; the container health check will keep reporting unhealthy." >&2
+fi
+
 echo ""
 echo "=== DocumentDB is ready ==="
 echo "All logs are being streamed to docker logs with prefixes:"

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -267,7 +267,7 @@ export DOCUMENTDB_RUNTIME_GROUP=${DOCUMENTDB_RUNTIME_GROUP:-$DOCUMENTDB_RUNTIME_
 # container (e.g. `docker restart`) so the healthcheck cannot report healthy
 # while this boot is still starting up.
 export DOCUMENTDB_RUNTIME_STATE_FILE=${DOCUMENTDB_RUNTIME_STATE_FILE:-/tmp/documentdb-local-runtime.env}
-rm -f "$DOCUMENTDB_RUNTIME_STATE_FILE"
+rm -f "$DOCUMENTDB_RUNTIME_STATE_FILE" "${DOCUMENTDB_RUNTIME_STATE_FILE}.tmp"
 
 # Setup centralized log directory structure
 echo "Setting up centralized log directory at $DOCUMENTDB_LOG_DIR..."
@@ -683,11 +683,11 @@ echo "Gateway started with PID: $gateway_pid"
 # healthy on a fully initialized database, and it records the ports actually
 # in use — which may come from CLI flags that HEALTHCHECK / `docker exec`
 # sessions cannot see in their environment. Written via a temp file + mv so
-# the healthcheck never sources a partially written file. A write failure is
+# the healthcheck never reads a partially written file. A write failure is
 # not fatal to the database, but the container will keep reporting unhealthy,
 # so warn loudly.
-if printf 'DOCUMENTDB_PORT=%s\nPOSTGRESQL_PORT=%s\nSTART_POSTGRESQL=%s\nTLS_MODE=%s\n' \
-        "$DOCUMENTDB_PORT" "$POSTGRESQL_PORT" "$START_POSTGRESQL" "$TLS_MODE" \
+if printf 'DOCUMENTDB_PORT=%s\nPOSTGRESQL_PORT=%s\nSTART_POSTGRESQL=%s\n' \
+        "$DOCUMENTDB_PORT" "$POSTGRESQL_PORT" "$START_POSTGRESQL" \
         > "${DOCUMENTDB_RUNTIME_STATE_FILE}.tmp" \
         && mv "${DOCUMENTDB_RUNTIME_STATE_FILE}.tmp" "$DOCUMENTDB_RUNTIME_STATE_FILE"; then
     echo "Runtime state for the health check written to $DOCUMENTDB_RUNTIME_STATE_FILE"

--- a/documentdb-local/scripts/healthcheck.sh
+++ b/documentdb-local/scripts/healthcheck.sh
@@ -19,8 +19,9 @@
 # The state file — not this process's environment — is the authority for the
 # ports: HEALTHCHECK / `docker exec` sessions only see the image's ENV
 # defaults, never values the entrypoint parsed from CLI flags such as
-# `--documentdb-port`. Environment variables and the optional port argument
-# still work for standalone use (e.g. probing from a sidecar wrapper).
+# `--documentdb-port`. The state file is always required — its absence means
+# startup has not completed — while environment variables supply any key it
+# omits and the optional port argument overrides the DocumentDB port.
 #
 # Usage: healthcheck.sh [gateway-port]
 #   gateway-port  overrides the DocumentDB port from the state file/env.
@@ -39,12 +40,27 @@ if [ ! -f "$STATE_FILE" ]; then
     exit 1
 fi
 
-# The file contains only KEY=VALUE lines written by emulator_entrypoint.sh.
-# shellcheck source=/dev/null
-. "$STATE_FILE"
-documentdb_port="${DOCUMENTDB_PORT:-$documentdb_port}"
-postgresql_port="${POSTGRESQL_PORT:-$postgresql_port}"
-start_postgresql="${START_POSTGRESQL:-$start_postgresql}"
+# Parse, never source, the KEY=VALUE lines emulator_entrypoint.sh writes: the
+# entrypoint does not validate every value it publishes (START_POSTGRESQL takes
+# whatever `--start-pg` was given), so `.` would execute a value such as
+# `false; some-command` on every probe and would silently truncate any value
+# containing whitespace. Reading the values literally also keeps this probe's
+# view byte-identical to the entrypoint's, so the two cannot disagree about
+# whether START_POSTGRESQL was exactly "true". Unlisted keys are ignored, and an
+# empty value falls through to the environment/default resolved above.
+while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+        *=*) ;;
+        *) continue ;;
+    esac
+    value="${line#*=}"
+    [ -n "$value" ] || continue
+    case "${line%%=*}" in
+        DOCUMENTDB_PORT) documentdb_port="$value" ;;
+        POSTGRESQL_PORT) postgresql_port="$value" ;;
+        START_POSTGRESQL) start_postgresql="$value" ;;
+    esac
+done < "$STATE_FILE"
 
 if [ "$#" -ge 1 ] && [ -n "$1" ]; then
     documentdb_port="$1"
@@ -56,7 +72,12 @@ is_port() {
     case "$1" in
         ''|*[!0-9]*) return 1 ;;
     esac
-    [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+    # Drop leading zeros, then bound the width before comparing: a digits-only
+    # value wider than the shell's integer type makes `[ -ge ]` write
+    # "integer expression expected" into the container's health log.
+    _port="${1#"${1%%[!0]*}"}"
+    [ -n "$_port" ] && [ "${#_port}" -le 5 ] || return 1
+    [ "$_port" -ge 1 ] && [ "$_port" -le 65535 ]
 }
 
 if ! is_port "$documentdb_port"; then
@@ -73,11 +94,16 @@ if [ "$start_postgresql" = "true" ]; then
         echo "unhealthy: invalid PostgreSQL port '$postgresql_port'"
         exit 1
     fi
-    if command -v pg_isready >/dev/null 2>&1; then
-        if ! pg_isready -q -h localhost -p "$postgresql_port"; then
-            echo "unhealthy: PostgreSQL is not accepting connections on localhost:$postgresql_port"
-            exit 1
-        fi
+    # A missing pg_isready is a broken image, not a reason to skip the probe:
+    # reporting healthy here would mean reporting healthy with a dead database
+    # whenever the gateway's TLS listener happens to answer.
+    if ! command -v pg_isready >/dev/null 2>&1; then
+        echo "unhealthy: pg_isready not found, cannot probe PostgreSQL on localhost:$postgresql_port"
+        exit 1
+    fi
+    if ! pg_isready -q -h localhost -p "$postgresql_port"; then
+        echo "unhealthy: PostgreSQL is not accepting connections on localhost:$postgresql_port"
+        exit 1
     fi
 fi
 

--- a/documentdb-local/scripts/healthcheck.sh
+++ b/documentdb-local/scripts/healthcheck.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Health probe for the documentdb-local container. Backs the image's built-in
+# HEALTHCHECK and docker-compose `healthcheck:` blocks:
+#
+#   test: ["CMD", "/usr/local/bin/documentdb-healthcheck"]
+#
+# Exits 0 (healthy) only when all of the following hold:
+#   1. The entrypoint finished startup: it publishes its resolved runtime
+#      settings to $DOCUMENTDB_RUNTIME_STATE_FILE only after initialization
+#      (including sample/custom data seeding) completes, so orchestrators
+#      gated on `service_healthy` never see a half-initialized database.
+#   2. The bundled PostgreSQL accepts connections (skipped when this
+#      container did not start PostgreSQL, i.e. START_POSTGRESQL=false).
+#   3. The gateway completes a TLS handshake on the DocumentDB port. The
+#      gateway serves TLS in every tlsMode (allowTLS/disabled additionally
+#      accept plain connections), so a TLS probe is valid in all modes.
+#
+# The state file — not this process's environment — is the authority for the
+# ports: HEALTHCHECK / `docker exec` sessions only see the image's ENV
+# defaults, never values the entrypoint parsed from CLI flags such as
+# `--documentdb-port`. Environment variables and the optional port argument
+# still work for standalone use (e.g. probing from a sidecar wrapper).
+#
+# Usage: healthcheck.sh [gateway-port]
+#   gateway-port  overrides the DocumentDB port from the state file/env.
+
+set -u
+
+STATE_FILE="${DOCUMENTDB_RUNTIME_STATE_FILE:-/tmp/documentdb-local-runtime.env}"
+
+# Precedence per setting: CLI argument > state file > environment > default.
+documentdb_port="${DOCUMENTDB_PORT:-10260}"
+postgresql_port="${POSTGRESQL_PORT:-9712}"
+start_postgresql="${START_POSTGRESQL:-true}"
+
+if [ ! -f "$STATE_FILE" ]; then
+    echo "unhealthy: startup has not completed (state file $STATE_FILE not found)"
+    exit 1
+fi
+
+# The file contains only KEY=VALUE lines written by emulator_entrypoint.sh.
+# shellcheck source=/dev/null
+. "$STATE_FILE"
+documentdb_port="${DOCUMENTDB_PORT:-$documentdb_port}"
+postgresql_port="${POSTGRESQL_PORT:-$postgresql_port}"
+start_postgresql="${START_POSTGRESQL:-$start_postgresql}"
+
+if [ "$#" -ge 1 ] && [ -n "$1" ]; then
+    documentdb_port="$1"
+fi
+
+# Fail (rather than probe a guessed port) on a corrupt value: a state file the
+# entrypoint did not write correctly is itself a sign the container is broken.
+is_port() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
+
+if ! is_port "$documentdb_port"; then
+    echo "unhealthy: invalid DocumentDB port '$documentdb_port'"
+    exit 1
+fi
+
+if [ "$start_postgresql" = "true" ]; then
+    if ! is_port "$postgresql_port"; then
+        echo "unhealthy: invalid PostgreSQL port '$postgresql_port'"
+        exit 1
+    fi
+    if command -v pg_isready >/dev/null 2>&1; then
+        if ! pg_isready -q -h localhost -p "$postgresql_port"; then
+            echo "unhealthy: PostgreSQL is not accepting connections on localhost:$postgresql_port"
+            exit 1
+        fi
+    fi
+fi
+
+# </dev/null (not `echo |`, and never -quiet): with stdin at EOF s_client
+# exits right after the handshake without sending stray bytes into the wire
+# protocol, and its exit status directly reflects connect/handshake success.
+# -quiet implies -ign_eof, which would leave the probe hanging on the open
+# connection until the healthcheck timeout kills it.
+if ! openssl s_client -connect "localhost:$documentdb_port" </dev/null >/dev/null 2>&1; then
+    echo "unhealthy: TLS handshake with the gateway on localhost:$documentdb_port failed"
+    exit 1
+fi
+
+echo "healthy: gateway accepting TLS connections on localhost:$documentdb_port"
+exit 0

--- a/documentdb-local/scripts/healthcheck.sh
+++ b/documentdb-local/scripts/healthcheck.sh
@@ -64,6 +64,10 @@ if ! is_port "$documentdb_port"; then
     exit 1
 fi
 
+# Mirrors the entrypoint's own `[ "$START_POSTGRESQL" = "true" ]` test, which
+# does not validate the value either: any other value means it did not start
+# PostgreSQL, so rejecting one here would report unhealthy for a container that
+# is running exactly as the entrypoint decided.
 if [ "$start_postgresql" = "true" ]; then
     if ! is_port "$postgresql_port"; then
         echo "unhealthy: invalid PostgreSQL port '$postgresql_port'"

--- a/packaging/gateway/docker/Dockerfile_documentdb_local
+++ b/packaging/gateway/docker/Dockerfile_documentdb_local
@@ -195,6 +195,7 @@ COPY --from=stage /home/documentdb/code/documentdb-local/scripts/emulator_entryp
 COPY --from=stage /home/documentdb/code/documentdb-local/scripts/documentdb_reserved_roles.sh /home/documentdb/gateway/scripts/documentdb_reserved_roles.sh
 COPY --from=stage /home/documentdb/code/documentdb-local/scripts/documentdb_validate_username.sh /home/documentdb/gateway/scripts/documentdb_validate_username.sh
 COPY --from=stage /home/documentdb/code/documentdb-local/scripts/documentdb_install_getparameter_stub.sh /home/documentdb/gateway/scripts/documentdb_install_getparameter_stub.sh
+COPY --from=stage /home/documentdb/code/documentdb-local/scripts/healthcheck.sh /home/documentdb/gateway/scripts/healthcheck.sh
 COPY --from=stage /home/documentdb/code/scripts/utils.sh /home/documentdb/gateway/scripts/utils.sh
 COPY --from=stage /home/documentdb/code/scripts/preload_libraries.sh /home/documentdb/gateway/scripts/preload_libraries.sh
 COPY --from=stage /home/documentdb/code/scripts/setup_psqlrc.sh /home/documentdb/gateway/scripts/setup_psqlrc.sh
@@ -213,5 +214,20 @@ RUN sudo chown -R documentdb:documentdb /home/documentdb/gateway
 # Make initialization script executable
 RUN sudo chmod +x /home/documentdb/gateway/scripts/init_documentdb_data.sh
 
+# Expose the health probe on a stable path that stays valid if the scripts
+# directory ever moves, so compose files can rely on
+# `test: ["CMD", "/usr/local/bin/documentdb-healthcheck"]` across releases.
+RUN sudo chmod +x /home/documentdb/gateway/scripts/healthcheck.sh && \
+    sudo ln -s /home/documentdb/gateway/scripts/healthcheck.sh /usr/local/bin/documentdb-healthcheck
+
 WORKDIR /home/documentdb/gateway/scripts
+# Built-in health probe: healthy once the entrypoint finished initialization
+# and the gateway answers a TLS handshake (see healthcheck.sh). It tracks the
+# configured DocumentDB port automatically — including one set via the
+# --documentdb-port CLI flag — so `docker run` users and docker-compose
+# `depends_on: condition: service_healthy` need no extra configuration. The
+# start period covers first-boot initdb plus sample-data seeding on slow
+# machines; probes only start counting toward `retries` after it elapses.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD ["/usr/local/bin/documentdb-healthcheck"]
 ENTRYPOINT ["/bin/bash", "-c", "/home/documentdb/gateway/scripts/emulator_entrypoint.sh \"$@\"", "--"]

--- a/packaging/gateway/docker/Dockerfile_documentdb_local
+++ b/packaging/gateway/docker/Dockerfile_documentdb_local
@@ -225,9 +225,13 @@ WORKDIR /home/documentdb/gateway/scripts
 # and the gateway answers a TLS handshake (see healthcheck.sh). It tracks the
 # configured DocumentDB port automatically — including one set via the
 # --documentdb-port CLI flag — so `docker run` users and docker-compose
-# `depends_on: condition: service_healthy` need no extra configuration. The
-# start period covers first-boot initdb plus sample-data seeding on slow
-# machines; probes only start counting toward `retries` after it elapses.
-HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+# `depends_on: condition: service_healthy` need no extra configuration.
+# The start period matches DOCUMENTDB_PG_READY_TIMEOUT, the entrypoint's own
+# 600s budget for PostgreSQL to come up, so a slow first boot (initdb plus
+# sample-data seeding on a cold volume) is never reported unhealthy before the
+# entrypoint itself gives up. It costs a fast boot nothing: a probe that
+# succeeds during the start period marks the container healthy right away, and
+# probes only count toward `retries` after the period elapses.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=600s --retries=3 \
     CMD ["/usr/local/bin/documentdb-healthcheck"]
 ENTRYPOINT ["/bin/bash", "-c", "/home/documentdb/gateway/scripts/emulator_entrypoint.sh \"$@\"", "--"]

--- a/packaging/gateway/test/Dockerfile_deb_gateway_test
+++ b/packaging/gateway/test/Dockerfile_deb_gateway_test
@@ -107,6 +107,7 @@ COPY documentdb-local/scripts/documentdb_reserved_roles.sh /home/documentdb/gate
 COPY documentdb-local/scripts/documentdb_validate_username.sh /home/documentdb/gateway/scripts/documentdb_validate_username.sh
 COPY documentdb-local/scripts/documentdb_install_getparameter_stub.sh /home/documentdb/gateway/scripts/documentdb_install_getparameter_stub.sh
 COPY documentdb-local/scripts/init_documentdb_data.sh /home/documentdb/gateway/scripts/init_documentdb_data.sh
+COPY documentdb-local/scripts/healthcheck.sh /home/documentdb/gateway/scripts/healthcheck.sh
 COPY scripts/utils.sh /home/documentdb/gateway/scripts/utils.sh
 COPY scripts/preload_libraries.sh /home/documentdb/gateway/scripts/preload_libraries.sh
 COPY scripts/setup_psqlrc.sh /home/documentdb/gateway/scripts/setup_psqlrc.sh


### PR DESCRIPTION
## Description

Closes #482. Supersedes #677, which took a much larger approach (four example
directories, 24 files); this one stays close to what the issue actually asked for — a
`healthcheck.sh` in the image plus a documented compose scenario.

The image shipped no `HEALTHCHECK`, so compose users had to hand-roll a probe. The one
iterated on in the issue used `openssl s_client -quiet`, which implies `-ign_eof` and so
leaves the probe hanging on the open connection until the healthcheck timeout kills it —
which is why the `-brief` variant "worked". This PR abstracts that logic into a script
shipped in the image and documents the compose scenario.

**`documentdb-local/scripts/healthcheck.sh`**, exposed at the stable path
`/usr/local/bin/documentdb-healthcheck` and wired up as the image's default `HEALTHCHECK`
(interval 30s, timeout 10s, start period 120s, 3 retries). Healthy requires all three of:

1. **Startup completed.** The entrypoint publishes its resolved runtime settings to
   `/tmp/documentdb-local-runtime.env` (atomic write) only *after* one-shot data seeding
   finishes, and clears a stale file early on boot since `/tmp` survives `docker restart`.
   So a service gated on `depends_on: condition: service_healthy` never observes a
   half-initialized database — which a plain TCP/TLS probe cannot guarantee.
2. **PostgreSQL accepts connections** — skipped when `START_POSTGRESQL=false`.
3. **The gateway completes a TLS handshake**, using `openssl s_client </dev/null` and never
   `-quiet`, for the reason above. The gateway serves TLS in every `tlsMode`, so this is
   valid in all modes.

Reading the published state (rather than the environment) is also what makes the probe
follow a port set via `--documentdb-port`: Docker spawns `HEALTHCHECK` and `docker exec`
processes with the image's static env, where that flag is invisible.

**Compose example** under `documentdb-local/examples/docker-compose/` — compose file plus a
README covering the health check, readiness-gating your own services, persistence, seeding,
and port changes.

Credentials are generated fresh per run into the shell environment (the README shows the
`openssl rand` one-liner), so nothing credential-shaped is stored in the directory and no
credentials appear on a command line. Compose refuses to start when either variable is
unset, so the stack cannot silently come up on the image's well-known defaults. The
runnable `wait-for-healthy` service demonstrates `depends_on: condition: service_healthy`
without needing credentials at all.

`packaging/gateway/test/Dockerfile_deb_gateway_test` gets the matching `COPY`, which
`test_clean_install_image_copies_entrypoint_script_dependencies` requires.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactoring / code cleanup
- [x] DevOps / tooling
- [x] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code (Opus 5)
  - **How it was used:** Wrote the initial implementation, tests and docs from the issue
    description, and ran the verification below. I reviewed every line, directed the
    design decisions (state file as the readiness gate, TLS handshake over a bare TCP
    check, `</dev/null` instead of `-quiet`), and verified the results myself.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines

## Testing

- `documentdb_local_tests/test_healthcheck.py` — 10 new unit tests using the same
  stub-`PATH` harness as `test_emulator_entrypoint.py`: which probes run, against which
  ports, precedence of argument > state file > environment, and how each probe's exit code
  maps to the verdict.
- `test_emulator_entrypoint.py` — 2 new tests for the state-file lifecycle (written with
  resolved settings including CLI flags; stale file removed when startup fails).
- Full `documentdb-local/scripts/documentdb_local_tests` suite: **189 passed**, 27
  env-dependent skips.
- `shellcheck` clean on the new script; `bash -n` on both scripts; `docker compose config`
  validates with and without the `wait-for-healthy` profile, and fails as intended when
  the credential variables are unset.
- End-to-end run of the probe against a live `openssl s_server`: exits 0 while the listener
  is up, 1 after it stops.
- `test_image.py` — 3 new image-contract tests (probe passes on a ready container; Docker
  itself converges on `healthy`; and one that passes only if the probe reads the runtime
  state rather than the exec environment, run under `--documentdb-port 11000`). These need
  a built image, so CI exercises them.
