### PR TITLE
Add native one-command installer

### DIFF
--- a/.github/workflows/build_all_packages.yml
+++ b/.github/workflows/build_all_packages.yml
@@ -7,7 +7,8 @@
 # documentdb meta — across the OS/arch/PG matrix, and upload each slice as a
 # short-lived (7-day) artifact. That is convenient for per-cell debugging but
 # leaves no single, durable, verified place to pick up "all packages for
-# version X".
+# version X". The bundle also carries the reviewed `install.sh` bootstrap used
+# by documentdb.io; it is checksummed but excluded from package-count math.
 #
 # This workflow fans out to those two reusable workflows over the FULL matrix,
 # then aggregates every produced .deb/.rpm into one durable bundle with a
@@ -126,6 +127,7 @@ jobs:
           set -euo pipefail
 
           mkdir -p packages
+          install -m 0755 packaging/install.sh packages/install.sh
 
           # Collect every .deb/.rpm except Debian debug-symbol packages and
           # dedup by basename: the noarch extras and the PG-agnostic gateway
@@ -256,8 +258,10 @@ jobs:
             exit 1
           fi
 
-          # Reproducible, sorted checksum manifest over the package files only.
-          find . -maxdepth 1 -type f \( -name '*.deb' -o -name '*.rpm' \) -printf '%f\0' \
+          # Reproducible, sorted checksum manifest over packages and the
+          # one-command installer. Package category/total math below continues
+          # to count only .deb/.rpm files.
+          find . -maxdepth 1 -type f \( -name '*.deb' -o -name '*.rpm' -o -name 'install.sh' \) -printf '%f\0' \
             | sort -z | xargs -0 sha256sum > SHA256SUMS
 
           count_glob() { find . -maxdepth 1 -type f -name "$1" | wc -l | tr -d ' '; }
@@ -351,6 +355,9 @@ jobs:
             echo
             echo "Files:"
             find . -maxdepth 1 -type f \( -name '*.deb' -o -name '*.rpm' \) -printf '  %f\n' | sort
+            echo
+            echo "Installer:"
+            echo "  install.sh"
           } >> manifest.txt
 
           echo "----- manifest.txt -----"
