### PR TITLE
Bind the packaged gateway to loopback unless --listen-all is given

### DIFF
--- a/documentdb-local/scripts/documentdb-setup.sh
+++ b/documentdb-local/scripts/documentdb-setup.sh
@@ -76,6 +76,15 @@ PG_PORT=""
 PG_PORT_EXPLICIT=false
 GATEWAY_PORT="${DEFAULT_GATEWAY_PORT}"
 GATEWAY_PORT_EXPLICIT=false
+# Bind the gateway to loopback unless the operator explicitly asks for a
+# network-reachable listener. The gateway itself defaults to all interfaces
+# (`use_local_host` is false when DOCUMENTDB_LISTEN_ADDR carries no host), so a
+# wizard that passed the bare ":PORT" form published a MongoDB-compatible
+# endpoint on every interface of the host, protected only by the admin password
+# and fronted by an auto-generated self-signed certificate. On a cloud VM with a
+# permissive security group that is an internet-reachable database nobody asked
+# for. Exposure is now opt-in via --listen-all.
+LISTEN_ALL=false
 DATA_DIR=""
 DATA_DIR_EXPLICIT=false
 NO_ENABLE=false
@@ -184,6 +193,10 @@ Options:
   --pg-version <VER>      PostgreSQL version (auto-detected if not specified)
   --pg-port <PORT>        PostgreSQL port (default: 9700 + PG_VERSION)
   --listen-port <PORT>    Gateway listen port (default: 10260; also: --gateway-port)
+  --listen-all            Bind the gateway to all interfaces instead of
+                          127.0.0.1 only. The endpoint becomes reachable from
+                          the network, so firewall the port and supply a real
+                          certificate (--tls-cert/--tls-key) before using it.
   --data-dir <DIR>        PostgreSQL data directory
                           (default: /var/lib/documentdb-local/<VER>/data)
   --use-new-postgres-instance
@@ -2355,7 +2368,13 @@ ensure_pg_ident_map() {
     # load SetupConfiguration.json. So the operator's --listen-port has to
     # land in the per-major env file. Thread it through register-gateway.
     if [[ -n "${GATEWAY_PORT}" ]]; then
-        rg_args+=(--listen-addr ":${GATEWAY_PORT}")
+        # Loopback by default; ":PORT" (no host) is what makes the gateway bind
+        # 0.0.0.0 and [::], so it is used only when --listen-all was given.
+        if [[ "${LISTEN_ALL}" == "true" ]]; then
+            rg_args+=(--listen-addr ":${GATEWAY_PORT}")
+        else
+            rg_args+=(--listen-addr "127.0.0.1:${GATEWAY_PORT}")
+        fi
     fi
     # Standalone defaults to TLS auto-gen per design §4.3 — UNLESS the
     # operator explicitly passed --tls-cert/--tls-key (in which case
@@ -3967,6 +3986,10 @@ parse_arguments() {
                 ;;
             --no-enable)
                 NO_ENABLE=true
+                shift
+                ;;
+            --listen-all)
+                LISTEN_ALL=true
                 shift
                 ;;
             --skip-init-data)

--- a/documentdb-local/scripts/documentdb_local_tests/test_documentdb_setup.py
+++ b/documentdb-local/scripts/documentdb_local_tests/test_documentdb_setup.py
@@ -5897,6 +5897,36 @@ class GatewayEnvFragmentCarriesListenAddrTests(unittest.TestCase):
         self.assertIn('--tls-auto-generate true', body,
                       "setup must enable TLS auto-gen on standalone (design §4.3 default)")
 
+    def test_setup_binds_loopback_unless_listen_all(self):
+        """The gateway binds every interface when DOCUMENTDB_LISTEN_ADDR carries
+        no host (`use_local_host` defaults to false), so passing the bare
+        ":PORT" form unconditionally published the wire-protocol endpoint on
+        every interface of the host - guarded only by the admin password and an
+        auto-generated self-signed certificate. The default must be loopback,
+        with exposure opt-in via --listen-all."""
+        script = SETUP_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("LISTEN_ALL=false", script,
+                      "setup must default to a loopback-only gateway listener")
+        self.assertIn("--listen-all)", script,
+                      "setup must accept --listen-all to opt into an exposed listener")
+
+        match = re.search(
+            r"ensure_pg_ident_map\(\)\s*\{(?P<body>.*?)^\}",
+            script,
+            flags=re.DOTALL | re.MULTILINE,
+        )
+        self.assertIsNotNone(match)
+        body = match.group("body")
+        self.assertIn('--listen-addr "127.0.0.1:${GATEWAY_PORT}"', body,
+                      "setup must bind the gateway to loopback by default")
+        # The all-interfaces form must remain reachable, but only from the
+        # --listen-all branch: an unguarded ":${GATEWAY_PORT}" would restore the
+        # original exposure.
+        exposed = body.index('--listen-addr ":${GATEWAY_PORT}"')
+        guard = body.index('LISTEN_ALL')
+        self.assertLess(guard, exposed,
+                        "the all-interfaces listen address must be guarded by LISTEN_ALL")
+
 
 class BrownfieldUsesDistroSocketTests(unittest.TestCase):
     """Brownfield setup discovered


### PR DESCRIPTION
## Problem

`documentdb-setup` passes `--listen-addr ":${GATEWAY_PORT}"` to `documentdb-register-gateway` unconditionally. A listen address with **no host** is exactly what selects all-interfaces mode:

- `DocumentDBSetupConfiguration::use_local_host()` falls back to `false` when the host part is absent (`configuration/setup.rs`)
- `bind_listeners` then binds **both `0.0.0.0:PORT` and `[::]:PORT`** (`service/tcp_listener.rs`)

So the documented quickstart —

```bash
sudo apt install documentdb
sudo documentdb-setup --admin-user admin
```

— publishes a MongoDB-compatible endpoint on **every interface of the host**, protected only by the admin password and fronted by an auto-generated self-signed certificate that clients are told to accept via `tlsAllowInvalidCertificates=true`.

Nothing surfaces this. The connect string printed on success, and the one in the install docs, is `127.0.0.1:10260`, which reads as loopback-only. On a cloud VM with a permissive security group this is an internet-reachable database the operator never asked for.

The PostgreSQL instance behind it is *not* affected — it stays on `127.0.0.1:9700+N` — so the gateway was the only unintended listener.

Found while running a first-time-user install of v0.116-0 from the published packages and checking the result with `ss`:

```
LISTEN 0 4096 0.0.0.0:10260 0.0.0.0:*
LISTEN 0 4096    [::]:10260    [::]:*
```

## Change

Default to `127.0.0.1:${GATEWAY_PORT}`, and add `--listen-all` for operators who genuinely want a network-reachable listener.

No new plumbing is needed. `--listen-addr` already accepts loopback hosts, and the gateway already maps them to `use_local_host = true`, which binds `127.0.0.1` only — this is asserted by the gateway's own tests (`listen_addr_accepts_loopback_explicit_hosts` expects `Some(true)`, `listen_addr_accepts_bare_port_for_all_interfaces` expects `Some(false)`). The change simply stops choosing the exposed form by default.

```
-        rg_args+=(--listen-addr ":${GATEWAY_PORT}")
+        if [[ "${LISTEN_ALL}" == "true" ]]; then
+            rg_args+=(--listen-addr ":${GATEWAY_PORT}")
+        else
+            rg_args+=(--listen-addr "127.0.0.1:${GATEWAY_PORT}")
+        fi
```

## Compatibility

This changes the default for **new installs and re-runs** of `documentdb-setup`.

- An existing install keeps whatever is recorded in its per-major `gateway.env` until the wizard is re-run.
- Anyone who wants the previous behaviour passes `--listen-all`.
- `--listen-port` / `--gateway-port` are unaffected; only the host part changes.

Because it changes observable behaviour, this targets the next release rather than v0.116-0.

## Tests

Added `test_setup_binds_loopback_unless_listen_all` to `test_documentdb_setup.py`. It asserts the loopback default, that `--listen-all` exists, and — importantly — that the all-interfaces form appears **only** inside the `LISTEN_ALL` branch, so an unguarded `":${GATEWAY_PORT}"` cannot silently restore the exposure.

The pre-existing `test_setup_passes_listen_addr_to_register_gateway` still passes unchanged, since the exposed form remains present under the flag.

```
Ran 409 tests in 14.855s
OK
```

Verified the new test is meaningful rather than tautological: reverting just the default to `":${GATEWAY_PORT}"` turns it red (`FAILED (failures=1)`), and restoring it turns it green again.

## Follow-up (not in this PR)

`packaging/README.md` and the install docs should mention the listener's reachability and how to supply a real certificate; I've covered that on the website side in documentdb/documentdb.github.io#149.
