### PR TITLE
Fix inaccurate --help text in emulator_entrypoint.sh

### DIFF
--- a/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_emulator_entrypoint.py
@@ -1333,6 +1333,45 @@ class EntrypointUxTextTests(unittest.TestCase):
         self.assertNotIn("Overrides PORT environment variable.", text)
         self.assertNotIn("Overrides PG_PORT environment variable.", text)
 
+    def test_help_documents_env_vars_for_every_flag_that_reads_one(self):
+        # --create-user and --start-pg are honored as CREATE_USER /
+        # START_POSTGRESQL (set in Dockerfile_documentdb_local), but the help
+        # used to list no env var for either, hiding the only docker-run -e path.
+        text = self._text()
+        self.assertIn("Overrides CREATE_USER environment variable.", text)
+        self.assertIn("Overrides START_POSTGRESQL environment variable.", text)
+
+    def test_help_does_not_advertise_nonexistent_telemetry_backend(self):
+        # The usage collector is not Azure Application Insights; no such
+        # integration exists in this repo. Naming it sends operators looking
+        # for an instrumentation key that nothing consumes.
+        text = self._text()
+        self.assertNotIn("Application Insights", text)
+        # Also guard the long-standing "colletor" typo it appeared alongside.
+        self.assertNotIn("colletor", text)
+
+    def test_help_does_not_claim_password_is_required(self):
+        # PASSWORD falls back to a built-in default before the "required"
+        # check runs, so that check never fires. Help must not promise a
+        # guard the script does not enforce.
+        text = self._text()
+        self.assertNotIn("REQUIRED.", text)
+
+    def test_help_shows_value_placeholder_for_value_taking_flags(self):
+        # Each of these parses as `shift; export X=$1; shift`. Documenting them
+        # as bare flags leads operators to write the form that swallows the
+        # next argument -- and the arg loop has no `*)` arm to recover.
+        text = self._text()
+        for flag in (
+            "--enable-telemetry [true|false]",
+            "--create-user [true|false]",
+            "--start-pg [true|false]",
+            "--documentdb-port [PORT]",
+            "--pg-port [PORT]",
+            "--log-level [LEVEL]",
+        ):
+            self.assertIn(flag, text, f"help must show a value placeholder for {flag}")
+
     def test_cleanup_stops_postgresql(self):
         # docker stop must cleanly stop the daemonized PostgreSQL (pg_ctl fast
         # stop) instead of leaving it to be SIGKILLed with WAL recovery next boot.

--- a/documentdb-local/scripts/emulator_entrypoint.sh
+++ b/documentdb-local/scripts/emulator_entrypoint.sh
@@ -118,29 +118,38 @@ Optional arguments:
                         docker run: --mount type=bind,source=./.local/data,target=/usr/documentdb/data)
                         Defaults to /data
                         Overrides DATA_PATH environment variable.
-  --documentdb-port     The port of the DocumentDB endpoint on the container. 
+  --documentdb-port [PORT]
+                        The port of the DocumentDB endpoint on the container.
                         You still need to publish this port (e.g. -p 10260:10260).
                         Defaults to 10260
                         Overrides DOCUMENTDB_PORT environment variable.
-  --enable-telemetry    Enable telemetry data sent to the usage colletor (Azure Application Insights). 
+  --enable-telemetry [true|false]
+                        Enable telemetry data sent to the usage collector.
+                        Defaults to false.
                         Overrides ENABLE_TELEMETRY environment variable.
-  --log-level           The verbosity of logs that will be emitted.
+  --log-level [LEVEL]   The verbosity of logs that will be emitted.
                         Overrides LOG_LEVEL environment variable.
                           quiet, error, warn, info (default), debug, trace
-  --username            Specify the username for the DocumentDB.
+  --username [NAME]     Specify the username for the DocumentDB.
                         Defaults to default_user
                         Overrides USERNAME environment variable.
-  --password            Specify the password for the DocumentDB.
-                        REQUIRED.
+  --password [PASSWORD] Specify the password for the DocumentDB.
+                        Always set this. If unset, a well-known built-in default is
+                        used and anyone who can reach the published port can
+                        authenticate with it.
                         Overrides PASSWORD environment variable.
-  --create-user         Specify whether to create a user. 
+  --create-user [true|false]
+                        Specify whether to create a user.
                         Defaults to true.
-  --start-pg            Specify whether to start the PostgreSQL server.
+                        Overrides CREATE_USER environment variable.
+  --start-pg [true|false]
+                        Specify whether to start the PostgreSQL server.
                         Defaults to true.
-  --pg-port             Specify the port for the PostgreSQL server.
+                        Overrides START_POSTGRESQL environment variable.
+  --pg-port [PORT]      Specify the port for the PostgreSQL server.
                         Defaults to 9712.
                         Overrides POSTGRESQL_PORT environment variable.
-  --owner               Specify the owner of the DocumentDB.
+  --owner [NAME]        Specify the owner of the DocumentDB.
                         Overrides OWNER environment variable.
                         defaults to documentdb.
   --allow-external-connections [true|false]


### PR DESCRIPTION
## Description

Extends the "honest help text" work already covered by `EntrypointUxTextTests`. Found while validating the [documentdb-local docs page](https://github.com/documentdb/docs/pull/60) against this script — several doc errors turned out to be faithful transcriptions of the help output, so the fix belongs here too.

Four claims in `--help` do not match what the script does:

**1. `--enable-telemetry` names a backend that does not exist.** The help says the usage collector is "Azure Application Insights." That string occurs exactly once in the repo — in this help line. There is no Application Insights integration and no instrumentation key anywhere. Also fixes the `colletor` typo on the same line.

**2. `--password` is documented `REQUIRED.`** `PASSWORD` falls back to a built-in default before the required-check runs, so the check never fires:

```sh
export PASSWORD=${PASSWORD:-Admin100}   # ~line 335
...
if [ -z "${PASSWORD:-}" ]; then         # ~line 394 — unreachable
```

This is the dangerous direction for a credential claim. An operator who trusts "REQUIRED" can start the container unattended and end up with the well-known default reachable on the published port. Replaced with what actually happens. (The existing `USING_DEFAULT_CREDS` warning still fires — this just stops the help from contradicting it.)

**3. `--create-user` and `--start-pg` listed no environment variable.** Both are read as `CREATE_USER` / `START_POSTGRESQL`, and both are set in `Dockerfile_documentdb_local`. The omission hid the only `docker run -e` path for either.

**4. Value-taking flags were shown as bare flags.** `--enable-telemetry`, `--create-user`, `--start-pg`, `--documentdb-port`, `--pg-port`, `--log-level`, `--username`, `--password` and `--owner` all parse as `shift; export X=$1; shift`, but were displayed without a placeholder — unlike `--cert-path [PATH]` and `--allow-external-connections [true|false]`. An operator writing the documented bare form has the flag consume the next argument.

### Deliberately not fixed here

Two related problems are behavior changes rather than text fixes, and are worth deciding on separately. Happy to open issues or follow-up PRs if you want them:

- **`LOG_LEVEL` and `ENABLE_TELEMETRY` are accepted and ignored.** Both are parsed and validated, but neither is written to `SetupConfiguration.json` or passed to the gateway. The gateway reads `DOCUMENTDB_LOG_LEVEL` (`configuration/setup.rs`), so `--log-level debug` currently validates, errors nothing, and changes no output.
- **The argument loop has no `*)` arm.** A stray non-option argument matches neither a flag nor `-*)`, so nothing shifts and `while [[ $# -gt 0 ]]` spins. This is reachable today from the bare-flag forms fixed above, which is what makes point 4 more than cosmetic.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** Claude Code
  - **How it was used:** Cross-referenced the docs page against this script to find the mismatches, then drafted the help-text edits and the regression tests. Every claim was verified against the source by hand before submitting, and the reasoning in this description reflects that verification rather than the model output.

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines

On testing scope, to be precise: `EntrypointUxTextTests` passes locally (7/7, including the 4 new tests). I did not build and run the container image — these are text-only changes to the help block, with no change to parsing or runtime behavior. The rest of `test_emulator_entrypoint.py` has the same pre-existing failure count with and without this change (67) on my Windows checkout, where the tests that shell out to `bash` mangle absolute paths; that is a local environment artifact, not something this PR touches.