### PR TITLE
packaging: remove unused build-image dependencies

### DIFF
--- a/packaging/deb/Dockerfile-deb
+++ b/packaging/deb/Dockerfile-deb
@@ -14,8 +14,7 @@ RUN apt-get install -y --no-install-recommends \
     gnupg2 \
     lsb-release \
     ca-certificates \
-    locales \
-    python3
+    locales
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen en_US.UTF-8
@@ -47,17 +46,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     devscripts \
     debhelper \
     dpkg-dev \
-    libipc-run-perl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts /tmp/install_setup
 
+# citus_indent is a code formatter and is deliberately not installed: the
+# package build never invokes it (debian/rules disables dh_auto_test) and the
+# formatting gate runs in the regress workflow instead. Installing it here also
+# meant compiling the pinned uncrustify 0.68.1 from source in every image build,
+# which does not build with GCC >= 15.
 RUN export CLEAN_SETUP=1 && \
     export INSTALL_DEPENDENCIES_ROOT=/tmp/install_setup && \
     MAKE_PROGRAM=cmake /tmp/install_setup/install_setup_libbson.sh && \
     /tmp/install_setup/install_setup_pcre2.sh && \
-    /tmp/install_setup/install_setup_intel_decimal_math_lib.sh && \
-    /tmp/install_setup/install_citus_indent.sh
+    /tmp/install_setup/install_setup_intel_decimal_math_lib.sh
 
 # Install PostGIS - try package first, fall back to building from source if not available
 RUN apt-get update && \
@@ -89,4 +91,3 @@ COPY packaging/deb/packaging-entrypoint.sh /usr/local/bin/packaging-entrypoint.s
 
 # Set the entrypoint
 ENTRYPOINT ["packaging-entrypoint.sh"]
-

--- a/packaging/deb/Dockerfile-deb
+++ b/packaging/deb/Dockerfile-deb
@@ -28,6 +28,10 @@ ENV LANG=en_US.UTF-8
 RUN echo "deb [signed-by=/usr/share/keyrings/pgdg-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main ${POSTGRES_VERSION}" > /etc/apt/sources.list.d/pgdg.list && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /usr/share/keyrings/pgdg-archive-keyring.gpg
 
+# Build-time dependencies only. The extension's runtime dependencies -- the
+# server package and the cron/pgvector/postgis/rum extensions -- are declared in
+# debian/control and resolved when the .deb is installed; nothing in the package
+# build compiles or links against them, so they are not installed here.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     tzdata \
@@ -35,14 +39,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     cmake \
     git \
-    postgresql-${POSTGRES_VERSION} \
     postgresql-server-dev-${POSTGRES_VERSION} \
     libpq-dev \
     libicu-dev \
     libkrb5-dev \
-    postgresql-${POSTGRES_VERSION}-cron \
-    postgresql-${POSTGRES_VERSION}-pgvector \
-    $(if [ "${POSTGRES_VERSION}" -lt 18 ]; then echo "postgresql-${POSTGRES_VERSION}-rum"; fi) \
     devscripts \
     debhelper \
     dpkg-dev \
@@ -60,20 +60,6 @@ RUN export CLEAN_SETUP=1 && \
     MAKE_PROGRAM=cmake /tmp/install_setup/install_setup_libbson.sh && \
     /tmp/install_setup/install_setup_pcre2.sh && \
     /tmp/install_setup/install_setup_intel_decimal_math_lib.sh
-
-# Install PostGIS - try package first, fall back to building from source if not available
-RUN apt-get update && \
-    (apt-get install -y --no-install-recommends postgresql-${POSTGRES_VERSION}-postgis-3 || \
-     (apt-get update && \
-      apt-get install -qy \
-      libproj-dev \
-      libxml2-dev \
-      libjson-c-dev \
-      libgeos-dev \
-      libgeos++-dev \
-    && rm -rf /var/lib/apt/lists/* && \
-    export INSTALL_DEPENDENCIES_ROOT=/tmp/install_setup && \
-    PGVERSION=${POSTGRES_VERSION} /tmp/install_setup/install_setup_postgis.sh))
 
 # Set the working directory inside the container
 WORKDIR /build

--- a/packaging/rpm/rhel-8/Dockerfile-rhel8
+++ b/packaging/rpm/rhel-8/Dockerfile-rhel8
@@ -44,8 +44,6 @@ RUN dnf -y install --allowerasing \
         which \
         libicu-devel \
         krb5-devel \
-        python3 \
-        perl-IPC-Run \
         tar && \
     dnf clean all
 
@@ -84,11 +82,13 @@ RUN rpmdev-setuptree
 
 COPY scripts /tmp/install_setup
 
+# citus_indent is a code formatter and is deliberately not installed: the spec
+# has no %check and the package build never invokes it. The formatting gate runs
+# in the regress workflow instead.
 RUN export INSTALL_DEPENDENCIES_ROOT=/tmp/install_setup && \
     MAKE_PROGRAM=cmake /tmp/install_setup/install_setup_libbson.sh && \
     /tmp/install_setup/install_setup_pcre2.sh && \
-    /tmp/install_setup/install_setup_intel_decimal_math_lib.sh && \
-    /tmp/install_setup/install_citus_indent.sh
+    /tmp/install_setup/install_setup_intel_decimal_math_lib.sh
 
 WORKDIR /build
 COPY . /build

--- a/packaging/rpm/rhel-9/Dockerfile-rhel9
+++ b/packaging/rpm/rhel-9/Dockerfile-rhel9
@@ -44,8 +44,6 @@ RUN dnf -y install --allowerasing \
         which \
         libicu-devel \
         krb5-devel \
-        python3 \
-        perl-IPC-Run \
         tar && \
     dnf update -y --refresh && \
     dnf clean all
@@ -86,11 +84,13 @@ RUN rpmdev-setuptree
 
 COPY scripts /tmp/install_setup
 
+# citus_indent is a code formatter and is deliberately not installed: the spec
+# has no %check and the package build never invokes it. The formatting gate runs
+# in the regress workflow instead.
 RUN export INSTALL_DEPENDENCIES_ROOT=/tmp/install_setup && \
     MAKE_PROGRAM=cmake /tmp/install_setup/install_setup_libbson.sh && \
     /tmp/install_setup/install_setup_pcre2.sh && \
-    /tmp/install_setup/install_setup_intel_decimal_math_lib.sh && \
-    /tmp/install_setup/install_citus_indent.sh
+    /tmp/install_setup/install_setup_intel_decimal_math_lib.sh
 
 WORKDIR /build
 COPY . /build

--- a/packaging/test_packages/deb/Dockerfile-deb-test
+++ b/packaging/test_packages/deb/Dockerfile-deb-test
@@ -31,8 +31,8 @@ RUN echo "deb [signed-by=/usr/share/keyrings/pgdg-archive-keyring.gpg] http://ap
 # actual dependencies of the package, plus libipc-run-perl for the TAP suites
 # (extended_rum_recovery_tests): PostgreSQL::Test::Cluster requires IPC::Run,
 # and without it every t/*.pl dies at compile ("Can't locate IPC/Run.pm",
-# "No plan found in TAP output") -- the build image already installs it
-# (libipc-run-perl in Dockerfile-deb), this test image must too.
+# "No plan found in TAP output"). This image is where `make check` actually
+# runs, so it is the image that needs it.
 RUN apt-get update && apt-get install -y \
     postgresql-${POSTGRES_VERSION} \
     postgresql-${POSTGRES_VERSION}-cron \


### PR DESCRIPTION
## Description

Removes dependencies that are not inputs to the extension package build:

- drops the formatter and TAP-only IPC module from DEB/RPM build images; test images retain the TAP dependency
- stops installing PostgreSQL runtime packages and the PostGIS source-build fallback in the DEB builder
- leaves DEB/RPM runtime dependency metadata unchanged

These Dockerfiles only create ephemeral package-builder images; the shipped package payload and runtime dependency declarations are intended to remain unchanged.

## Validation

- Before/after artifact comparisons are recorded in the two commit messages (payload file lists, per-file digests, and package dependency metadata).
- The internal OSS package gate is running against the exact Ubuntu 26.04 base branch.
- This draft PR is intended to exercise the public DEB/RPM package workflows against the public tree.

## Type of Change

- [x] DevOps / tooling
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring / cleanup
- [ ] Test improvement

## AI Disclosure

- [x] AI tools were used to assist with this PR
  - **Tool used:** GitHub Copilot CLI
  - **How it was used:** code review, dependency-path tracing, validation planning, and porting the reviewed commits to the public validation branch

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] All commits are signed off (DCO)
- [x] I have read the CONTRIBUTING guidelines