@@ -452,6 +459,7 @@ jobs:
           path: |
             packages/*.deb
             packages/*.rpm
+            packages/install.sh
             packages/SHA256SUMS
             packages/manifest.txt
           retention-days: 90

--- a/.github/workflows/build_deb_packages.yml
+++ b/.github/workflows/build_deb_packages.yml
@@ -123,6 +123,18 @@ jobs:
           echo "DOCUMENTDB_VERSION=${{ steps.version.outputs.version }}" >> "$GITHUB_ENV"
           echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
 
+      - name: Test one-command installer behavior
+        if: matrix.os == 'ubuntu24.04' && matrix.arch == 'amd64' && matrix.pg_version == env.PAVED_PG_MAJOR
+        run: bash packaging/test_packages/test-install-script.sh
+
+      # Exercise the real host probes on both Tier-1 architectures. The
+      # deterministic suite above covers the RPM-family branches; this dry run
+      # additionally proves the script recognizes GitHub's native Ubuntu
+      # runners without mutating their repositories or packages.
+      - name: Verify installer dry-run on native runner
+        if: matrix.os == 'ubuntu24.04'
+        run: sh packaging/install.sh --dry-run --pg-major "${{ matrix.pg_version }}"
+
       - name: Build Debian Package
         run: |
           # Build the extension .deb only. `build_packages.sh

--- a/.github/workflows/documentdb_release.yml
+++ b/.github/workflows/documentdb_release.yml
@@ -2,11 +2,11 @@
 #
 # Package production goes through the consolidated build_all_packages.yml
 # reusable workflow, which fans out to the DEB/RPM builds over the Tier-1
-# matrix and emits ONE verified bundle: every .deb/.rpm, SHA256SUMS,
-# manifest.txt, gated by a per-category presence check. The release job
-# attaches that bundle verbatim, so a release can never ship a silently
-# partial package set (the v0.114-0 release shipped no RPMs at all —
-# exactly the failure mode the presence check exists to stop).
+# matrix and emits ONE verified bundle: every .deb/.rpm, the native install.sh
+# bootstrap, SHA256SUMS, and manifest.txt, gated by a per-category presence
+# check. The release job attaches that bundle verbatim, so a release can never
+# ship a silently partial package set (the v0.114-0 release shipped no RPMs at
+# all — exactly the failure mode the presence check exists to stop).
 #
 # Downstream: the documentdb.github.io deploy workflow downloads the
 # published release assets, GPG-signs them, and publishes the apt/yum
@@ -123,7 +123,7 @@ jobs:
 
       # Only the consolidated, presence-checked bundle is attached — not the
       # raw per-cell artifacts. It already contains every .deb/.rpm (deduped,
-      # dbgsym excluded) plus SHA256SUMS and manifest.txt.
+      # dbgsym excluded), install.sh, SHA256SUMS, and manifest.txt.
       - name: Download consolidated package bundle
         uses: actions/download-artifact@v4
         with:
@@ -199,7 +199,7 @@ jobs:
 
           ## 📦 Packages
 
-          All \`.deb\` / \`.rpm\` files are attached below, together with \`SHA256SUMS\` and \`manifest.txt\`. Verify after downloading:
+          All \`.deb\` / \`.rpm\` files and the clean-host \`install.sh\` bootstrap are attached below, together with \`SHA256SUMS\` and \`manifest.txt\`. Verify after downloading:
 
           \`\`\`sh
           gh release download v${VERSION_DASH} -R ${{ github.repository }} -D pkgs && cd pkgs && sha256sum -c SHA256SUMS

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -19,6 +19,44 @@ below, which is the authoritative statement of the CI scope); other OS/PG
 combinations are exposed by the build scripts below for community packagers and
 validation runs.
 
+## One-command native install
+
+`packaging/install.sh` is the clean-host bootstrap for the current package
+repository. It detects the host, configures the required signed repositories,
+installs the stand-alone `documentdb-N` package, and runs `documentdb-setup`
+to create and start a new private PostgreSQL-backed DocumentDB instance.
+
+```sh
+# Preview every operation without changing the host.
+./packaging/install.sh --dry-run
+
+# Interactive install. PostgreSQL 18 is the default.
+./packaging/install.sh
+
+# Select PostgreSQL 17 instead.
+./packaging/install.sh --pg-major 17
+```
+
+Supported native matrix:
+
+| Distribution | Architectures | PostgreSQL |
+|---|---|---|
+| Ubuntu 24.04 LTS | amd64, arm64 | 17, 18 |
+| RHEL 9 (registered or RHUI with CodeReady Builder), Rocky Linux / AlmaLinux / CentOS Stream 9 | x86_64, aarch64 | 17, 18 |
+
+The installer requires a running systemd host and root or `sudo` access. It is
+deliberately a **new-install bootstrap**, not an upgrade or recovery tool: it
+refuses existing DocumentDB packages, managed state, and data directories. If
+package installation succeeded but `documentdb-setup` later failed, resolve the
+reported error and run the setup command printed by the installer; it never
+removes or reuses existing data automatically.
+
+For unattended installation, pass `--yes --admin-password-file <FILE>`.
+Passwords are copied into a private temporary file and are never placed in the
+command line or environment. The setup wizard currently binds the gateway on
+all interfaces with a self-signed TLS certificate, so restrict the selected
+port with the host firewall before exposing it to an untrusted network.
+
 ## What CI builds (package-production tiers)
 
 First-party CI does **not** build the full distro × PG-major cartesian product.

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,0 +1,1160 @@
+#!/bin/sh
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Install the current stable DocumentDB stand-alone package from the hosted
+# package repository, then provision a new private PostgreSQL-backed instance.
+#
+# Supported targets:
+#   - Ubuntu 24.04 LTS on amd64 or arm64
+#   - RHEL, Rocky Linux, AlmaLinux, or CentOS Stream 9 on x86_64 or aarch64
+#
+# This is intentionally a new-install bootstrap, not an upgrade tool.
+
+set -eu
+
+umask 077
+
+PROGRAM="${0##*/}"
+DEFAULT_PG_MAJOR="18"
+DEFAULT_ADMIN_USER="admin"
+DEFAULT_LISTEN_PORT="10260"
+PGDG_APT_KEY_FINGERPRINT="B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8"
+DOCUMENTDB_KEY_FINGERPRINT="1F748DA911519E749521438252101F285C52B856"
+PGDG_APT_KEY_URL="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+DOCUMENTDB_KEY_URL="https://documentdb.io/documentdb-archive-keyring.gpg"
+EPEL_RELEASE_URL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+
+PG_MAJOR="${DEFAULT_PG_MAJOR}"
+ADMIN_USER="${DEFAULT_ADMIN_USER}"
+ADMIN_PASSWORD_FILE=""
+LISTEN_PORT="${DEFAULT_LISTEN_PORT}"
+ASSUME_YES="false"
+DRY_RUN="false"
+
+TESTING="${DOCUMENTDB_INSTALLER_TESTING:-false}"
+SYSTEM_ROOT=""
+TMP_DIR=""
+TTY_STATE=""
+TTY_PATH="/dev/tty"
+IS_ROOT="false"
+SUDO="sudo"
+
+OS_ID=""
+OS_VERSION_ID=""
+OS_DISPLAY=""
+PACKAGE_FAMILY=""
+DISTRO_KIND=""
+RAW_ARCH=""
+APT_ARCH=""
+RPM_ARCH=""
+PGDG_REPO_PRESENT="false"
+PGDG_MANAGED_SOURCE="false"
+DOCUMENTDB_REPO_PRESENT="false"
+RHEL_CRB_METHOD=""
+RHEL_CRB_REPO=""
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [OPTIONS]
+
+Install the current stable DocumentDB release and provision a new private
+DocumentDB instance.
+
+Supported hosts:
+  Ubuntu 24.04 LTS                 amd64, arm64
+  RHEL/Rocky/Alma/CentOS Stream 9 x86_64, aarch64
+
+Options:
+  --pg-major <17|18>          PostgreSQL major (default: 18)
+  --admin-user <USER>         Initial DocumentDB administrator (default: admin)
+  --admin-password-file <FILE>
+                              Read the initial administrator password from FILE.
+                              Required with --yes.
+  --listen-port <PORT>        Gateway port, 1024-65535 (default: 10260)
+  --yes                       Do not ask for confirmation. Requires
+                              --admin-password-file and non-interactive sudo.
+  --dry-run                   Detect the host and print the planned operations
+                              without changing files, repositories, or packages.
+  -h, --help                  Show this help.
+
+Interactive installation from a repository checkout:
+  ./packaging/install.sh
+
+Non-interactive installation from a repository checkout:
+  ./packaging/install.sh --yes \
+    --admin-password-file /secure/path/password
+
+This installer is for clean hosts. It refuses to upgrade, replace, or resume an
+existing DocumentDB installation and never removes existing data.
+EOF
+}
+
+log() {
+    printf '[documentdb-install] %s\n' "$*"
+}
+
+warn() {
+    printf '[documentdb-install] WARNING: %s\n' "$*" >&2
+}
+
+die() {
+    printf '[documentdb-install] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+restore_tty() {
+    if [ -n "${TTY_STATE}" ] && [ -r "${TTY_PATH}" ]; then
+        stty "${TTY_STATE}" < "${TTY_PATH}" 2>/dev/null || true
+        TTY_STATE=""
+        printf '\n' > "${TTY_PATH}" 2>/dev/null || true
+    fi
+}
+
+cleanup() {
+    restore_tty
+    if [ -n "${TMP_DIR}" ] && [ -d "${TMP_DIR}" ]; then
+        rm -rf "${TMP_DIR}"
+    fi
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+system_path() {
+    printf '%s%s\n' "${SYSTEM_ROOT}" "$1"
+}
+
+lowercase() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+strip_outer_quotes() {
+    value="$1"
+    case "${value}" in
+        \"*\")
+            value=${value#\"}
+            value=${value%\"}
+            ;;
+        \'*\')
+            value=${value#\'}
+            value=${value%\'}
+            ;;
+    esac
+    printf '%s\n' "${value}"
+}
+
+parse_arguments() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --pg-major)
+                [ "$#" -ge 2 ] || die "--pg-major requires a value."
+                PG_MAJOR="$2"
+                shift 2
+                ;;
+            --admin-user)
+                [ "$#" -ge 2 ] || die "--admin-user requires a value."
+                ADMIN_USER="$2"
+                shift 2
+                ;;
+            --admin-password-file)
+                [ "$#" -ge 2 ] || die "--admin-password-file requires a value."
+                ADMIN_PASSWORD_FILE="$2"
+                shift 2
+                ;;
+            --listen-port)
+                [ "$#" -ge 2 ] || die "--listen-port requires a value."
+                LISTEN_PORT="$2"
+                shift 2
+                ;;
+            --yes)
+                ASSUME_YES="true"
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN="true"
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            --)
+                shift
+                [ "$#" -eq 0 ] || die "Unexpected positional arguments: $*"
+                ;;
+            *)
+                die "Unknown option: $1. Run ${PROGRAM} --help for usage."
+                ;;
+        esac
+    done
+}
+
+validate_arguments() {
+    case "${PG_MAJOR}" in
+        17|18) ;;
+        *) die "--pg-major must be 17 or 18." ;;
+    esac
+
+    [ -n "${ADMIN_USER}" ] || die "--admin-user cannot be empty."
+    case "${ADMIN_USER}" in
+        *'
+'*) die "--admin-user cannot contain a newline." ;;
+    esac
+
+    case "${LISTEN_PORT}" in
+        ''|*[!0-9]*) die "--listen-port must be a number from 1024 through 65535." ;;
+    esac
+    [ "${#LISTEN_PORT}" -le 5 ] ||
+        die "--listen-port must be from 1024 through 65535."
+    if [ "${LISTEN_PORT}" -lt 1024 ] || [ "${LISTEN_PORT}" -gt 65535 ]; then
+        die "--listen-port must be from 1024 through 65535."
+    fi
+
+    if [ "${DRY_RUN}" = "false" ] && [ "${ASSUME_YES}" = "true" ] &&
+       [ -z "${ADMIN_PASSWORD_FILE}" ]; then
+        die "--yes requires --admin-password-file."
+    fi
+
+    if [ "${DRY_RUN}" = "false" ] && [ -n "${ADMIN_PASSWORD_FILE}" ]; then
+        [ -f "${ADMIN_PASSWORD_FILE}" ] ||
+            die "Password file '${ADMIN_PASSWORD_FILE}' is not a regular file."
+        [ -r "${ADMIN_PASSWORD_FILE}" ] ||
+            die "Password file '${ADMIN_PASSWORD_FILE}' is not readable."
+    fi
+}
+
+initialize_environment() {
+    case "${TESTING}" in
+        true|false) ;;
+        *) die "DOCUMENTDB_INSTALLER_TESTING must be true or false." ;;
+    esac
+
+    if [ "${TESTING}" = "true" ]; then
+        [ "${DRY_RUN}" = "true" ] ||
+            die "Internal installer test mode is restricted to --dry-run."
+        SYSTEM_ROOT="${DOCUMENTDB_INSTALLER_TEST_ROOT:-}"
+        case "${SYSTEM_ROOT}" in
+            /*|'') ;;
+            *) die "DOCUMENTDB_INSTALLER_TEST_ROOT must be an absolute path." ;;
+        esac
+        return
+    fi
+
+    PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+    export PATH
+    unset CDPATH ENV BASH_ENV APT_CONFIG DNF0_CONFIG_FILE GNUPGHOME GPG_AGENT_INFO || true
+    LC_ALL=C
+    export LC_ALL
+}
+
+command_exists() {
+    if [ "${TESTING}" = "true" ]; then
+        missing="${DOCUMENTDB_INSTALLER_TEST_MISSING_COMMAND:-}"
+        [ "$1" != "${missing}" ]
+        return
+    fi
+    command -v "$1" >/dev/null 2>&1
+}
+
+require_command() {
+    command_exists "$1" || die "Required command '$1' is not available."
+}
+
+get_uname_s() {
+    if [ "${TESTING}" = "true" ]; then
+        printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_UNAME_S:-Linux}"
+    else
+        uname -s
+    fi
+}
+
+get_uname_m() {
+    if [ "${TESTING}" = "true" ]; then
+        printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_UNAME_M:-x86_64}"
+    else
+        uname -m
+    fi
+}
+
+get_kernel_release() {
+    if [ "${TESTING}" = "true" ]; then
+        printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_KERNEL_RELEASE:-generic-linux}"
+        return
+    fi
+    kernel_release_file="$(system_path /proc/sys/kernel/osrelease)"
+    if [ -r "${kernel_release_file}" ]; then
+        cat "${kernel_release_file}"
+    else
+        uname -r
+    fi
+}
+
+get_systemd_state() {
+    if [ "${TESTING}" = "true" ]; then
+        printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_SYSTEMD_STATE:-running}"
+    else
+        systemctl is-system-running 2>/dev/null || true
+    fi
+}
+
+get_container_virtualization() {
+    if [ "${TESTING}" = "true" ]; then
+        printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_CONTAINER_VIRT:-none}"
+        return
+    fi
+    if command_exists systemd-detect-virt; then
+        systemd-detect-virt --container 2>/dev/null || true
+    else
+        printf 'none\n'
+    fi
+}
+
+get_chroot_virtualization() {
+    if [ "${TESTING}" = "true" ]; then
+        printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_CHROOT_VIRT:-none}"
+        return
+    fi
+    if command_exists systemd-detect-virt; then
+        systemd-detect-virt --chroot 2>/dev/null || true
+    else
+        printf 'none\n'
+    fi
+}
+
+get_native_package_arch() {
+    if [ "${TESTING}" = "true" ]; then
+        if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+            printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_NATIVE_ARCH:-${APT_ARCH}}"
+        else
+            printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_NATIVE_ARCH:-${RPM_ARCH}}"
+        fi
+        return
+    fi
+
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        dpkg --print-architecture
+    else
+        rpm --eval '%{_arch}'
+    fi
+}
+
+read_os_release() {
+    os_release_file="$(system_path /etc/os-release)"
+    [ -r "${os_release_file}" ] || die "Cannot read ${os_release_file}."
+
+    OS_ID=""
+    OS_VERSION_ID=""
+    while IFS='=' read -r key value; do
+        case "${key}" in
+            ID)
+                OS_ID="$(strip_outer_quotes "${value}")"
+                ;;
+            VERSION_ID)
+                OS_VERSION_ID="$(strip_outer_quotes "${value}")"
+                ;;
+        esac
+    done < "${os_release_file}"
+
+    OS_ID="$(lowercase "${OS_ID}")"
+    case "${OS_ID}" in
+        ''|*[!a-z0-9._-]*) die "Invalid ID in ${os_release_file}." ;;
+    esac
+    case "${OS_VERSION_ID}" in
+        ''|*[!0-9.]*) die "Invalid VERSION_ID in ${os_release_file}." ;;
+    esac
+}
+
+detect_platform() {
+    os_name="$(get_uname_s)"
+    [ "${os_name}" = "Linux" ] ||
+        die "Unsupported operating system '${os_name}'. This installer supports Linux only."
+
+    kernel_release="$(lowercase "$(get_kernel_release)")"
+    case "${kernel_release}" in
+        *microsoft*|*wsl*)
+            die "Windows Subsystem for Linux is not supported by this installer."
+            ;;
+    esac
+
+    read_os_release
+
+    case "${OS_ID}" in
+        ubuntu)
+            [ "${OS_VERSION_ID}" = "24.04" ] ||
+                die "Unsupported Ubuntu release ${OS_VERSION_ID}. Only Ubuntu 24.04 LTS is supported."
+            PACKAGE_FAMILY="apt"
+            DISTRO_KIND="ubuntu"
+            OS_DISPLAY="Ubuntu 24.04 LTS"
+            ;;
+        rhel)
+            case "${OS_VERSION_ID}" in
+                9|9.*) ;;
+                *) die "Unsupported RHEL release ${OS_VERSION_ID}. Only RHEL 9 is supported." ;;
+            esac
+            PACKAGE_FAMILY="rpm"
+            DISTRO_KIND="rhel"
+            OS_DISPLAY="Red Hat Enterprise Linux 9"
+            ;;
+        rocky)
+            case "${OS_VERSION_ID}" in
+                9|9.*) ;;
+                *) die "Unsupported Rocky Linux release ${OS_VERSION_ID}. Only Rocky Linux 9 is supported." ;;
+            esac
+            PACKAGE_FAMILY="rpm"
+            DISTRO_KIND="rocky"
+            OS_DISPLAY="Rocky Linux 9"
+            ;;
+        almalinux)
+            case "${OS_VERSION_ID}" in
+                9|9.*) ;;
+                *) die "Unsupported AlmaLinux release ${OS_VERSION_ID}. Only AlmaLinux 9 is supported." ;;
+            esac
+            PACKAGE_FAMILY="rpm"
+            DISTRO_KIND="almalinux"
+            OS_DISPLAY="AlmaLinux 9"
+            ;;
+        centos)
+            case "${OS_VERSION_ID}" in
+                9|9.*) ;;
+                *) die "Unsupported CentOS release ${OS_VERSION_ID}. Only CentOS Stream 9 is supported." ;;
+            esac
+            PACKAGE_FAMILY="rpm"
+            DISTRO_KIND="centos-stream"
+            OS_DISPLAY="CentOS Stream 9"
+            ;;
+        *)
+            die "Unsupported Linux distribution '${OS_ID}' ${OS_VERSION_ID}. Supported distributions are Ubuntu 24.04 and RHEL-compatible 9."
+            ;;
+    esac
+
+    RAW_ARCH="$(lowercase "$(get_uname_m)")"
+    case "${RAW_ARCH}" in
+        x86_64|amd64)
+            APT_ARCH="amd64"
+            RPM_ARCH="x86_64"
+            ;;
+        aarch64|arm64)
+            APT_ARCH="arm64"
+            RPM_ARCH="aarch64"
+            ;;
+        *)
+            die "Unsupported CPU architecture '${RAW_ARCH}'. Supported architectures are x86_64 and arm64."
+            ;;
+    esac
+}
+
+validate_native_environment() {
+    require_command grep
+    require_command awk
+    require_command sed
+    require_command sort
+    require_command find
+    require_command mktemp
+    require_command install
+    require_command systemctl
+
+    systemd_dir="$(system_path /run/systemd/system)"
+    [ -d "${systemd_dir}" ] ||
+        die "A running systemd host is required; ${systemd_dir} is not present."
+
+    systemd_state="$(get_systemd_state)"
+    case "${systemd_state}" in
+        running|degraded) ;;
+        *) die "systemd is not ready (state: ${systemd_state:-unknown})." ;;
+    esac
+
+    container_virt="$(get_container_virtualization)"
+    case "${container_virt}" in
+        ''|none) ;;
+        *) die "Container environment '${container_virt}' is not supported by the native installer." ;;
+    esac
+
+    chroot_virt="$(get_chroot_virtualization)"
+    case "${chroot_virt}" in
+        ''|none) ;;
+        *) die "Chroot environment '${chroot_virt}' is not supported by the native installer." ;;
+    esac
+
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        require_command apt-get
+        require_command dpkg
+        require_command dpkg-query
+    else
+        require_command dnf
+        require_command rpm
+    fi
+
+    native_arch="$(lowercase "$(get_native_package_arch)")"
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        [ "${native_arch}" = "${APT_ARCH}" ] ||
+            die "Kernel architecture '${RAW_ARCH}' does not match dpkg architecture '${native_arch}'."
+    else
+        [ "${native_arch}" = "${RPM_ARCH}" ] ||
+            die "Kernel architecture '${RAW_ARCH}' does not match RPM architecture '${native_arch}'."
+    fi
+}
+
+list_existing_packages() {
+    if [ "${TESTING}" = "true" ]; then
+        printf '%s\n' "${DOCUMENTDB_INSTALLER_TEST_EXISTING_PACKAGES:-}"
+        return
+    fi
+
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        dpkg-query -W -f='${db:Status-Abbrev} ${binary:Package}\n' \
+            'documentdb*' 'postgresql-*-documentdb' 2>/dev/null |
+            awk '$1 !~ /^un/ { print $2 }' | sort -u || true
+    else
+        {
+            rpm -qa 'documentdb*' 2>/dev/null || true
+            rpm -qa 'postgresql*documentdb*' 2>/dev/null || true
+        } | sort -u
+    fi
+}
+
+directory_has_entries() {
+    directory="$1"
+    [ -d "${directory}" ] || return 1
+    first_entry="$(find "${directory}" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)"
+    [ -n "${first_entry}" ]
+}
+
+detect_existing_installation() {
+    existing_packages="$(list_existing_packages)"
+    if [ -n "${existing_packages}" ]; then
+        printf '%s\n' "${existing_packages}" | sed 's/^/  - /' >&2
+        die "DocumentDB packages are already installed. This bootstrap does not perform upgrades. If a previous install stopped after package installation, run documentdb-setup directly to resume it."
+    fi
+
+    if [ "${TESTING}" = "false" ] && command_exists documentdb-setup; then
+        die "documentdb-setup is already present on PATH. Refusing to replace or upgrade an existing installation."
+    fi
+
+    state_dir="$(system_path /etc/documentdb/local)"
+    data_dir="$(system_path /var/lib/documentdb-local)"
+    if directory_has_entries "${state_dir}" || directory_has_entries "${data_dir}"; then
+        die "Residual DocumentDB state exists under /etc/documentdb/local or /var/lib/documentdb-local. Refusing to reuse or remove existing data."
+    fi
+
+    alias_unit="$(system_path /etc/systemd/system/documentdb-local.target)"
+    if [ -e "${alias_unit}" ] || [ -L "${alias_unit}" ]; then
+        die "Residual systemd unit ${alias_unit} exists. Remove or reconcile the prior installation manually."
+    fi
+}
+
+file_contains() {
+    file="$1"
+    pattern="$2"
+    [ -r "${file}" ] && grep -Eq "${pattern}" "${file}"
+}
+
+file_matches_content() {
+    file="$1"
+    expected="$2"
+    [ -r "${file}" ] || return 1
+    actual="$(
+        sed \
+            -e '/^[[:space:]]*#/d' \
+            -e '/^[[:space:]]*$/d' \
+            -e 's/[[:space:]]*$//' \
+            "${file}"
+    )"
+    [ "${actual}" = "${expected}" ]
+}
+
+preflight_apt_repositories() {
+    sources_list="$(system_path /etc/apt/sources.list)"
+    sources_dir="$(system_path /etc/apt/sources.list.d)"
+    managed_pgdg="$(system_path /etc/apt/sources.list.d/pgdg.list)"
+    managed_docdb="$(system_path /etc/apt/sources.list.d/documentdb.list)"
+    desired_pgdg="deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main"
+    desired_docdb="deb [arch=${APT_ARCH} signed-by=/usr/share/keyrings/documentdb-archive-keyring.gpg] https://documentdb.io/deb stable ubuntu24"
+
+    PGDG_REPO_PRESENT="false"
+    PGDG_MANAGED_SOURCE="false"
+    DOCUMENTDB_REPO_PRESENT="false"
+
+    for file in "${sources_list}" "${sources_dir}"/*.list "${sources_dir}"/*.sources; do
+        [ -f "${file}" ] || continue
+        if file_contains "${file}" 'apt\.postgresql\.org/pub/repos/apt'; then
+            if [ "${file}" != "${managed_pgdg}" ] ||
+               ! file_matches_content "${file}" "${desired_pgdg}"; then
+                die "Conflicting PGDG repository configuration found in ${file}. The installer only reuses its exact HTTPS noble-pgdg source definition."
+            fi
+            PGDG_REPO_PRESENT="true"
+            PGDG_MANAGED_SOURCE="true"
+        fi
+        if file_contains "${file}" 'documentdb\.io/deb'; then
+            if [ "${file}" != "${managed_docdb}" ] ||
+               ! file_matches_content "${file}" "${desired_docdb}"; then
+                die "Conflicting DocumentDB repository configuration found in ${file}."
+            fi
+            DOCUMENTDB_REPO_PRESENT="true"
+        fi
+    done
+
+    if [ -e "${managed_pgdg}" ] && [ "${PGDG_REPO_PRESENT}" = "false" ]; then
+        die "Refusing to overwrite unrelated repository file ${managed_pgdg}."
+    fi
+    if [ -e "${managed_docdb}" ] && [ "${DOCUMENTDB_REPO_PRESENT}" = "false" ]; then
+        die "Refusing to overwrite unrelated repository file ${managed_docdb}."
+    fi
+
+    DESIRED_PGDG_SOURCE="${desired_pgdg}"
+    DESIRED_DOCUMENTDB_SOURCE="${desired_docdb}"
+}
+
+detect_rhel_crb_method() {
+    if [ "${TESTING}" = "true" ]; then
+        if [ "${DOCUMENTDB_INSTALLER_TEST_RHEL_REGISTERED:-true}" = "true" ]; then
+            RHEL_CRB_METHOD="subscription-manager"
+            RHEL_CRB_REPO="codeready-builder-for-rhel-9-${RPM_ARCH}-rpms"
+            return
+        fi
+        RHEL_CRB_REPO="${DOCUMENTDB_INSTALLER_TEST_RHEL_CRB_REPO:-}"
+        [ -n "${RHEL_CRB_REPO}" ] ||
+            die "RHEL 9 is not registered and no RHUI CodeReady Builder repository is available."
+        RHEL_CRB_METHOD="dnf"
+        return
+    fi
+
+    if command_exists subscription-manager &&
+       subscription-manager identity >/dev/null 2>&1; then
+        RHEL_CRB_METHOD="subscription-manager"
+        RHEL_CRB_REPO="codeready-builder-for-rhel-9-${RPM_ARCH}-rpms"
+        return
+    fi
+
+    RHEL_CRB_REPO="$(
+        dnf -q repolist --all 2>/dev/null |
+            awk 'tolower($1) ~ /codeready-builder/ && tolower($1) ~ /rhel-9/ { print $1; exit }'
+    )"
+    [ -n "${RHEL_CRB_REPO}" ] ||
+        die "RHEL 9 is not registered with subscription-manager and no RHUI CodeReady Builder repository was found."
+    RHEL_CRB_METHOD="dnf"
+}
+
+preflight_rpm_repositories() {
+    repo_dir="$(system_path /etc/yum.repos.d)"
+    managed_docdb="$(system_path /etc/yum.repos.d/documentdb.repo)"
+    managed_pgdg="$(system_path /etc/yum.repos.d/pgdg-redhat-all.repo)"
+    docdb_key="$(system_path /etc/pki/rpm-gpg/RPM-GPG-KEY-documentdb)"
+    desired_docdb="[documentdb]
+name=DocumentDB Repository
+baseurl=https://documentdb.io/rpm/rhel9
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file://${docdb_key}"
+
+    PGDG_REPO_PRESENT="false"
+    DOCUMENTDB_REPO_PRESENT="false"
+
+    for file in "${repo_dir}"/*.repo; do
+        [ -f "${file}" ] || continue
+        if file_contains "${file}" 'download\.postgresql\.org/pub/repos/yum'; then
+            if [ "${file}" != "${managed_pgdg}" ]; then
+                die "Conflicting PGDG repository configuration found in ${file}. The installer only reuses the PGDG repository package's canonical pgdg-redhat-all.repo file."
+            fi
+            if [ "${TESTING}" = "false" ] &&
+               ! rpm -q pgdg-redhat-repo >/dev/null 2>&1; then
+                die "${managed_pgdg} exists but is not owned by the pgdg-redhat-repo package."
+            fi
+            PGDG_REPO_PRESENT="true"
+        fi
+        if file_contains "${file}" 'documentdb\.io/rpm'; then
+            if [ "${file}" != "${managed_docdb}" ] ||
+               ! file_matches_content "${file}" "${desired_docdb}"; then
+                die "Conflicting DocumentDB repository configuration found in ${file}."
+            fi
+            DOCUMENTDB_REPO_PRESENT="true"
+        fi
+    done
+
+    if [ -e "${managed_docdb}" ] && [ "${DOCUMENTDB_REPO_PRESENT}" = "false" ]; then
+        die "Refusing to overwrite unrelated repository file ${managed_docdb}."
+    fi
+
+    if [ "${TESTING}" = "false" ] && rpm -q postgresql-server >/dev/null 2>&1; then
+        die "The RHEL AppStream postgresql-server package is installed. Refusing to disable the PostgreSQL module on an existing PostgreSQL host."
+    fi
+
+    if [ "${DISTRO_KIND}" = "rhel" ]; then
+        detect_rhel_crb_method
+    fi
+
+    DESIRED_DOCUMENTDB_RPM_REPO="${desired_docdb}"
+}
+
+preflight_repositories() {
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        preflight_apt_repositories
+    else
+        preflight_rpm_repositories
+    fi
+}
+
+print_argument() {
+    argument="$1"
+    case "${argument}" in
+        ''|*[!A-Za-z0-9_./:=,@%+-]*)
+            escaped="$(printf '%s' "${argument}" | sed "s/'/'\\\\''/g")"
+            printf "'%s'" "${escaped}"
+            ;;
+        *)
+            printf '%s' "${argument}"
+            ;;
+    esac
+}
+
+print_command() {
+    printf '  +'
+    for argument in "$@"; do
+        printf ' '
+        print_argument "${argument}"
+    done
+    printf '\n'
+}
+
+run_command() {
+    if [ "${DRY_RUN}" = "true" ]; then
+        print_command "$@"
+    else
+        "$@"
+    fi
+}
+
+run_root() {
+    if [ "${IS_ROOT}" = "true" ]; then
+        run_command "$@"
+    else
+        run_command "${SUDO}" "$@"
+    fi
+}
+
+run_root_no_stdin() {
+    if [ "${DRY_RUN}" = "true" ]; then
+        run_root "$@"
+    elif [ "${IS_ROOT}" = "true" ]; then
+        "$@" < /dev/null
+    else
+        "${SUDO}" "$@" < /dev/null
+    fi
+}
+
+write_root_file() {
+    destination="$1"
+    mode="$2"
+    content="$3"
+
+    if [ "${DRY_RUN}" = "true" ]; then
+        log "Would write ${destination} (mode ${mode}):"
+        printf '%s\n' "${content}" | sed 's/^/    /'
+        return
+    fi
+
+    staged="${TMP_DIR}/$(basename "${destination}").staged"
+    printf '%s\n' "${content}" > "${staged}"
+    run_root install -D -m "${mode}" "${staged}" "${destination}"
+}
+
+strict_curl() {
+    url="$1"
+    output="$2"
+    curl --disable --proto '=https' --proto-redir '=https' --tlsv1.2 \
+        -fsSL "${url}" -o "${output}"
+}
+
+verify_key_fingerprint() {
+    key_file="$1"
+    expected="$2"
+    label="$3"
+
+    key_listing="$(
+        GNUPGHOME="${TMP_DIR}/gnupg" gpg --no-options --batch \
+            --show-keys --with-colons "${key_file}" 2>/dev/null
+    )" || die "Cannot inspect the ${label} signing key."
+
+    public_key_count="$(printf '%s\n' "${key_listing}" | awk -F: '$1 == "pub" { count++ } END { print count + 0 }')"
+    [ "${public_key_count}" -eq 1 ] ||
+        die "${label} key file contains ${public_key_count} primary keys; expected exactly one."
+
+    actual="$(printf '%s\n' "${key_listing}" |
+        awk -F: '$1 == "pub" { want = 1; next } want && $1 == "fpr" { print toupper($10); exit }')"
+    [ "${actual}" = "${expected}" ] ||
+        die "${label} key fingerprint is ${actual:-unknown}; expected ${expected}."
+}
+
+download_key() {
+    url="$1"
+    output="$2"
+    expected="$3"
+    label="$4"
+
+    if [ "${DRY_RUN}" = "true" ]; then
+        log "Would download ${label} key from ${url} and require fingerprint ${expected}."
+        return
+    fi
+
+    strict_curl "${url}" "${output}"
+    verify_key_fingerprint "${output}" "${expected}" "${label}"
+}
+
+ensure_apt_keyring() {
+    destination="$1"
+    url="$2"
+    expected="$3"
+    label="$4"
+    armored="${TMP_DIR}/$(basename "${destination}").asc"
+    binary="${TMP_DIR}/$(basename "${destination}").gpg"
+
+    if [ "${DRY_RUN}" = "true" ]; then
+        log "Would verify or install ${destination} for ${label}."
+        download_key "${url}" "${armored}" "${expected}" "${label}"
+        return
+    fi
+
+    if [ -f "${destination}" ]; then
+        verify_key_fingerprint "${destination}" "${expected}" "${label}"
+        return
+    fi
+
+    download_key "${url}" "${armored}" "${expected}" "${label}"
+    GNUPGHOME="${TMP_DIR}/gnupg" gpg --no-options --batch --yes \
+        --dearmor --output "${binary}" "${armored}"
+    run_root install -D -m 0644 "${binary}" "${destination}"
+}
+
+ensure_rpm_documentdb_key() {
+    destination="$(system_path /etc/pki/rpm-gpg/RPM-GPG-KEY-documentdb)"
+    downloaded="${TMP_DIR}/RPM-GPG-KEY-documentdb"
+
+    if [ "${DRY_RUN}" = "true" ]; then
+        log "Would verify or install ${destination}."
+        download_key "${DOCUMENTDB_KEY_URL}" "${downloaded}" \
+            "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
+        run_root rpm --import "${destination}"
+        return
+    fi
+
+    if [ -f "${destination}" ]; then
+        verify_key_fingerprint "${destination}" \
+            "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
+    else
+        download_key "${DOCUMENTDB_KEY_URL}" "${downloaded}" \
+            "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
+        run_root install -D -m 0644 "${downloaded}" "${destination}"
+    fi
+    run_root_no_stdin rpm --import "${destination}"
+}
+
+create_temp_dir() {
+    [ "${DRY_RUN}" = "false" ] || return
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/documentdb-install.XXXXXX")"
+    mkdir -m 0700 "${TMP_DIR}/gnupg"
+}
+
+determine_privilege_mode() {
+    if [ "${TESTING}" = "true" ]; then
+        IS_ROOT="false"
+        SUDO="sudo"
+        return
+    fi
+
+    if [ "$(id -u)" -eq 0 ]; then
+        IS_ROOT="true"
+        SUDO=""
+        return
+    fi
+
+    require_command sudo
+    IS_ROOT="false"
+    SUDO="sudo"
+}
+
+acquire_privileges() {
+    [ "${DRY_RUN}" = "false" ] || return
+    [ "${IS_ROOT}" = "false" ] || return
+
+    if [ "${ASSUME_YES}" = "true" ]; then
+        sudo -n true >/dev/null 2>&1 ||
+            die "--yes requires root or non-interactive sudo access."
+    else
+        sudo -v
+    fi
+}
+
+tty_available() {
+    [ -r "${TTY_PATH}" ] && [ -w "${TTY_PATH}" ]
+}
+
+confirm_plan() {
+    [ "${DRY_RUN}" = "false" ] || return
+    [ "${ASSUME_YES}" = "false" ] || return
+    tty_available ||
+        die "Interactive confirmation requires /dev/tty. Use --yes with --admin-password-file for unattended installation."
+
+    printf 'Continue with this installation? [y/N] ' > "${TTY_PATH}"
+    answer=""
+    IFS= read -r answer < "${TTY_PATH}" || true
+    case "${answer}" in
+        y|Y|yes|YES) ;;
+        *) die "Installation cancelled." ;;
+    esac
+}
+
+prompt_password_file() {
+    [ "${DRY_RUN}" = "false" ] || return
+
+    password_copy="${TMP_DIR}/admin-password"
+    if [ -n "${ADMIN_PASSWORD_FILE}" ]; then
+        cp "${ADMIN_PASSWORD_FILE}" "${password_copy}"
+        chmod 0600 "${password_copy}"
+        [ -s "${password_copy}" ] || die "Password file is empty."
+        ADMIN_PASSWORD_FILE="${password_copy}"
+        return
+    fi
+
+    tty_available ||
+        die "Password prompt requires /dev/tty. Use --admin-password-file for unattended installation."
+    require_command stty
+
+    attempts=0
+    while [ "${attempts}" -lt 3 ]; do
+        TTY_STATE="$(stty -g < "${TTY_PATH}")"
+        stty -echo < "${TTY_PATH}"
+        printf 'DocumentDB admin password: ' > "${TTY_PATH}"
+        password=""
+        IFS= read -r password < "${TTY_PATH}" || true
+        printf '\nConfirm admin password: ' > "${TTY_PATH}"
+        confirmation=""
+        IFS= read -r confirmation < "${TTY_PATH}" || true
+        restore_tty
+
+        if [ -n "${password}" ] && [ "${password}" = "${confirmation}" ]; then
+            printf '%s' "${password}" > "${password_copy}"
+            chmod 0600 "${password_copy}"
+            password=""
+            confirmation=""
+            ADMIN_PASSWORD_FILE="${password_copy}"
+            return
+        fi
+
+        password=""
+        confirmation=""
+        attempts=$((attempts + 1))
+        if [ "${attempts}" -lt 3 ]; then
+            warn "Passwords were empty or did not match; try again."
+        fi
+    done
+
+    die "Passwords did not match after three attempts."
+}
+
+print_plan() {
+    log "Installation plan"
+    printf '  Operating system: %s\n' "${OS_DISPLAY}"
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        printf '  Architecture:     %s\n' "${APT_ARCH}"
+        printf '  Package manager:  apt\n'
+    else
+        printf '  Architecture:     %s\n' "${RPM_ARCH}"
+        printf '  Package manager:  dnf\n'
+    fi
+    printf '  PostgreSQL major: %s\n' "${PG_MAJOR}"
+    printf '  Package:          documentdb-%s\n' "${PG_MAJOR}"
+    printf '  Admin user:       %s\n' "${ADMIN_USER}"
+    printf '  Gateway port:     %s\n' "${LISTEN_PORT}"
+    printf '  Deployment:       new private PostgreSQL instance managed by systemd\n'
+    printf '\n'
+    warn "The setup wizard currently binds the gateway on all interfaces with a self-signed TLS certificate. Restrict port ${LISTEN_PORT} with the host firewall before exposing this machine to an untrusted network."
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        log "The installer may add the PGDG and DocumentDB APT repositories."
+    else
+        log "The installer may enable CRB/CodeReady Builder, EPEL, PGDG, and the DocumentDB DNF repository."
+    fi
+}
+
+install_ubuntu() {
+    pgdg_keyring="$(system_path /usr/share/keyrings/postgresql.gpg)"
+    docdb_keyring="$(system_path /usr/share/keyrings/documentdb-archive-keyring.gpg)"
+    pgdg_source="$(system_path /etc/apt/sources.list.d/pgdg.list)"
+    docdb_source="$(system_path /etc/apt/sources.list.d/documentdb.list)"
+
+    run_root_no_stdin env DEBIAN_FRONTEND=noninteractive apt-get update
+    run_root_no_stdin env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        --no-install-recommends ca-certificates curl gnupg
+
+    if [ "${PGDG_REPO_PRESENT}" = "false" ]; then
+        ensure_apt_keyring "${pgdg_keyring}" "${PGDG_APT_KEY_URL}" \
+            "${PGDG_APT_KEY_FINGERPRINT}" "PGDG"
+        write_root_file "${pgdg_source}" 0644 "${DESIRED_PGDG_SOURCE}"
+    elif [ "${PGDG_MANAGED_SOURCE}" = "true" ]; then
+        ensure_apt_keyring "${pgdg_keyring}" "${PGDG_APT_KEY_URL}" \
+            "${PGDG_APT_KEY_FINGERPRINT}" "PGDG"
+    else
+        log "Reusing the existing Ubuntu 24.04 PGDG repository configuration."
+    fi
+
+    ensure_apt_keyring "${docdb_keyring}" "${DOCUMENTDB_KEY_URL}" \
+        "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
+    if [ "${DOCUMENTDB_REPO_PRESENT}" = "false" ]; then
+        write_root_file "${docdb_source}" 0644 "${DESIRED_DOCUMENTDB_SOURCE}"
+    else
+        log "Reusing the existing DocumentDB APT repository configuration."
+    fi
+
+    run_root_no_stdin env DEBIAN_FRONTEND=noninteractive apt-get update
+    run_root_no_stdin env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        "documentdb-${PG_MAJOR}"
+}
+
+rpm_package_installed() {
+    package="$1"
+    if [ "${TESTING}" = "true" ]; then
+        installed="${DOCUMENTDB_INSTALLER_TEST_RPM_INSTALLED:-}"
+        case " ${installed} " in
+            *" ${package} "*) return 0 ;;
+            *) return 1 ;;
+        esac
+    fi
+    rpm -q "${package}" >/dev/null 2>&1
+}
+
+install_rhel_family() {
+    docdb_repo="$(system_path /etc/yum.repos.d/documentdb.repo)"
+    docdb_key="$(system_path /etc/pki/rpm-gpg/RPM-GPG-KEY-documentdb)"
+    pgdg_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-${RPM_ARCH}/pgdg-redhat-repo-latest.noarch.rpm"
+
+    require_command curl
+    run_root_no_stdin dnf install -y ca-certificates gnupg2 dnf-plugins-core
+
+    case "${DISTRO_KIND}" in
+        rhel)
+            if [ "${RHEL_CRB_METHOD}" = "subscription-manager" ]; then
+                require_command subscription-manager
+                run_root_no_stdin subscription-manager repos \
+                    --enable "${RHEL_CRB_REPO}"
+            else
+                run_root_no_stdin dnf config-manager --set-enabled "${RHEL_CRB_REPO}"
+            fi
+            ;;
+        rocky|almalinux|centos-stream)
+            run_root_no_stdin dnf config-manager --set-enabled crb
+            ;;
+    esac
+
+    if ! rpm_package_installed epel-release; then
+        run_root_no_stdin dnf install -y "${EPEL_RELEASE_URL}"
+    else
+        log "Reusing the installed epel-release package."
+    fi
+    if [ "${DISTRO_KIND}" = "centos-stream" ] &&
+       ! rpm_package_installed epel-next-release; then
+        run_root_no_stdin dnf install -y epel-next-release
+    fi
+
+    if [ "${PGDG_REPO_PRESENT}" = "false" ]; then
+        run_root_no_stdin dnf install -y "${pgdg_repo_url}"
+    else
+        log "Reusing the existing PGDG DNF repository configuration."
+    fi
+
+    run_root_no_stdin dnf -qy module disable postgresql
+
+    ensure_rpm_documentdb_key
+    if [ "${DOCUMENTDB_REPO_PRESENT}" = "false" ]; then
+        write_root_file "${docdb_repo}" 0644 "${DESIRED_DOCUMENTDB_RPM_REPO}"
+    else
+        log "Reusing the existing DocumentDB DNF repository configuration."
+    fi
+
+    run_root_no_stdin dnf clean expire-cache
+    run_root_no_stdin dnf -y makecache --refresh
+    run_root_no_stdin dnf -q --disablerepo='*' --enablerepo=documentdb \
+        list --available "documentdb-${PG_MAJOR}"
+    run_root_no_stdin dnf install -y "documentdb-${PG_MAJOR}"
+}
+
+run_setup() {
+    setup_command="documentdb-setup"
+    if [ "${DRY_RUN}" = "false" ]; then
+        command_exists "${setup_command}" ||
+            die "Package installation completed but documentdb-setup is not on PATH."
+    fi
+
+    if [ "${DRY_RUN}" = "true" ]; then
+        log "Would provision and start the DocumentDB instance:"
+        run_root "${setup_command}" --yes \
+            --pg-version "${PG_MAJOR}" \
+            --use-new-postgres-instance \
+            --admin-user "${ADMIN_USER}" \
+            --admin-password-file "<temporary-password-file>" \
+            --listen-port "${LISTEN_PORT}"
+        return
+    fi
+
+    if ! run_root_no_stdin "${setup_command}" --yes \
+        --pg-version "${PG_MAJOR}" \
+        --use-new-postgres-instance \
+        --admin-user "${ADMIN_USER}" \
+        --admin-password-file "${ADMIN_PASSWORD_FILE}" \
+        --listen-port "${LISTEN_PORT}"; then
+        warn "The packages remain installed, but setup did not complete."
+        warn "After resolving the reported error, resume with:"
+        warn "  sudo documentdb-setup --yes --pg-version ${PG_MAJOR} --use-new-postgres-instance --admin-user ${ADMIN_USER} --admin-password-file <file> --listen-port ${LISTEN_PORT}"
+        return 1
+    fi
+
+    run_root_no_stdin "${setup_command}" --status --pg-version "${PG_MAJOR}"
+}
+
+print_success() {
+    log "DocumentDB installation completed successfully."
+    printf '  Endpoint: mongodb://%s@127.0.0.1:%s/?tls=true&tlsAllowInvalidCertificates=true\n' \
+        "${ADMIN_USER}" "${LISTEN_PORT}"
+    printf '  Status:   sudo documentdb-setup --status --pg-version %s\n' "${PG_MAJOR}"
+    printf '  Service:  sudo systemctl status documentdb-local@%s.target\n' "${PG_MAJOR}"
+}
+
+main() {
+    parse_arguments "$@"
+    validate_arguments
+    initialize_environment
+    detect_platform
+    validate_native_environment
+    determine_privilege_mode
+    detect_existing_installation
+    preflight_repositories
+    print_plan
+
+    if [ "${DRY_RUN}" = "true" ]; then
+        if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+            install_ubuntu
+        else
+            install_rhel_family
+        fi
+        run_setup
+        log "Dry run complete; no changes were made."
+        return
+    fi
+
+    confirm_plan
+    acquire_privileges
+    create_temp_dir
+    prompt_password_file
+
+    if [ "${PACKAGE_FAMILY}" = "apt" ]; then
+        install_ubuntu
+    else
+        install_rhel_family
+    fi
+
+    run_setup
+    print_success
+}
+
+# Keep the call as the final executable line: if a curl stream is truncated,
+# the shell sees only definitions and never starts a partial installation.
+main "$@"

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -629,10 +629,15 @@ detect_rhel_crb_method() {
                 {
                     id = tolower($1)
                     expected = "codeready-builder-for-rhel-9-" tolower(arch) "-rhui-rpms"
+                    aws = "codeready-builder-for-rhel-9-rhui-rpms"
                     if (id == expected) {
                         print $1
                         found = 1
                         exit
+                    }
+                    if ((id == aws || id == "rhui-" aws) && fallback == "") {
+                        fallback = $1
+                        next
                     }
                     if (id ~ /codeready-builder/ &&
                         id ~ /rhel-9/ &&
@@ -646,6 +651,8 @@ detect_rhel_crb_method() {
                 END {
                     if (!found && candidate != "") {
                         print candidate
+                    } else if (!found && fallback != "") {
+                        print fallback
                     }
                 }
             '

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -20,8 +20,12 @@ DEFAULT_PG_MAJOR="18"
 DEFAULT_ADMIN_USER="admin"
 DEFAULT_LISTEN_PORT="10260"
 PGDG_APT_KEY_FINGERPRINT="B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8"
+EPEL_KEY_FINGERPRINT="FF8AD1344597106ECE813B918A3872BF3228467C"
+PGDG_RPM_KEY_FINGERPRINT="D4BF08AE67A0B4C7A1DBCCD240BCA2B408B40D20"
 DOCUMENTDB_KEY_FINGERPRINT="1F748DA911519E749521438252101F285C52B856"
 PGDG_APT_KEY_URL="https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+EPEL_KEY_URL="https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9"
+PGDG_RPM_KEY_URL="https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL"
 DOCUMENTDB_KEY_URL="https://documentdb.io/documentdb-archive-keyring.gpg"
 EPEL_RELEASE_URL="https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
 
@@ -606,29 +610,45 @@ preflight_apt_repositories() {
 }
 
 detect_rhel_crb_method() {
-    if [ "${TESTING}" = "true" ]; then
-        if [ "${DOCUMENTDB_INSTALLER_TEST_RHEL_REGISTERED:-true}" = "true" ]; then
-            RHEL_CRB_METHOD="subscription-manager"
-            RHEL_CRB_REPO="codeready-builder-for-rhel-9-${RPM_ARCH}-rpms"
-            return
-        fi
-        RHEL_CRB_REPO="${DOCUMENTDB_INSTALLER_TEST_RHEL_CRB_REPO:-}"
-        [ -n "${RHEL_CRB_REPO}" ] ||
-            die "RHEL 9 is not registered and no RHUI CodeReady Builder repository is available."
-        RHEL_CRB_METHOD="dnf"
-        return
-    fi
-
-    if command_exists subscription-manager &&
-       subscription-manager identity >/dev/null 2>&1; then
+    consumer_cert="$(system_path /etc/pki/consumer/cert.pem)"
+    if command_exists subscription-manager && [ -s "${consumer_cert}" ]; then
         RHEL_CRB_METHOD="subscription-manager"
         RHEL_CRB_REPO="codeready-builder-for-rhel-9-${RPM_ARCH}-rpms"
         return
     fi
 
+    if [ "${TESTING}" = "true" ]; then
+        repolist="${DOCUMENTDB_INSTALLER_TEST_RHEL_REPOLIST:-}"
+    else
+        repolist="$(dnf -q repolist --all 2>/dev/null || true)"
+    fi
+
     RHEL_CRB_REPO="$(
-        dnf -q repolist --all 2>/dev/null |
-            awk 'tolower($1) ~ /codeready-builder/ && tolower($1) ~ /rhel-9/ { print $1; exit }'
+        printf '%s\n' "${repolist}" |
+            awk -v arch="${RPM_ARCH}" '
+                {
+                    id = tolower($1)
+                    expected = "codeready-builder-for-rhel-9-" tolower(arch) "-rhui-rpms"
+                    if (id == expected) {
+                        print $1
+                        found = 1
+                        exit
+                    }
+                    if (id ~ /codeready-builder/ &&
+                        id ~ /rhel-9/ &&
+                        id ~ tolower(arch) &&
+                        id ~ /rpms$/ &&
+                        id !~ /(debug|source)-rpms$/ &&
+                        candidate == "") {
+                        candidate = $1
+                    }
+                }
+                END {
+                    if (!found && candidate != "") {
+                        print candidate
+                    }
+                }
+            '
     )"
     [ -n "${RHEL_CRB_REPO}" ] ||
         die "RHEL 9 is not registered with subscription-manager and no RHUI CodeReady Builder repository was found."
@@ -826,27 +846,60 @@ ensure_apt_keyring() {
     run_root install -D -m 0644 "${binary}" "${destination}"
 }
 
-ensure_rpm_documentdb_key() {
-    destination="$(system_path /etc/pki/rpm-gpg/RPM-GPG-KEY-documentdb)"
-    downloaded="${TMP_DIR}/RPM-GPG-KEY-documentdb"
+ensure_rpm_key() {
+    rpm_key_destination="$1"
+    rpm_key_url="$2"
+    rpm_key_expected="$3"
+    rpm_key_label="$4"
+    rpm_key_downloaded="${TMP_DIR:-/tmp}/$(basename "${rpm_key_destination}")"
 
     if [ "${DRY_RUN}" = "true" ]; then
-        log "Would verify or install ${destination}."
-        download_key "${DOCUMENTDB_KEY_URL}" "${downloaded}" \
-            "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
-        run_root rpm --import "${destination}"
+        log "Would verify or install ${rpm_key_destination} for ${rpm_key_label}."
+        download_key "${rpm_key_url}" "${rpm_key_downloaded}" \
+            "${rpm_key_expected}" "${rpm_key_label}"
+        run_root rpm --import "${rpm_key_destination}"
         return
     fi
 
-    if [ -f "${destination}" ]; then
-        verify_key_fingerprint "${destination}" \
-            "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
+    if [ -f "${rpm_key_destination}" ]; then
+        verify_key_fingerprint "${rpm_key_destination}" \
+            "${rpm_key_expected}" "${rpm_key_label}"
     else
-        download_key "${DOCUMENTDB_KEY_URL}" "${downloaded}" \
-            "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
-        run_root install -D -m 0644 "${downloaded}" "${destination}"
+        download_key "${rpm_key_url}" "${rpm_key_downloaded}" \
+            "${rpm_key_expected}" "${rpm_key_label}"
+        run_root install -D -m 0644 "${rpm_key_downloaded}" "${rpm_key_destination}"
     fi
-    run_root_no_stdin rpm --import "${destination}"
+    run_root_no_stdin rpm --import "${rpm_key_destination}"
+}
+
+install_verified_repository_rpm() {
+    repository_rpm_url="$1"
+    repository_rpm_filename="$2"
+    repository_key_destination="$3"
+    repository_key_url="$4"
+    repository_key_fingerprint="$5"
+    repository_label="$6"
+    repository_rpm_path="${TMP_DIR:-/tmp}/${repository_rpm_filename}"
+
+    ensure_rpm_key "${repository_key_destination}" "${repository_key_url}" \
+        "${repository_key_fingerprint}" "${repository_label}"
+
+    if [ "${DRY_RUN}" = "true" ]; then
+        log "Would download ${repository_label} repository package from ${repository_rpm_url}."
+    else
+        strict_curl "${repository_rpm_url}" "${repository_rpm_path}"
+    fi
+
+    run_root_no_stdin dnf --setopt=localpkg_gpgcheck=1 install -y \
+        "${repository_rpm_path}"
+
+    if [ "${DRY_RUN}" = "false" ]; then
+        # The repository package owns the same key path. Re-check it after the
+        # transaction so the enabled repositories cannot silently replace the
+        # independently verified bootstrap key.
+        verify_key_fingerprint "${repository_key_destination}" \
+            "${repository_key_fingerprint}" "${repository_label}"
+    fi
 }
 
 create_temp_dir() {
@@ -1025,6 +1078,8 @@ rpm_package_installed() {
 install_rhel_family() {
     docdb_repo="$(system_path /etc/yum.repos.d/documentdb.repo)"
     docdb_key="$(system_path /etc/pki/rpm-gpg/RPM-GPG-KEY-documentdb)"
+    epel_key="$(system_path /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9)"
+    pgdg_key="$(system_path /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL)"
     pgdg_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-${RPM_ARCH}/pgdg-redhat-repo-latest.noarch.rpm"
 
     require_command curl
@@ -1046,7 +1101,13 @@ install_rhel_family() {
     esac
 
     if ! rpm_package_installed epel-release; then
-        run_root_no_stdin dnf install -y "${EPEL_RELEASE_URL}"
+        install_verified_repository_rpm \
+            "${EPEL_RELEASE_URL}" \
+            "epel-release-latest-9.noarch.rpm" \
+            "${epel_key}" \
+            "${EPEL_KEY_URL}" \
+            "${EPEL_KEY_FINGERPRINT}" \
+            "EPEL 9"
     else
         log "Reusing the installed epel-release package."
     fi
@@ -1056,14 +1117,21 @@ install_rhel_family() {
     fi
 
     if [ "${PGDG_REPO_PRESENT}" = "false" ]; then
-        run_root_no_stdin dnf install -y "${pgdg_repo_url}"
+        install_verified_repository_rpm \
+            "${pgdg_repo_url}" \
+            "pgdg-redhat-repo-latest.noarch.rpm" \
+            "${pgdg_key}" \
+            "${PGDG_RPM_KEY_URL}" \
+            "${PGDG_RPM_KEY_FINGERPRINT}" \
+            "PGDG RPM"
     else
         log "Reusing the existing PGDG DNF repository configuration."
     fi
 
     run_root_no_stdin dnf -qy module disable postgresql
 
-    ensure_rpm_documentdb_key
+    ensure_rpm_key "${docdb_key}" "${DOCUMENTDB_KEY_URL}" \
+        "${DOCUMENTDB_KEY_FINGERPRINT}" "DocumentDB"
     if [ "${DOCUMENTDB_REPO_PRESENT}" = "false" ]; then
         write_root_file "${docdb_repo}" 0644 "${DESIRED_DOCUMENTDB_RPM_REPO}"
     else

--- a/packaging/test_packages/test-install-script.sh
+++ b/packaging/test_packages/test-install-script.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Deterministic behavior tests for packaging/install.sh. The installer exposes
+# a dry-run-only test mode so these checks can exercise every supported distro
+# and architecture without changing the host or requiring nested VMs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+INSTALLER="${REPO_ROOT}/packaging/install.sh"
+
+PASS=0
+FAIL=0
+TEMP_DIRS=()
+LAST_OUTPUT=""
+NEW_ROOT=""
+
+cleanup() {
+    if (( ${#TEMP_DIRS[@]} > 0 )); then
+        rm -rf "${TEMP_DIRS[@]}"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    PASS=$((PASS + 1))
+    printf 'PASS: %s\n' "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s\n' "$1" >&2
+}
+
+new_root() {
+    local id="$1" version="$2"
+    NEW_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/documentdb-installer-test.XXXXXX")"
+    TEMP_DIRS+=("${NEW_ROOT}")
+    mkdir -p \
+        "${NEW_ROOT}/etc/apt/sources.list.d" \
+        "${NEW_ROOT}/etc/yum.repos.d" \
+        "${NEW_ROOT}/run/systemd/system"
+    printf 'ID=%s\nVERSION_ID="%s"\n' "${id}" "${version}" > "${NEW_ROOT}/etc/os-release"
+}
+
+run_installer() {
+    local root="$1" arch="$2" native_arch="$3"
+    shift 3
+
+    env \
+        DOCUMENTDB_INSTALLER_TESTING=true \
+        DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
+        DOCUMENTDB_INSTALLER_TEST_UNAME_M="${arch}" \
+        DOCUMENTDB_INSTALLER_TEST_NATIVE_ARCH="${native_arch}" \
+        sh "${INSTALLER}" --dry-run "$@" 2>&1
+}
+
+expect_success() {
+    local description="$1"
+    shift
+    if LAST_OUTPUT="$("$@" 2>&1)"; then
+        pass "${description}"
+    else
+        fail "${description}"
+        printf '%s\n' "${LAST_OUTPUT}" >&2
+        return 1
+    fi
+}
+
+expect_failure() {
+    local description="$1" expected="$2"
+    shift 2
+    local output
+    if output="$("$@" 2>&1)"; then
+        fail "${description} (unexpected success)"
+        printf '%s\n' "${output}" >&2
+        return 1
+    fi
+    if grep -Fq -- "${expected}" <<< "${output}"; then
+        pass "${description}"
+    else
+        fail "${description} (missing: ${expected})"
+        printf '%s\n' "${output}" >&2
+        return 1
+    fi
+}
+
+assert_contains() {
+    local description="$1" output="$2" expected="$3"
+    if grep -Fq -- "${expected}" <<< "${output}"; then
+        pass "${description}"
+    else
+        fail "${description} (missing: ${expected})"
+        return 1
+    fi
+}
+
+printf '=== packaging/install.sh behavior tests ===\n'
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_success "Ubuntu amd64 dry-run succeeds" \
+    run_installer "${root}" x86_64 amd64
+output="${LAST_OUTPUT}"
+assert_contains "Ubuntu selects APT" "${output}" "Package manager:  apt"
+assert_contains "Ubuntu selects amd64 repository" "${output}" "deb [arch=amd64"
+assert_contains "Ubuntu defaults to PG18 package" "${output}" "apt-get install -y documentdb-18"
+assert_contains "Ubuntu plans managed setup" "${output}" "--use-new-postgres-instance"
+if [ ! -e "${root}/etc/apt/sources.list.d/documentdb.list" ]; then
+    pass "Ubuntu dry-run writes no repository file"
+else
+    fail "Ubuntu dry-run wrote a repository file"
+fi
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_success "Ubuntu arm64 PG17 dry-run succeeds" \
+    run_installer "${root}" aarch64 arm64 --pg-major 17
+output="${LAST_OUTPUT}"
+assert_contains "Ubuntu selects arm64 repository" "${output}" "deb [arch=arm64"
+assert_contains "Ubuntu selects PG17 package" "${output}" "apt-get install -y documentdb-17"
+
+for distro in rocky almalinux; do
+    new_root "${distro}" 9.6
+    root="${NEW_ROOT}"
+    expect_success "${distro} x86_64 dry-run succeeds" \
+        run_installer "${root}" x86_64 x86_64 --pg-major 18
+    output="${LAST_OUTPUT}"
+    assert_contains "${distro} enables CRB" "${output}" "dnf config-manager --set-enabled crb"
+    assert_contains "${distro} uses EL9 x86_64 PGDG" "${output}" "EL-9-x86_64"
+    assert_contains "${distro} selects PG18 package" "${output}" "dnf install -y documentdb-18"
+    if grep -Eq -- 'dnf install -y .*curl' <<< "${output}"; then
+        fail "${distro} must not replace curl-minimal"
+    else
+        pass "${distro} preserves curl-minimal"
+    fi
+done
+
+new_root centos 9
+root="${NEW_ROOT}"
+expect_success "CentOS Stream aarch64 dry-run succeeds" \
+    run_installer "${root}" arm64 aarch64 --pg-major 17
+output="${LAST_OUTPUT}"
+assert_contains "CentOS Stream enables CRB" "${output}" "dnf config-manager --set-enabled crb"
+assert_contains "CentOS Stream installs EPEL Next" "${output}" "dnf install -y epel-next-release"
+assert_contains "CentOS Stream uses EL9 aarch64 PGDG" "${output}" "EL-9-aarch64"
+
+new_root rhel 9.4
+root="${NEW_ROOT}"
+expect_success "RHEL aarch64 dry-run succeeds" \
+    run_installer "${root}" aarch64 aarch64 --pg-major 18
+output="${LAST_OUTPUT}"
+assert_contains "RHEL enables CodeReady Builder" "${output}" \
+    "subscription-manager repos --enable codeready-builder-for-rhel-9-aarch64-rpms"
+assert_contains "RHEL enables repository metadata checks" "${output}" "repo_gpgcheck=1"
+assert_contains "RHEL pre-accepts DNF metadata key import" "${output}" "dnf -y makecache --refresh"
+
+new_root rhel 9.4
+root="${NEW_ROOT}"
+output="$(
+    env \
+        DOCUMENTDB_INSTALLER_TESTING=true \
+        DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
+        DOCUMENTDB_INSTALLER_TEST_RHEL_REGISTERED=false \
+        DOCUMENTDB_INSTALLER_TEST_RHEL_CRB_REPO=codeready-builder-for-rhel-9-rhui-rpms \
+        sh "${INSTALLER}" --dry-run 2>&1
+)"
+assert_contains "RHEL RHUI host enables discovered CodeReady Builder repo" "${output}" \
+    "dnf config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms"
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+printf '%s\n' \
+    'deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main' \
+    > "${root}/etc/apt/sources.list.d/pgdg.list"
+printf '%s\n' \
+    'deb [arch=amd64 signed-by=/usr/share/keyrings/documentdb-archive-keyring.gpg] https://documentdb.io/deb stable ubuntu24' \
+    > "${root}/etc/apt/sources.list.d/documentdb.list"
+expect_success "Exact existing APT repositories are reused" \
+    run_installer "${root}" x86_64 amd64
+output="${LAST_OUTPUT}"
+assert_contains "Existing PGDG source is reused" "${output}" \
+    "Would verify or install ${root}/usr/share/keyrings/postgresql.gpg"
+assert_contains "Existing DocumentDB source is reused" "${output}" \
+    "Reusing the existing DocumentDB APT repository configuration."
+
+new_root rocky 9.6
+root="${NEW_ROOT}"
+cat > "${root}/etc/yum.repos.d/pgdg-redhat-all.repo" <<'REPO'
+[pgdg18]
+name=PostgreSQL 18 for RHEL / Rocky Linux $releasever - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/18/redhat/rhel-$releasever-$basearch
+enabled=1
+gpgcheck=1
+REPO
+output="$(run_installer "${root}" x86_64 x86_64)"
+assert_contains "Canonical PGDG RPM repository is reused" "${output}" \
+    "Reusing the existing PGDG DNF repository configuration."
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+printf '%s\n' \
+    'deb https://apt.postgresql.org/pub/repos/apt jammy-pgdg main' \
+    > "${root}/etc/apt/sources.list.d/pgdg.list"
+expect_failure "Conflicting PGDG repository is rejected" \
+    "Conflicting PGDG repository configuration" \
+    run_installer "${root}" x86_64 amd64
+
+new_root ubuntu 22.04
+root="${NEW_ROOT}"
+expect_failure "Ubuntu 22.04 is rejected" "Only Ubuntu 24.04 LTS is supported" \
+    run_installer "${root}" x86_64 amd64
+
+new_root debian 12
+root="${NEW_ROOT}"
+expect_failure "Debian is rejected" "Unsupported Linux distribution 'debian'" \
+    run_installer "${root}" x86_64 amd64
+
+new_root rocky 8.10
+root="${NEW_ROOT}"
+expect_failure "Rocky Linux 8 is rejected" "Only Rocky Linux 9 is supported" \
+    run_installer "${root}" x86_64 x86_64
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Unsupported architecture is rejected" \
+    "Supported architectures are x86_64 and arm64" \
+    run_installer "${root}" ppc64le ppc64le
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Kernel/package architecture mismatch is rejected" \
+    "does not match dpkg architecture" \
+    run_installer "${root}" x86_64 arm64
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "WSL is rejected" "Windows Subsystem for Linux is not supported" \
+    env \
+        DOCUMENTDB_INSTALLER_TESTING=true \
+        DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
+        DOCUMENTDB_INSTALLER_TEST_KERNEL_RELEASE="5.15.0-microsoft-standard-WSL2" \
+        sh "${INSTALLER}" --dry-run
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+rm -rf "${root}/run/systemd/system"
+expect_failure "Host without running systemd is rejected" \
+    "A running systemd host is required" \
+    run_installer "${root}" x86_64 amd64
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Container environment is rejected" \
+    "Container environment 'docker' is not supported" \
+    env \
+        DOCUMENTDB_INSTALLER_TESTING=true \
+        DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
+        DOCUMENTDB_INSTALLER_TEST_CONTAINER_VIRT=docker \
+        sh "${INSTALLER}" --dry-run
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Existing packages are rejected" \
+    "DocumentDB packages are already installed" \
+    env \
+        DOCUMENTDB_INSTALLER_TESTING=true \
+        DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
+        DOCUMENTDB_INSTALLER_TEST_EXISTING_PACKAGES=documentdb-18 \
+        sh "${INSTALLER}" --dry-run
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+mkdir -p "${root}/var/lib/documentdb-local/18/data"
+expect_failure "Residual data is rejected" "Residual DocumentDB state exists" \
+    run_installer "${root}" x86_64 amd64
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "PostgreSQL 16 is rejected" "--pg-major must be 17 or 18" \
+    run_installer "${root}" x86_64 amd64 --pg-major 16
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Privileged listen port is rejected" \
+    "--listen-port must be from 1024 through 65535" \
+    run_installer "${root}" x86_64 amd64 --listen-port 443
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+output="$(run_installer "${root}" x86_64 amd64 --listen-port 1024)"
+assert_contains "Lowest supported listen port is accepted" "${output}" "--listen-port 1024"
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+output="$(run_installer "${root}" x86_64 amd64 --listen-port 65535)"
+assert_contains "Highest supported listen port is accepted" "${output}" "--listen-port 65535"
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Listen port above 65535 is rejected" \
+    "--listen-port must be from 1024 through 65535" \
+    run_installer "${root}" x86_64 amd64 --listen-port 65536
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Oversized listen port is rejected without overflow" \
+    "--listen-port must be from 1024 through 65535" \
+    run_installer "${root}" x86_64 amd64 --listen-port 18446744073709561876
+
+new_root ubuntu 24.04
+root="${NEW_ROOT}"
+expect_failure "Missing required command is rejected" \
+    "Required command 'systemctl' is not available" \
+    env \
+        DOCUMENTDB_INSTALLER_TESTING=true \
+        DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
+        DOCUMENTDB_INSTALLER_TEST_MISSING_COMMAND=systemctl \
+        sh "${INSTALLER}" --dry-run
+
+expect_failure "--yes requires a password file outside dry-run" \
+    "--yes requires --admin-password-file" \
+    env DOCUMENTDB_INSTALLER_TESTING=true sh "${INSTALLER}" --yes
+
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/packaging/test_packages/test-install-script.sh
+++ b/packaging/test_packages/test-install-script.sh
@@ -150,6 +150,8 @@ assert_contains "CentOS Stream uses EL9 aarch64 PGDG" "${output}" "EL-9-aarch64"
 
 new_root rhel 9.4
 root="${NEW_ROOT}"
+mkdir -p "${root}/etc/pki/consumer"
+printf 'registered\n' > "${root}/etc/pki/consumer/cert.pem"
 expect_success "RHEL aarch64 dry-run succeeds" \
     run_installer "${root}" aarch64 aarch64 --pg-major 18
 output="${LAST_OUTPUT}"
@@ -164,12 +166,29 @@ output="$(
     env \
         DOCUMENTDB_INSTALLER_TESTING=true \
         DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
-        DOCUMENTDB_INSTALLER_TEST_RHEL_REGISTERED=false \
-        DOCUMENTDB_INSTALLER_TEST_RHEL_CRB_REPO=codeready-builder-for-rhel-9-rhui-rpms \
+        DOCUMENTDB_INSTALLER_TEST_RHEL_REPOLIST='
+codeready-builder-for-rhel-9-x86_64-rhui-debug-rpms disabled
+codeready-builder-for-rhel-9-x86_64-rhui-rpms disabled
+codeready-builder-for-rhel-9-x86_64-rhui-source-rpms disabled' \
         sh "${INSTALLER}" --dry-run 2>&1
 )"
 assert_contains "RHEL RHUI host enables discovered CodeReady Builder repo" "${output}" \
-    "dnf config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms"
+    "dnf config-manager --set-enabled codeready-builder-for-rhel-9-x86_64-rhui-rpms"
+if grep -Fq -- "rhui-debug-rpms" <<< "${output}" &&
+   grep -Fq -- "config-manager --set-enabled codeready-builder-for-rhel-9-x86_64-rhui-debug-rpms" <<< "${output}"; then
+    fail "RHEL RHUI discovery selected the debug repository"
+else
+    pass "RHEL RHUI discovery ignores debug/source repositories"
+fi
+
+assert_contains "EPEL bootstrap key fingerprint is pinned" "${output}" \
+    "FF8AD1344597106ECE813B918A3872BF3228467C"
+assert_contains "PGDG RPM bootstrap key fingerprint is pinned" "${output}" \
+    "D4BF08AE67A0B4C7A1DBCCD240BCA2B408B40D20"
+assert_contains "EPEL bootstrap RPM requires signature verification" "${output}" \
+    "dnf --setopt=localpkg_gpgcheck=1 install -y /tmp/epel-release-latest-9.noarch.rpm"
+assert_contains "PGDG bootstrap RPM requires signature verification" "${output}" \
+    "dnf --setopt=localpkg_gpgcheck=1 install -y /tmp/pgdg-redhat-repo-latest.noarch.rpm"
 
 new_root ubuntu 24.04
 root="${NEW_ROOT}"

--- a/packaging/test_packages/test-install-script.sh
+++ b/packaging/test_packages/test-install-script.sh
@@ -181,6 +181,27 @@ else
     pass "RHEL RHUI discovery ignores debug/source repositories"
 fi
 
+for arch_pair in "x86_64:x86_64" "aarch64:aarch64"; do
+    kernel_arch="${arch_pair%%:*}"
+    native_arch="${arch_pair##*:}"
+    new_root rhel 9.4
+    root="${NEW_ROOT}"
+    output="$(
+        env \
+            DOCUMENTDB_INSTALLER_TESTING=true \
+            DOCUMENTDB_INSTALLER_TEST_ROOT="${root}" \
+            DOCUMENTDB_INSTALLER_TEST_UNAME_M="${kernel_arch}" \
+            DOCUMENTDB_INSTALLER_TEST_NATIVE_ARCH="${native_arch}" \
+            DOCUMENTDB_INSTALLER_TEST_RHEL_REPOLIST='
+codeready-builder-for-rhel-9-rhui-debug-rpms disabled
+codeready-builder-for-rhel-9-rhui-rpms disabled
+codeready-builder-for-rhel-9-rhui-source-rpms disabled' \
+            sh "${INSTALLER}" --dry-run 2>&1
+    )"
+    assert_contains "AWS RHEL ${kernel_arch} selects arch-less binary CRB repo" "${output}" \
+        "dnf config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms"
+done
+
 assert_contains "EPEL bootstrap key fingerprint is pinned" "${output}" \
     "FF8AD1344597106ECE813B918A3872BF3228467C"
 assert_contains "PGDG RPM bootstrap key fingerprint is pinned" "${output}" \


### PR DESCRIPTION
## Description

Add a clean-host POSIX shell installer for the current first-party native package matrix. The installer detects the supported host, configures signed PGDG and DocumentDB repositories, installs `documentdb-N`, and provisions a new private PostgreSQL-backed instance through `documentdb-setup`.

Supported targets:

- Ubuntu 24.04 on amd64 and arm64
- RHEL, Rocky Linux, AlmaLinux, and CentOS Stream 9 on x86_64 and aarch64
- PostgreSQL 17 and 18, with PostgreSQL 18 as the default

The installer includes strict preflight checks, signing-key fingerprint verification, interactive and password-file credential flows, `--dry-run`, existing-install refusal, RHSM/RHUI handling, and explicit rejection of WSL, containers, unsupported distributions, and unsupported architectures.

The release workflow now includes `install.sh` in the consolidated package bundle and `SHA256SUMS`. Publishing the stable `https://documentdb.io/install.sh` endpoint remains a follow-up change in `documentdb/documentdb.github.io` after this release asset is available.

## Type of Change

- [x] New feature
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [x] DevOps / tooling
- [x] Test improvement
- [ ] Other: ___________

## AI Disclosure

- [ ] No AI tools were used substantially in this PR
- [x] AI tools were used to assist with this PR (please complete below)
  - **Tool(s) used:** GitHub Copilot, Claude, Grok
  - **How it was used:** Researched comparable installers, implemented and reviewed the installer and test coverage, and identified EL9 edge cases. The resulting changes were locally validated and manually reviewed.

## Validation

- `sh -n packaging/install.sh`
- `shellcheck -s sh packaging/install.sh`
- `shellcheck -s bash packaging/test_packages/test-install-script.sh`
- `bash packaging/test_packages/test-install-script.sh` (58 passed)
- Parsed all modified GitHub Actions workflows as YAML
- Verified the pinned EPEL, PGDG, and DocumentDB signing-key fingerprints against their official key endpoints
- Independent PR reviews with Claude Opus 5, Grok 4.6, and GPT-5.6 Terra; their EL9 findings are addressed in the latest commit

## Checklist

- [x] I can explain every change in this PR if asked during review
- [x] I have tested these changes locally
- [x] I have added or updated tests as appropriate
- [x] All commits are signed off (DCO: `git commit -s`)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines

