### PR TITLE
fix(gateway): reuse existing user pool on settings-key miss in get_data_pool

### DIFF
--- a/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
+++ b/pg_documentdb_gw/documentdb_gateway_core/src/postgres/conn_mgmt/pool_manager.rs
@@ -145,16 +145,35 @@ impl PoolManager {
     ) -> Result<Arc<ConnectionPool>> {
         let settings = PgPoolSettings::from_configuration(dynamic_configuration);
 
-        match self.user_data_pools.get(&(username.to_owned(), settings)) {
-            None => Err(DocumentDBError::internal_error(
-                "Connection pool missing for user.".to_owned(),
-            )),
-            Some(pool_ref) => {
-                let pool = Arc::clone(pool_ref.value());
-                pool.touch();
-                Ok(pool)
-            }
+        if let Some(pool_ref) = self.user_data_pools.get(&(username.to_owned(), settings)) {
+            let pool = Arc::clone(pool_ref.value());
+            pool.touch();
+            return Ok(pool);
         }
+
+        // The `settings` half of the key is derived from the live configuration and
+        // can shift out from under an already-authenticated connection: notably
+        // `max_connections` is re-read from a Postgres GUC on every dynamic-config
+        // refresh and silently defaults to 25 on a bad read (see
+        // `PgConfiguration::max_connections`). When it changes, the user's pool is
+        // still healthy but filed under a key that will never be recomputed, and a
+        // hard miss here permanently breaks every request for that user until they
+        // reconnect. Fall back to the existing pool for this username instead;
+        // `allocate_data_pool` re-files it under the current key on the next auth.
+        let fallback = self
+            .user_data_pools
+            .iter()
+            .find(|entry| entry.key().0 == username)
+            .map(|entry| Arc::clone(entry.value()));
+
+        if let Some(pool) = fallback {
+            pool.touch();
+            return Ok(pool);
+        }
+
+        Err(DocumentDBError::internal_error(
+            "Connection pool missing for user.".to_owned(),
+        ))
     }
 
     /// # Errors
@@ -678,6 +697,50 @@ mod tests {
         assert_eq!(
             dynamic_configuration.max_conn() * 2,
             user_pool.status().status().max_size
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_data_pool_falls_back_to_existing_pool_on_settings_change() {
+        // We still need an async context to create the connection pool (see
+        // ConnectionPool::new_with_user), but the test itself doesn't need to be async.
+        yield_now().await;
+
+        let dynamic_configuration = MaxConnectionConfig {
+            max_conn: 100.into(),
+        };
+        let pool_manager = test_pool_manager();
+
+        pool_manager
+            .allocate_data_pool("user", "password", &dynamic_configuration)
+            .unwrap();
+
+        let original_pool = pool_manager
+            .get_data_pool("user", &dynamic_configuration)
+            .unwrap();
+
+        // Simulate a dynamic-config refresh that flips `max_connections` (e.g. a bad
+        // GUC read silently defaulting to 25). This changes the `PgPoolSettings` half
+        // of the pool key so the exact-key lookup misses, but the user's pool is
+        // still healthy and must be reused instead of hard-erroring.
+        dynamic_configuration.set_max_conn(25);
+
+        let fallback_pool = pool_manager
+            .get_data_pool("user", &dynamic_configuration)
+            .expect(
+                "get_data_pool must fall back to the existing user pool on a settings-key miss",
+            );
+
+        assert!(
+            Arc::ptr_eq(&original_pool, &fallback_pool),
+            "settings-key miss must reuse the same warm pool for the user"
+        );
+
+        // No new pool was created by the fallback path.
+        assert_eq!(
+            3,
+            pool_manager.report_pool_stats().len(),
+            "2 system pools + 1 user pool; fallback must not allocate a new pool"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes #720.

`get_data_pool` (`postgres/conn_mgmt/pool_manager.rs`) keys the per-user pool cache on `(username, PgPoolSettings)`. `PgPoolSettings` includes `max_connections`, which is re-read from a Postgres GUC on every dynamic-config refresh (and silently defaults to `25` on a bad read). When it changes, the exact-key lookup misses and the gateway hard-fails **every** request for that user — permanently — even though their pool is still present and healthy. This PR makes `get_data_pool` reuse the user's existing pool on a settings-key miss instead of erroring. Root cause and evidence: #720.

## What changed

`get_data_pool` keeps the exact-key fast path, and on a miss reuses any existing pool for that `username` before erroring (illustrative):

```rust
if let Some(p) = self.user_data_pools.get(&(username.to_owned(), settings)) {
    p.touch(); return Ok(Arc::clone(p.value()));
}
// settings drifted (e.g. max_connections re-read) — pool is healthy but filed
// under a stale key. Reuse it; allocate_data_pool re-files under the current
// key on the next auth.
if let Some(p) = self.user_data_pools.iter()
    .find(|e| e.key().0 == username).map(|e| Arc::clone(e.value())) {
    p.touch(); return Ok(p);
}
Err(DocumentDBError::internal_error("Connection pool missing for user.".to_owned()))
```

Plus a regression test (`test_get_data_pool_falls_back_to_existing_pool_on_settings_change`): allocate a pool, flip `max_connections`, assert `get_data_pool` returns the *same* pool (`Arc::ptr_eq`) with no new pool created.

## Why it's correct

- The settings delta isn't a real topology change — role/password/live connections are unaffected; only the pool's *sizing* may lag by one refresh.
- Convergence is preserved: `allocate_data_pool` re-files the pool under the current key on the next authentication, so this only bridges the gap for already-authenticated users — it isn't a permanent bypass. The exact-key hit path is untouched, so the deliberate rebuild-on-`max_connections`-change (`validate_max_conn_change`) still works.

## Why not mirror `get_system_shared_pool`

That path self-heals by *building* a new pool from system credentials it always holds. `get_data_pool` has no user password at request time (only `allocate_data_pool` has it, at auth), so reusing the existing pool is the only option here.

## Alternatives considered

- **Drop `max_connections` from the key** — rejected: rebuilding pools on a real `max_connections` change is intentional/tested (`validate_max_conn_change`).
- **Harden `max_connections()` to not fabricate `25`** — good complementary defense-in-depth, but a *legitimate* `max_connections` change flips the same key and hits the same miss, so it's not a substitute. Happy to add as a follow-up.

## Testing

`cargo test -p documentdb_gateway_core pool_manager` → **13 passed, 0 failed** (the new test, the no-pool-still-errors case, and `validate_max_conn_change`). `rustfmt` + `clippy --workspace --all-targets --all-features -- -D warnings` clean on the pinned toolchain.

## Type of Change
- [x] Bug fix

## AI Disclosure
- [x] AI tools were used. **Tool:** Claude (Anthropic). Root-cause tracing, the fix, and the test were prepared with substantial AI assistance, then reviewed and verified against the source by the author.

## Checklist
- [x] I can explain every change if asked
- [x] Tested locally (`cargo test` — 13 passed)
- [x] Tests added/updated
- [x] Commits signed off (DCO)
- [x] Read CONTRIBUTING.md

---

Signed-off-by: Morchid Chellali <mc@wetransform.to>
